### PR TITLE
fix: pin AWF container images to specific firewall version

### DIFF
--- a/templates/base.yml
+++ b/templates/base.yml
@@ -193,9 +193,11 @@ jobs:
         displayName: "Download AWF (Agentic Workflow Firewall) v{{ firewall_version }}"
 
       - bash: |
-          docker pull ghcr.io/github/gh-aw-firewall/squid:latest
-          docker pull ghcr.io/github/gh-aw-firewall/agent:latest
-        displayName: "Pre-pull AWF container images"
+          docker pull ghcr.io/github/gh-aw-firewall/squid:v{{ firewall_version }}
+          docker pull ghcr.io/github/gh-aw-firewall/agent:v{{ firewall_version }}
+          docker tag ghcr.io/github/gh-aw-firewall/squid:v{{ firewall_version }} ghcr.io/github/gh-aw-firewall/squid:latest
+          docker tag ghcr.io/github/gh-aw-firewall/agent:v{{ firewall_version }} ghcr.io/github/gh-aw-firewall/agent:latest
+        displayName: "Pre-pull AWF container images (v{{ firewall_version }})"
 
       {{ prepare_steps }}
 
@@ -352,9 +354,11 @@ jobs:
         displayName: "Download AWF (Agentic Workflow Firewall) v{{ firewall_version }}"
 
       - bash: |
-          docker pull ghcr.io/github/gh-aw-firewall/squid:latest
-          docker pull ghcr.io/github/gh-aw-firewall/agent:latest
-        displayName: "Pre-pull AWF container images"
+          docker pull ghcr.io/github/gh-aw-firewall/squid:v{{ firewall_version }}
+          docker pull ghcr.io/github/gh-aw-firewall/agent:v{{ firewall_version }}
+          docker tag ghcr.io/github/gh-aw-firewall/squid:v{{ firewall_version }} ghcr.io/github/gh-aw-firewall/squid:latest
+          docker tag ghcr.io/github/gh-aw-firewall/agent:v{{ firewall_version }} ghcr.io/github/gh-aw-firewall/agent:latest
+        displayName: "Pre-pull AWF container images (v{{ firewall_version }})"
 
       - bash: |
           mkdir -p {{ working_directory }}/safe_outputs


### PR DESCRIPTION
Pulls versioned Docker images (e.g. \ghcr.io/.../squid:v0.5.0\) instead of \:latest\ to ensure reproducible builds, then tags them as \:latest\ for backward compatibility with AWF.

This prevents silent breakage when upstream images are updated.