### PR TITLE
ci: add workflow_dispatch to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,12 @@ on:
   push:
     branches:
       - main
+  workflow_dispatch:
+    inputs:
+      tag_name:
+        description: "Release tag to upload assets to (e.g., v0.1.1)"
+        required: true
+        type: string
 
 env:
   CARGO_TERM_COLOR: always
@@ -15,6 +21,7 @@ permissions:
 jobs:
   release-please:
     name: Release Please
+    if: github.event_name == 'push'
     runs-on: ubuntu-latest
     outputs:
       release_created: ${{ steps.release.outputs.release_created }}
@@ -28,7 +35,9 @@ jobs:
   build:
     name: Build (Linux)
     needs: release-please
-    if: ${{ needs.release-please.outputs.release_created }}
+    if: >-
+      always() &&
+      (needs.release-please.outputs.release_created == 'true' || github.event_name == 'workflow_dispatch')
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -54,7 +63,8 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          gh release upload ${{ needs.release-please.outputs.tag_name }} \
+          TAG="${{ needs.release-please.outputs.tag_name || github.event.inputs.tag_name }}"
+          gh release upload "$TAG" \
             target/release/ado-aw-linux-x64 \
             target/release/checksums.txt \
             --clobber


### PR DESCRIPTION
Adds manual trigger support to the release workflow so builds can be dispatched for existing releases (e.g., when release-please doesn't track a version bump).

- Adds \workflow_dispatch\ input for \	ag_name\
- Skips release-please job on manual dispatch
- Build job runs on both release-please releases and manual dispatch
- Upload step resolves tag from either source