### PR TITLE
feat: replace read-only-service-connection with permissions field

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -177,7 +177,9 @@ network:                       # optional network policy (standalone target only
     - "*.mycompany.com"
   blocked:                     # blocked host patterns (takes precedence over allow)
     - "evil.example.com"
-read-only-service-connection: my-arm-connection  # optional: ARM service connection for read-only ADO token
+permissions:                   # optional ADO access token configuration
+  read: my-read-arm-connection   # ARM service connection for read-only ADO access (Stage 1 agent)
+  write: my-write-arm-connection # ARM service connection for write ADO access (Stage 2 executor only)
 ---
 
 
@@ -568,20 +570,37 @@ Should be replaced with the description field from the front matter. This is use
 
 ## {{ acquire_ado_token }}
 
-Generates an `AzureCLI@2` step that acquires an Azure DevOps-scoped access token from an ARM service connection. This is only generated when `read-only-service-connection` is configured in the front matter.
+Generates an `AzureCLI@2` step that acquires a read-only ADO-scoped access token from the ARM service connection specified in `permissions.read`. This token is used by the agent in Stage 1 (inside the AWF sandbox).
 
 The step:
-- Uses the specified ARM service connection
+- Uses the ARM service connection from `permissions.read`
 - Calls `az account get-access-token` with the ADO resource ID
-- Stores the token in a secret pipeline variable `SC_ACCESS_TOKEN`
+- Stores the token in a secret pipeline variable `SC_READ_TOKEN`
 
-If no `read-only-service-connection` is configured, this marker is replaced with an empty string.
+If `permissions.read` is not configured, this marker is replaced with an empty string.
 
 ## {{ copilot_ado_env }}
 
-Generates environment variable entries for the copilot AWF step when `read-only-service-connection` is configured. Sets both `AZURE_DEVOPS_EXT_PAT` and `SYSTEM_ACCESSTOKEN` to the service connection token.
+Generates environment variable entries for the copilot AWF step when `permissions.read` is configured. Sets both `AZURE_DEVOPS_EXT_PAT` and `SYSTEM_ACCESSTOKEN` to the read service connection token (`SC_READ_TOKEN`).
 
-If no `read-only-service-connection` is configured, this marker is replaced with an empty string, and ADO access tokens are omitted from the copilot invocation.
+If `permissions.read` is not configured, this marker is replaced with an empty string, and ADO access tokens are omitted from the copilot invocation.
+
+## {{ acquire_write_token }}
+
+Generates an `AzureCLI@2` step that acquires a write-capable ADO-scoped access token from the ARM service connection specified in `permissions.write`. This token is used only by the executor in Stage 2 (`ProcessSafeOutputs` job) and is never exposed to the agent.
+
+The step:
+- Uses the ARM service connection from `permissions.write`
+- Calls `az account get-access-token` with the ADO resource ID
+- Stores the token in a secret pipeline variable `SC_WRITE_TOKEN`
+
+If `permissions.write` is not configured, this marker is replaced with an empty string.
+
+## {{ executor_ado_env }}
+
+Generates environment variable entries for the Stage 2 executor step when `permissions.write` is configured. Sets `SYSTEM_ACCESSTOKEN` to the write service connection token (`SC_WRITE_TOKEN`).
+
+If `permissions.write` is not configured, this marker is replaced with an empty string. Note: `System.AccessToken` is never used directly — all ADO tokens come from explicitly configured service connections.
 
 ## {{ compiler_version }}
 
@@ -1030,22 +1049,42 @@ network:
 
 All hosts (core + MCP-specific + user-specified) are combined into a comma-separated domain list passed to AWF's `--allow-domains` flag.
 
-### Read-Only Service Connection
+### Permissions (ADO Access Tokens)
 
-For agents that need read-only access to Azure DevOps resources (e.g., reading repository information), you can configure an ARM service connection to provide a scoped access token:
+ADO does not support fine-grained permissions — there are two access levels: blanket read and blanket write. Tokens are minted from ARM service connections; `System.AccessToken` is never used for agent or executor operations.
 
 ```yaml
-read-only-service-connection: my-arm-connection
+permissions:
+  read: my-read-arm-connection    # Stage 1 agent — read-only ADO access
+  write: my-write-arm-connection  # Stage 2 executor — write access for safe-outputs
 ```
 
-When configured:
-- The pipeline mints an ADO-scoped token from the ARM service connection
-- The token is passed to the copilot via `AZURE_DEVOPS_EXT_PAT` and `SYSTEM_ACCESSTOKEN`
-- This allows the agent to authenticate to ADO APIs without using the pipeline's default System.AccessToken
+#### Security Model
 
-When not configured:
-- ADO access tokens are omitted from the copilot invocation
-- The agent cannot authenticate to ADO APIs
+- **`permissions.read`**: Mints a read-only ADO-scoped token given to the agent inside the AWF sandbox (Stage 1). The agent can query ADO APIs but cannot write.
+- **`permissions.write`**: Mints a write-capable ADO-scoped token used **only** by the executor in Stage 2 (`ProcessSafeOutputs` job). This token is never exposed to the agent.
+- **Both omitted**: No ADO tokens are passed anywhere. The agent has no ADO API access.
+
+#### Compile-Time Validation
+
+If write-requiring safe-outputs (`create-pull-request`, `create-work-item`) are configured but `permissions.write` is missing, compilation fails with a clear error message.
+
+#### Examples
+
+```yaml
+# Agent can read ADO, safe-outputs can write
+permissions:
+  read: my-read-sc
+  write: my-write-sc
+
+# Agent can read ADO, no write safe-outputs needed
+permissions:
+  read: my-read-sc
+
+# Agent has no ADO access, but safe-outputs can create PRs/work items
+permissions:
+  write: my-write-sc
+```
 
 ## MCP Firewall
 

--- a/src/compile/common.rs
+++ b/src/compile/common.rs
@@ -486,6 +486,99 @@ pub fn generate_pipeline_path(output_path: &std::path::Path) -> String {
     format!("{{{{ workspace }}}}/{}", filename)
 }
 
+// ==================== Permission helpers ====================
+
+/// ADO resource ID for minting ADO-scoped tokens via Azure CLI.
+const ADO_RESOURCE_ID: &str = "499b84ac-1321-427f-aa17-267ca6975798";
+
+/// Generate an AzureCLI@2 step to acquire an ADO-scoped token from an ARM service connection.
+/// The `variable_name` parameter controls which pipeline variable the token is stored in
+/// (e.g. "SC_READ_TOKEN" for the agent, "SC_WRITE_TOKEN" for the executor).
+/// Returns empty string if no service connection is provided.
+pub fn generate_acquire_ado_token(service_connection: Option<&str>, variable_name: &str) -> String {
+    match service_connection {
+        Some(sc) => {
+            let mut lines = Vec::new();
+            lines.push("- task: AzureCLI@2".to_string());
+            lines.push(format!(
+                r#"  displayName: "Acquire ADO token ({variable_name})""#
+            ));
+            lines.push("  inputs:".to_string());
+            lines.push(format!("    azureSubscription: '{}'", sc));
+            lines.push("    scriptType: 'bash'".to_string());
+            lines.push("    scriptLocation: 'inlineScript'".to_string());
+            lines.push("    addSpnToEnvironment: true".to_string());
+            lines.push("    inlineScript: |".to_string());
+            lines.push("      ADO_TOKEN=$(az account get-access-token \\".to_string());
+            lines.push(format!(
+                "        --resource {} \\",
+                ADO_RESOURCE_ID
+            ));
+            lines.push("        --query accessToken -o tsv)".to_string());
+            lines.push(format!(
+                "      echo \"##vso[task.setvariable variable={variable_name};issecret=true]$ADO_TOKEN\""
+            ));
+            lines.join("\n")
+        }
+        None => String::new(),
+    }
+}
+
+/// Generate the env block entries for the copilot AWF step (Stage 1 agent).
+/// Uses the read-only token from the read service connection.
+/// When not configured, omits ADO access tokens entirely.
+pub fn generate_copilot_ado_env(read_service_connection: Option<&str>) -> String {
+    match read_service_connection {
+        Some(_) => {
+            "AZURE_DEVOPS_EXT_PAT: $(SC_READ_TOKEN)\nSYSTEM_ACCESSTOKEN: $(SC_READ_TOKEN)"
+                .to_string()
+        }
+        None => String::new(),
+    }
+}
+
+/// Generate the env block entries for the executor step (Stage 2 ProcessSafeOutputs).
+/// Uses the write token from the write service connection.
+/// When not configured, omits ADO access tokens entirely.
+pub fn generate_executor_ado_env(write_service_connection: Option<&str>) -> String {
+    match write_service_connection {
+        Some(_) => "SYSTEM_ACCESSTOKEN: $(SC_WRITE_TOKEN)".to_string(),
+        None => String::new(),
+    }
+}
+
+/// Safe-output names that require write access to ADO.
+const WRITE_REQUIRING_SAFE_OUTPUTS: &[&str] = &["create-pull-request", "create-work-item"];
+
+/// Validate that write-requiring safe-outputs have a write service connection configured.
+pub fn validate_write_permissions(front_matter: &FrontMatter) -> Result<()> {
+    let has_write_sc = front_matter
+        .permissions
+        .as_ref()
+        .is_some_and(|p| p.write.is_some());
+
+    if has_write_sc {
+        return Ok(());
+    }
+
+    let missing: Vec<&str> = WRITE_REQUIRING_SAFE_OUTPUTS
+        .iter()
+        .filter(|name| front_matter.safe_outputs.contains_key(**name))
+        .copied()
+        .collect();
+
+    if !missing.is_empty() {
+        anyhow::bail!(
+            "Safe outputs [{}] require write access to ADO, but no write service connection \
+             is configured. Add a 'permissions.write' field to the front matter:\n\n  \
+             permissions:\n    write: <your-write-arm-service-connection>\n",
+            missing.join(", ")
+        );
+    }
+
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/compile/mod.rs
+++ b/src/compile/mod.rs
@@ -18,7 +18,7 @@ use std::path::{Path, PathBuf};
 
 pub use common::parse_markdown;
 pub use common::sanitize_filename;
-pub use types::{CompileTarget, FrontMatter};
+pub use types::{CompileTarget, FrontMatter, PermissionsConfig};
 
 /// Trait for pipeline compilers.
 ///

--- a/src/compile/onees.rs
+++ b/src/compile/onees.rs
@@ -18,10 +18,11 @@ use std::path::Path;
 use super::Compiler;
 use super::common::{
     self, AWF_VERSION, DEFAULT_POOL, compute_effective_workspace, generate_copilot_params,
-    generate_checkout_self, generate_checkout_steps, generate_ci_trigger,
+    generate_acquire_ado_token, generate_checkout_self, generate_checkout_steps,
+    generate_ci_trigger, generate_copilot_ado_env, generate_executor_ado_env,
     generate_pipeline_path, generate_pipeline_resources, generate_pr_trigger,
     generate_repositories, generate_schedule, generate_source_path,
-    generate_working_directory, replace_with_indent,
+    generate_working_directory, replace_with_indent, validate_write_permissions,
 };
 use super::types::{FrontMatter, McpConfig};
 
@@ -113,6 +114,25 @@ displayName: "Finalize""#,
             threat_analysis_prompt,
         );
 
+        // Generate service connection token acquisition steps and env vars
+        let acquire_read_token = generate_acquire_ado_token(
+            front_matter.permissions.as_ref().and_then(|p| p.read.as_deref()),
+            "SC_READ_TOKEN",
+        );
+        let copilot_ado_env = generate_copilot_ado_env(
+            front_matter.permissions.as_ref().and_then(|p| p.read.as_deref()),
+        );
+        let acquire_write_token = generate_acquire_ado_token(
+            front_matter.permissions.as_ref().and_then(|p| p.write.as_deref()),
+            "SC_WRITE_TOKEN",
+        );
+        let executor_ado_env = generate_executor_ado_env(
+            front_matter.permissions.as_ref().and_then(|p| p.write.as_deref()),
+        );
+
+        // Validate that write-requiring safe-outputs have a write service connection
+        validate_write_permissions(front_matter)?;
+
         // Replace all template markers
         let compiler_version = env!("CARGO_PKG_VERSION");
         let replacements: Vec<(&str, &str)> = vec![
@@ -143,6 +163,10 @@ displayName: "Finalize""#,
             ("{{ pipeline_path }}", &pipeline_path),
             ("{{ working_directory }}", &working_directory),
             ("{{ agency_params }}", &agency_params),
+            ("{{ acquire_ado_token }}", &acquire_read_token),
+            ("{{ copilot_ado_env }}", &copilot_ado_env),
+            ("{{ acquire_write_token }}", &acquire_write_token),
+            ("{{ executor_ado_env }}", &executor_ado_env),
         ];
 
         let pipeline_yaml = replacements

--- a/src/compile/standalone.rs
+++ b/src/compile/standalone.rs
@@ -15,10 +15,12 @@ use std::path::Path;
 use super::Compiler;
 use super::common::{
     self, AWF_VERSION, DEFAULT_POOL, compute_effective_workspace, generate_copilot_params,
-    generate_cancel_previous_builds, generate_checkout_self, generate_checkout_steps,
-    generate_ci_trigger, generate_pipeline_path, generate_pipeline_resources, generate_pr_trigger,
-    generate_repositories, generate_schedule, generate_source_path, generate_working_directory,
-    replace_with_indent, sanitize_filename,
+    generate_acquire_ado_token, generate_cancel_previous_builds, generate_checkout_self,
+    generate_checkout_steps, generate_ci_trigger, generate_copilot_ado_env,
+    generate_executor_ado_env, generate_pipeline_path, generate_pipeline_resources,
+    generate_pr_trigger, generate_repositories, generate_schedule, generate_source_path,
+    generate_working_directory, replace_with_indent, sanitize_filename,
+    validate_write_permissions,
 };
 use super::types::{FrontMatter, McpConfig};
 use crate::allowed_hosts::{CORE_ALLOWED_HOSTS, mcp_required_hosts};
@@ -104,10 +106,24 @@ impl Compiler for StandaloneCompiler {
         let finalize_steps = generate_finalize_steps(&front_matter.post_steps);
         let agentic_depends_on = generate_agentic_depends_on(&front_matter.setup);
 
-        // Generate service connection token acquisition step and env vars
-        let acquire_ado_token =
-            generate_acquire_ado_token(&front_matter.read_only_service_connection);
-        let copilot_ado_env = generate_copilot_ado_env(&front_matter.read_only_service_connection);
+        // Generate service connection token acquisition steps and env vars
+        let acquire_read_token = generate_acquire_ado_token(
+            front_matter.permissions.as_ref().and_then(|p| p.read.as_deref()),
+            "SC_READ_TOKEN",
+        );
+        let copilot_ado_env = generate_copilot_ado_env(
+            front_matter.permissions.as_ref().and_then(|p| p.read.as_deref()),
+        );
+        let acquire_write_token = generate_acquire_ado_token(
+            front_matter.permissions.as_ref().and_then(|p| p.write.as_deref()),
+            "SC_WRITE_TOKEN",
+        );
+        let executor_ado_env = generate_executor_ado_env(
+            front_matter.permissions.as_ref().and_then(|p| p.write.as_deref()),
+        );
+
+        // Validate that write-requiring safe-outputs have a write service connection
+        validate_write_permissions(front_matter)?;
 
         // Load threat analysis prompt template
         let threat_analysis_prompt = include_str!("../../templates/threat-analysis.md");
@@ -148,8 +164,10 @@ impl Compiler for StandaloneCompiler {
             ("{{ workspace }}", &working_directory),
             ("{{ allowed_domains }}", &allowed_domains),
             ("{{ agent_content }}", markdown_body),
-            ("{{ acquire_ado_token }}", &acquire_ado_token),
+            ("{{ acquire_ado_token }}", &acquire_read_token),
             ("{{ copilot_ado_env }}", &copilot_ado_env),
+            ("{{ acquire_write_token }}", &acquire_write_token),
+            ("{{ executor_ado_env }}", &executor_ado_env),
         ];
 
         let pipeline_yaml = replacements
@@ -405,46 +423,6 @@ pub fn generate_firewall_config(front_matter: &FrontMatter) -> FirewallConfig {
     FirewallConfig {
         upstreams,
         metadata_path: None,
-    }
-}
-
-/// Generate the AzureCLI@2 step to acquire an ADO-scoped token from an ARM service connection.
-/// Returns empty string if no service connection is configured.
-fn generate_acquire_ado_token(service_connection: &Option<String>) -> String {
-    match service_connection {
-        Some(sc) => {
-            let mut lines = Vec::new();
-            lines.push("- task: AzureCLI@2".to_string());
-            lines.push(r#"  displayName: "Get ADO token from service connection""#.to_string());
-            lines.push("  inputs:".to_string());
-            lines.push(format!("    azureSubscription: '{}'", sc));
-            lines.push("    scriptType: 'bash'".to_string());
-            lines.push("    scriptLocation: 'inlineScript'".to_string());
-            lines.push("    addSpnToEnvironment: true".to_string());
-            lines.push("    inlineScript: |".to_string());
-            lines.push("      ADO_TOKEN=$(az account get-access-token \\".to_string());
-            lines.push("        --resource 499b84ac-1321-427f-aa17-267ca6975798 \\".to_string());
-            lines.push("        --query accessToken -o tsv)".to_string());
-            lines.push(
-                "      echo \"##vso[task.setvariable variable=SC_ACCESS_TOKEN;issecret=true]$ADO_TOKEN\""
-                    .to_string(),
-            );
-            lines.join("\n")
-        }
-        None => String::new(),
-    }
-}
-
-/// Generate the env block entries for the copilot AWF step.
-/// When a service connection is configured, uses the SC token.
-/// When not configured, omits ADO access tokens entirely.
-fn generate_copilot_ado_env(service_connection: &Option<String>) -> String {
-    match service_connection {
-        Some(_) => {
-            "AZURE_DEVOPS_EXT_PAT: $(SC_ACCESS_TOKEN)\nSYSTEM_ACCESSTOKEN: $(SC_ACCESS_TOKEN)"
-                .to_string()
-        }
-        None => String::new(),
     }
 }
 

--- a/src/compile/types.rs
+++ b/src/compile/types.rs
@@ -256,11 +256,15 @@ pub struct FrontMatter {
     /// Separate teardown job after safe outputs
     #[serde(default)]
     pub teardown: Vec<serde_yaml::Value>,
-    /// Azure Resource Manager service connection for read-only ADO token
-    /// When set, uses AzureCLI@2 to mint an ADO-scoped token from this connection.
-    /// When unset, ADO access tokens are omitted from the copilot invocation.
-    #[serde(default, rename = "read-only-service-connection")]
-    pub read_only_service_connection: Option<String>,
+    /// Permissions configuration for ADO access tokens.
+    ///
+    /// ADO supports two access levels: blanket read and blanket write.
+    /// Tokens are minted from ARM service connections — System.AccessToken is never used.
+    ///
+    /// - `read`: MI for Stage 1 (agent) — read-only ADO access
+    /// - `write`: MI for Stage 2 (executor) — write access for safe-outputs, never given to agent
+    #[serde(default)]
+    pub permissions: Option<PermissionsConfig>,
     /// Workflow-level environment variables
     #[serde(default)]
     pub env: HashMap<String, String>,
@@ -286,6 +290,40 @@ pub struct NetworkConfig {
     /// Blocked host patterns (takes precedence over allow)
     #[serde(default)]
     pub blocked: Vec<String>,
+}
+
+/// Permissions configuration for ADO access tokens.
+///
+/// ADO does not support fine-grained permissions. There are two access levels:
+/// blanket read and blanket write, each backed by an ARM service connection
+/// that mints an ADO-scoped token.
+///
+/// Examples:
+/// ```yaml
+/// # Both read and write
+/// permissions:
+///   read: my-read-arm-connection
+///   write: my-write-arm-connection
+///
+/// # Read-only (agent can query ADO APIs, no write safe-outputs)
+/// permissions:
+///   read: my-read-arm-connection
+///
+/// # Write-only (safe-outputs can write, agent gets no ADO token)
+/// permissions:
+///   write: my-write-arm-connection
+/// ```
+#[derive(Debug, Deserialize, Clone, Default)]
+pub struct PermissionsConfig {
+    /// ARM service connection for read-only ADO access.
+    /// Token is minted and given to the agent in Stage 1 (inside AWF sandbox).
+    #[serde(default)]
+    pub read: Option<String>,
+    /// ARM service connection for write ADO access.
+    /// Token is minted and used only by the executor in Stage 2 (ProcessSafeOutputs).
+    /// This token is never exposed to the agent.
+    #[serde(default)]
+    pub write: Option<String>,
 }
 
 /// Repository resource definition
@@ -496,5 +534,69 @@ mod tests {
         assert_eq!(ec.model(), "claude-opus-4.5");
         assert_eq!(ec.max_turns(), Some(50));
         assert_eq!(ec.timeout_minutes(), Some(30));
+    }
+
+    // ─── PermissionsConfig deserialization ───────────────────────────────
+
+    #[test]
+    fn test_permissions_both_fields() {
+        let yaml = "read: my-read-sc\nwrite: my-write-sc";
+        let pc: PermissionsConfig = serde_yaml::from_str(yaml).unwrap();
+        assert_eq!(pc.read.as_deref(), Some("my-read-sc"));
+        assert_eq!(pc.write.as_deref(), Some("my-write-sc"));
+    }
+
+    #[test]
+    fn test_permissions_read_only() {
+        let yaml = "read: my-read-sc";
+        let pc: PermissionsConfig = serde_yaml::from_str(yaml).unwrap();
+        assert_eq!(pc.read.as_deref(), Some("my-read-sc"));
+        assert!(pc.write.is_none());
+    }
+
+    #[test]
+    fn test_permissions_write_only() {
+        let yaml = "write: my-write-sc";
+        let pc: PermissionsConfig = serde_yaml::from_str(yaml).unwrap();
+        assert!(pc.read.is_none());
+        assert_eq!(pc.write.as_deref(), Some("my-write-sc"));
+    }
+
+    #[test]
+    fn test_permissions_default() {
+        let pc = PermissionsConfig::default();
+        assert!(pc.read.is_none());
+        assert!(pc.write.is_none());
+    }
+
+    #[test]
+    fn test_permissions_in_front_matter() {
+        let content = r#"---
+name: "Test Agent"
+description: "Test"
+permissions:
+  read: my-read-sc
+  write: my-write-sc
+---
+
+Body
+"#;
+        let (fm, _) = super::super::common::parse_markdown(content).unwrap();
+        let perms = fm.permissions.unwrap();
+        assert_eq!(perms.read.as_deref(), Some("my-read-sc"));
+        assert_eq!(perms.write.as_deref(), Some("my-write-sc"));
+    }
+
+    #[test]
+    fn test_permissions_omitted_in_front_matter() {
+        let content = r#"---
+name: "Test Agent"
+description: "Test"
+---
+
+Body
+"#;
+        let (fm, _) = super::super::common::parse_markdown(content).unwrap();
+        assert!(fm.permissions.is_none());
     }
 }

--- a/src/create.rs
+++ b/src/create.rs
@@ -28,6 +28,10 @@ struct AgentConfig {
     /// Repository aliases to checkout (if empty, all repos are checked out)
     checkout: Vec<String>,
     mcps: Vec<McpSelection>,
+    /// ARM service connection for read-only ADO access (Stage 1 agent)
+    read_service_connection: Option<String>,
+    /// ARM service connection for write ADO access (Stage 2 executor)
+    write_service_connection: Option<String>,
     prompt_body: String,
 }
 
@@ -59,6 +63,7 @@ enum WizardStep {
     Repositories,
     Checkout,
     Mcps,
+    Permissions,
     Done,
 }
 
@@ -73,7 +78,8 @@ impl WizardStep {
             Self::Workspace => Self::Repositories,
             Self::Repositories => Self::Checkout,
             Self::Checkout => Self::Mcps,
-            Self::Mcps => Self::Done,
+            Self::Mcps => Self::Permissions,
+            Self::Permissions => Self::Done,
             Self::Done => Self::Done,
         }
     }
@@ -89,7 +95,8 @@ impl WizardStep {
             Self::Repositories => Self::Workspace,
             Self::Checkout => Self::Repositories,
             Self::Mcps => Self::Checkout,
-            Self::Done => Self::Mcps,
+            Self::Permissions => Self::Mcps,
+            Self::Done => Self::Permissions,
         }
     }
 }
@@ -273,6 +280,56 @@ pub async fn create_agent(output_dir: Option<PathBuf>) -> Result<()> {
                     None => {
                         // User pressed Esc, step already updated
                     }
+                }
+            }
+
+            WizardStep::Permissions => {
+                let read_prompt = Text::new("Read service connection (optional):")
+                    .with_help_message(
+                        "ARM service connection for read-only ADO access. Leave empty to skip. (Esc to go back)",
+                    )
+                    .with_default(
+                        config.read_service_connection.as_deref().unwrap_or(""),
+                    )
+                    .prompt();
+
+                match read_prompt {
+                    Ok(val) => {
+                        config.read_service_connection = if val.trim().is_empty() {
+                            None
+                        } else {
+                            Some(val.trim().to_string())
+                        };
+                    }
+                    Err(InquireError::OperationCanceled) => {
+                        step = step.prev();
+                        continue;
+                    }
+                    Err(e) => return Err(e).context("Failed to get read service connection"),
+                }
+
+                let write_prompt = Text::new("Write service connection (optional):")
+                    .with_help_message(
+                        "ARM service connection for write ADO access (used by safe-outputs executor only). Leave empty to skip. (Esc to go back)",
+                    )
+                    .with_default(
+                        config.write_service_connection.as_deref().unwrap_or(""),
+                    )
+                    .prompt();
+
+                match write_prompt {
+                    Ok(val) => {
+                        config.write_service_connection = if val.trim().is_empty() {
+                            None
+                        } else {
+                            Some(val.trim().to_string())
+                        };
+                        step = step.next();
+                    }
+                    Err(InquireError::OperationCanceled) => {
+                        step = step.prev();
+                    }
+                    Err(e) => return Err(e).context("Failed to get write service connection"),
                 }
             }
 
@@ -1022,6 +1079,17 @@ fn generate_markdown(config: &AgentConfig) -> String {
                     }
                 }
             }
+        }
+    }
+
+    // Permissions
+    if config.read_service_connection.is_some() || config.write_service_connection.is_some() {
+        yaml_parts.push("permissions:".to_string());
+        if let Some(ref sc) = config.read_service_connection {
+            yaml_parts.push(format!("  read: {}", sc));
+        }
+        if let Some(ref sc) = config.write_service_connection {
+            yaml_parts.push(format!("  write: {}", sc));
         }
     }
 

--- a/templates/1es-base.yml
+++ b/templates/1es-base.yml
@@ -150,6 +150,8 @@ extends:
               {{ checkout_self }}
               {{ checkout_repositories }}
 
+              {{ acquire_ado_token }}
+
               - download: current
                 artifact: AgencyArtifact
 
@@ -239,8 +241,7 @@ extends:
                 displayName: "Run threat analysis"
                 workingDirectory: {{ working_directory }}
                 env:
-                  AZURE_DEVOPS_EXT_PAT: $(System.AccessToken)
-                  SYSTEM_ACCESSTOKEN: $(System.AccessToken)
+                  {{ copilot_ado_env }}
                   GITHUB_TOKEN: $(GITHUB_TOKEN)
                   GITHUB_READ_ONLY: 1
                   HTTP_PROXY: "http://127.0.0.1:$(PROXY_PORT)"
@@ -308,6 +309,8 @@ extends:
               {{ checkout_self }}
               {{ checkout_repositories }}
 
+              {{ acquire_write_token }}
+
               - download: current
                 artifact: analyzed_outputs
 
@@ -338,6 +341,6 @@ extends:
                 displayName: Process safe outputs
                 workingDirectory: {{ working_directory }}
                 env:
-                  SYSTEM_ACCESSTOKEN: $(System.AccessToken)
+                  {{ executor_ado_env }}
 
           {{ teardown_job }}

--- a/templates/base.yml
+++ b/templates/base.yml
@@ -501,6 +501,8 @@ jobs:
       {{ checkout_self }}
       {{ checkout_repositories }}
 
+      {{ acquire_write_token }}
+
       - download: current
         artifact: analyzed_outputs_$(Build.BuildId)
 
@@ -536,7 +538,7 @@ jobs:
         displayName: Process safe outputs
         workingDirectory: {{ working_directory }}
         env:
-          SYSTEM_ACCESSTOKEN: $(System.AccessToken)
+          {{ executor_ado_env }}
 
       - bash: |
           # Copy all logs to output directory for artifact upload

--- a/tests/compiler_tests.rs
+++ b/tests/compiler_tests.rs
@@ -316,6 +316,20 @@ fn test_fixture_complete_agent() {
     // Verify it has both built-in and custom MCPs
     assert!(content.contains("ado: true"), "Should have built-in MCP");
     assert!(content.contains("command:"), "Should have custom MCP");
+
+    // Verify permissions
+    assert!(
+        content.contains("permissions:"),
+        "Should have permissions"
+    );
+    assert!(
+        content.contains("read: my-read-arm-connection"),
+        "Should have read service connection"
+    );
+    assert!(
+        content.contains("write: my-write-arm-connection"),
+        "Should have write service connection"
+    );
 }
 
 /// Test that compiled output has no unreplaced template markers
@@ -474,6 +488,291 @@ fn test_fixture_pipeline_trigger_agent_compiled_output() {
             line.trim()
         );
     }
+
+    let _ = fs::remove_dir_all(&temp_dir);
+}
+
+/// Test that permissions with read+write service connections generates correct token steps
+#[test]
+fn test_permissions_read_write_compiled_output() {
+    let temp_dir = std::env::temp_dir().join(format!(
+        "agentic-pipeline-permissions-rw-{}",
+        std::process::id()
+    ));
+    fs::create_dir_all(&temp_dir).expect("Failed to create temp directory");
+
+    let test_input = temp_dir.join("perms-agent.md");
+    let test_content = r#"---
+name: "Permissions Test Agent"
+description: "Agent with read and write permissions"
+permissions:
+  read: my-read-sc
+  write: my-write-sc
+safe-outputs:
+  create-work-item:
+    work-item-type: Task
+---
+
+## Test Agent
+
+Do something.
+"#;
+    fs::write(&test_input, test_content).expect("Failed to write test input");
+
+    let output_path = temp_dir.join("perms-agent.yml");
+    let binary_path = PathBuf::from(env!("CARGO_BIN_EXE_ado-aw"));
+    let output = std::process::Command::new(&binary_path)
+        .args(["compile", test_input.to_str().unwrap(), "-o", output_path.to_str().unwrap()])
+        .output()
+        .expect("Failed to run compiler");
+
+    assert!(
+        output.status.success(),
+        "Compiler should succeed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let compiled = fs::read_to_string(&output_path).expect("Should read compiled YAML");
+
+    // Should contain read token acquisition (SC_READ_TOKEN)
+    assert!(
+        compiled.contains("SC_READ_TOKEN"),
+        "Compiled output should contain SC_READ_TOKEN for read service connection"
+    );
+    assert!(
+        compiled.contains("my-read-sc"),
+        "Compiled output should contain the read service connection name"
+    );
+
+    // Should contain write token acquisition (SC_WRITE_TOKEN)
+    assert!(
+        compiled.contains("SC_WRITE_TOKEN"),
+        "Compiled output should contain SC_WRITE_TOKEN for write service connection"
+    );
+    assert!(
+        compiled.contains("my-write-sc"),
+        "Compiled output should contain the write service connection name"
+    );
+
+    // Should NOT contain System.AccessToken in executor env
+    assert!(
+        !compiled.contains("SYSTEM_ACCESSTOKEN: $(System.AccessToken)"),
+        "Compiled output should not pass System.AccessToken to executor"
+    );
+
+    // Verify no unreplaced markers remain
+    for line in compiled.lines() {
+        let stripped = line.replace("${{", "");
+        assert!(
+            !stripped.contains("{{ "),
+            "Compiled output should not contain unreplaced marker: {}",
+            line.trim()
+        );
+    }
+
+    let _ = fs::remove_dir_all(&temp_dir);
+}
+
+/// Test that permissions omitted results in no token steps
+#[test]
+fn test_permissions_omitted_compiled_output() {
+    let temp_dir = std::env::temp_dir().join(format!(
+        "agentic-pipeline-permissions-none-{}",
+        std::process::id()
+    ));
+    fs::create_dir_all(&temp_dir).expect("Failed to create temp directory");
+
+    let test_input = temp_dir.join("no-perms-agent.md");
+    let test_content = r#"---
+name: "No Permissions Agent"
+description: "Agent with no permissions configured"
+---
+
+## Test Agent
+
+Do something.
+"#;
+    fs::write(&test_input, test_content).expect("Failed to write test input");
+
+    let output_path = temp_dir.join("no-perms-agent.yml");
+    let binary_path = PathBuf::from(env!("CARGO_BIN_EXE_ado-aw"));
+    let output = std::process::Command::new(&binary_path)
+        .args(["compile", test_input.to_str().unwrap(), "-o", output_path.to_str().unwrap()])
+        .output()
+        .expect("Failed to run compiler");
+
+    assert!(
+        output.status.success(),
+        "Compiler should succeed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let compiled = fs::read_to_string(&output_path).expect("Should read compiled YAML");
+
+    // Should NOT contain any SC token variables
+    assert!(
+        !compiled.contains("SC_READ_TOKEN"),
+        "Compiled output should not contain SC_READ_TOKEN when permissions are omitted"
+    );
+    assert!(
+        !compiled.contains("SC_WRITE_TOKEN"),
+        "Compiled output should not contain SC_WRITE_TOKEN when permissions are omitted"
+    );
+    assert!(
+        !compiled.contains("AzureCLI@2"),
+        "Compiled output should not contain AzureCLI task when permissions are omitted"
+    );
+
+    // Verify no unreplaced markers remain
+    for line in compiled.lines() {
+        let stripped = line.replace("${{", "");
+        assert!(
+            !stripped.contains("{{ "),
+            "Compiled output should not contain unreplaced marker: {}",
+            line.trim()
+        );
+    }
+
+    let _ = fs::remove_dir_all(&temp_dir);
+}
+
+/// Test that write-requiring safe-outputs fail without write service connection
+#[test]
+fn test_permissions_validation_fails_without_write_sc() {
+    let temp_dir = std::env::temp_dir().join(format!(
+        "agentic-pipeline-permissions-fail-{}",
+        std::process::id()
+    ));
+    fs::create_dir_all(&temp_dir).expect("Failed to create temp directory");
+
+    let test_input = temp_dir.join("bad-perms-agent.md");
+    let test_content = r#"---
+name: "Bad Permissions Agent"
+description: "Agent with create-work-item but no write SC"
+safe-outputs:
+  create-work-item:
+    work-item-type: Task
+---
+
+## Test Agent
+
+Do something.
+"#;
+    fs::write(&test_input, test_content).expect("Failed to write test input");
+
+    let output_path = temp_dir.join("bad-perms-agent.yml");
+    let binary_path = PathBuf::from(env!("CARGO_BIN_EXE_ado-aw"));
+    let output = std::process::Command::new(&binary_path)
+        .args(["compile", test_input.to_str().unwrap(), "-o", output_path.to_str().unwrap()])
+        .output()
+        .expect("Failed to run compiler");
+
+    assert!(
+        !output.status.success(),
+        "Compiler should fail when write-requiring safe-outputs lack write SC"
+    );
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("permissions.write"),
+        "Error message should mention permissions.write: {}",
+        stderr
+    );
+
+    let _ = fs::remove_dir_all(&temp_dir);
+}
+
+/// Test that write-requiring safe-outputs succeed with write service connection
+#[test]
+fn test_permissions_validation_passes_with_write_sc() {
+    let temp_dir = std::env::temp_dir().join(format!(
+        "agentic-pipeline-permissions-pass-{}",
+        std::process::id()
+    ));
+    fs::create_dir_all(&temp_dir).expect("Failed to create temp directory");
+
+    let test_input = temp_dir.join("good-perms-agent.md");
+    let test_content = r#"---
+name: "Good Permissions Agent"
+description: "Agent with create-work-item and write SC"
+permissions:
+  write: my-write-sc
+safe-outputs:
+  create-work-item:
+    work-item-type: Task
+  create-pull-request:
+    target-branch: main
+---
+
+## Test Agent
+
+Do something.
+"#;
+    fs::write(&test_input, test_content).expect("Failed to write test input");
+
+    let output_path = temp_dir.join("good-perms-agent.yml");
+    let binary_path = PathBuf::from(env!("CARGO_BIN_EXE_ado-aw"));
+    let output = std::process::Command::new(&binary_path)
+        .args(["compile", test_input.to_str().unwrap(), "-o", output_path.to_str().unwrap()])
+        .output()
+        .expect("Failed to run compiler");
+
+    assert!(
+        output.status.success(),
+        "Compiler should succeed when write SC is provided: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let _ = fs::remove_dir_all(&temp_dir);
+}
+
+/// Test that read-only permissions work (agent gets token, executor does not)
+#[test]
+fn test_permissions_read_only_compiled_output() {
+    let temp_dir = std::env::temp_dir().join(format!(
+        "agentic-pipeline-permissions-ro-{}",
+        std::process::id()
+    ));
+    fs::create_dir_all(&temp_dir).expect("Failed to create temp directory");
+
+    let test_input = temp_dir.join("read-only-agent.md");
+    let test_content = r#"---
+name: "Read Only Agent"
+description: "Agent with read-only permissions"
+permissions:
+  read: my-read-sc
+---
+
+## Test Agent
+
+Do something.
+"#;
+    fs::write(&test_input, test_content).expect("Failed to write test input");
+
+    let output_path = temp_dir.join("read-only-agent.yml");
+    let binary_path = PathBuf::from(env!("CARGO_BIN_EXE_ado-aw"));
+    let output = std::process::Command::new(&binary_path)
+        .args(["compile", test_input.to_str().unwrap(), "-o", output_path.to_str().unwrap()])
+        .output()
+        .expect("Failed to run compiler");
+
+    assert!(
+        output.status.success(),
+        "Compiler should succeed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let compiled = fs::read_to_string(&output_path).expect("Should read compiled YAML");
+
+    // Should contain read token but not write token
+    assert!(
+        compiled.contains("SC_READ_TOKEN"),
+        "Compiled output should contain SC_READ_TOKEN"
+    );
+    assert!(
+        !compiled.contains("SC_WRITE_TOKEN"),
+        "Compiled output should not contain SC_WRITE_TOKEN when only read is configured"
+    );
 
     let _ = fs::remove_dir_all(&temp_dir);
 }

--- a/tests/fixtures/complete-agent.md
+++ b/tests/fixtures/complete-agent.md
@@ -32,6 +32,14 @@ mcp-servers:
       - custom_function_2
     env:
       NODE_ENV: "test"
+permissions:
+  read: my-read-arm-connection
+  write: my-write-arm-connection
+safe-outputs:
+  create-pull-request:
+    target-branch: main
+  create-work-item:
+    work-item-type: Task
 steps:
   - bash: echo "Preparing context"
     displayName: "Prepare context"


### PR DESCRIPTION
Replace the single 
ead-only-service-connection front matter field with a structured permissions field that models ADO's two access levels via separate ARM service connections:

- permissions.read: mints a read-only token for the agent (Stage 1)
- permissions.write: mints a write token for the executor (Stage 2 only)

System.AccessToken is no longer used for agent or executor operations.

Key changes:
- Add PermissionsConfig type with read/write service connection fields
- Generate separate SC_READ_TOKEN and SC_WRITE_TOKEN pipeline variables
- Add compile-time validation: fail if write safe-outputs lack permissions.write
- Update both standalone and 1ES compilers and templates
- Add Permissions step to interactive creation wizard
- Add 5 integration tests covering all permission combinations
- Update AGENTS.md documentation