### PR TITLE
fix: drop v prefix from AWF container image tags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [0.1.2](https://github.com/githubnext/ado-aw/compare/v0.1.1...v0.1.2) (2026-03-16)
+
+
+### Bug Fixes
+
+* pin AWF container images to specific firewall version ([#30](https://github.com/githubnext/ado-aw/issues/30)) ([bb92c9c](https://github.com/githubnext/ado-aw/commit/bb92c9ccc6b5edbfa6b0ddeabca1cbe0cd39dd98))
+
 ## 0.1.0 (2026-03-13)
 
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "ado-aw"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ado-aw"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2024"
 
 [dependencies]

--- a/templates/base.yml
+++ b/templates/base.yml
@@ -193,10 +193,10 @@ jobs:
         displayName: "Download AWF (Agentic Workflow Firewall) v{{ firewall_version }}"
 
       - bash: |
-          docker pull ghcr.io/github/gh-aw-firewall/squid:v{{ firewall_version }}
-          docker pull ghcr.io/github/gh-aw-firewall/agent:v{{ firewall_version }}
-          docker tag ghcr.io/github/gh-aw-firewall/squid:v{{ firewall_version }} ghcr.io/github/gh-aw-firewall/squid:latest
-          docker tag ghcr.io/github/gh-aw-firewall/agent:v{{ firewall_version }} ghcr.io/github/gh-aw-firewall/agent:latest
+          docker pull ghcr.io/github/gh-aw-firewall/squid:{{ firewall_version }}
+          docker pull ghcr.io/github/gh-aw-firewall/agent:{{ firewall_version }}
+          docker tag ghcr.io/github/gh-aw-firewall/squid:{{ firewall_version }} ghcr.io/github/gh-aw-firewall/squid:latest
+          docker tag ghcr.io/github/gh-aw-firewall/agent:{{ firewall_version }} ghcr.io/github/gh-aw-firewall/agent:latest
         displayName: "Pre-pull AWF container images (v{{ firewall_version }})"
 
       {{ prepare_steps }}
@@ -354,10 +354,10 @@ jobs:
         displayName: "Download AWF (Agentic Workflow Firewall) v{{ firewall_version }}"
 
       - bash: |
-          docker pull ghcr.io/github/gh-aw-firewall/squid:v{{ firewall_version }}
-          docker pull ghcr.io/github/gh-aw-firewall/agent:v{{ firewall_version }}
-          docker tag ghcr.io/github/gh-aw-firewall/squid:v{{ firewall_version }} ghcr.io/github/gh-aw-firewall/squid:latest
-          docker tag ghcr.io/github/gh-aw-firewall/agent:v{{ firewall_version }} ghcr.io/github/gh-aw-firewall/agent:latest
+          docker pull ghcr.io/github/gh-aw-firewall/squid:{{ firewall_version }}
+          docker pull ghcr.io/github/gh-aw-firewall/agent:{{ firewall_version }}
+          docker tag ghcr.io/github/gh-aw-firewall/squid:{{ firewall_version }} ghcr.io/github/gh-aw-firewall/squid:latest
+          docker tag ghcr.io/github/gh-aw-firewall/agent:{{ firewall_version }} ghcr.io/github/gh-aw-firewall/agent:latest
         displayName: "Pre-pull AWF container images (v{{ firewall_version }})"
 
       - bash: |


### PR DESCRIPTION
Uses bare semver tags for Docker images (OCI convention) instead of \\-prefixed tags.

- \ghcr.io/.../squid:v0.5.0\ → \ghcr.io/.../squid:0.5.0\
- Tags pulled images as \:latest\ for backward compatibility with AWF
- Display names retain \\ prefix (human-readable context)