### PR TITLE
fix: quote chmod paths and remove fragile sha256sum pipe in templates

### DIFF
--- a/templates/1es-base.yml
+++ b/templates/1es-base.yml
@@ -67,7 +67,7 @@ extends:
 
                       echo "Verifying checksum..."
                       cd "$DOWNLOAD_DIR"
-                      sha256sum -c checksums.txt --ignore-missing | grep -q ": OK"
+                      sha256sum -c checksums.txt --ignore-missing
                       mv ado-aw-linux-x64 ado-aw
                       chmod +x ado-aw
                     displayName: "Download agentic pipeline compiler (v{{ compiler_version }})"
@@ -182,7 +182,7 @@ extends:
 
                   echo "Verifying checksum..."
                   cd "$DOWNLOAD_DIR"
-                  sha256sum -c checksums.txt --ignore-missing | grep -q ": OK"
+                  sha256sum -c checksums.txt --ignore-missing
                   mv ado-aw-linux-x64 ado-aw
                   chmod +x ado-aw
                 displayName: "Download agentic pipeline compiler (v{{ compiler_version }})"
@@ -327,13 +327,13 @@ extends:
 
                   echo "Verifying checksum..."
                   cd "$DOWNLOAD_DIR"
-                  sha256sum -c checksums.txt --ignore-missing | grep -q ": OK"
+                  sha256sum -c checksums.txt --ignore-missing
                   mv ado-aw-linux-x64 ado-aw
                   chmod +x ado-aw
                 displayName: "Download agentic pipeline compiler (v{{ compiler_version }})"
 
               - bash: |
-                  chmod +x $(Pipeline.Workspace)/agentic-pipeline-compiler/ado-aw
+                  chmod +x "$(Pipeline.Workspace)/agentic-pipeline-compiler/ado-aw"
                   echo "##vso[task.prependpath]$(Pipeline.Workspace)/agentic-pipeline-compiler"
                 displayName: Add agentic compiler to path
 

--- a/templates/base.yml
+++ b/templates/base.yml
@@ -65,7 +65,7 @@ jobs:
 
           echo "Verifying checksum..."
           cd "$DOWNLOAD_DIR"
-          sha256sum -c checksums.txt --ignore-missing | grep -q ": OK"
+          sha256sum -c checksums.txt --ignore-missing
           mv ado-aw-linux-x64 ado-aw
           chmod +x ado-aw
         displayName: "Download agentic pipeline compiler (v{{ compiler_version }})"
@@ -185,7 +185,7 @@ jobs:
 
           echo "Verifying checksum..."
           cd "$DOWNLOAD_DIR"
-          sha256sum -c checksums.txt --ignore-missing | grep -q ": OK"
+          sha256sum -c checksums.txt --ignore-missing
           mv awf-linux-x64 awf
           chmod +x awf
           echo "##vso[task.prependpath]$(Pipeline.Workspace)/awf"
@@ -325,7 +325,7 @@ jobs:
 
           echo "Verifying checksum..."
           cd "$DOWNLOAD_DIR"
-          sha256sum -c checksums.txt --ignore-missing | grep -q ": OK"
+          sha256sum -c checksums.txt --ignore-missing
           mv ado-aw-linux-x64 ado-aw
           chmod +x ado-aw
         displayName: "Download agentic pipeline compiler (v{{ compiler_version }})"
@@ -346,7 +346,7 @@ jobs:
 
           echo "Verifying checksum..."
           cd "$DOWNLOAD_DIR"
-          sha256sum -c checksums.txt --ignore-missing | grep -q ": OK"
+          sha256sum -c checksums.txt --ignore-missing
           mv awf-linux-x64 awf
           chmod +x awf
           echo "##vso[task.prependpath]$(Pipeline.Workspace)/awf"
@@ -523,14 +523,14 @@ jobs:
 
           echo "Verifying checksum..."
           cd "$DOWNLOAD_DIR"
-          sha256sum -c checksums.txt --ignore-missing | grep -q ": OK"
+          sha256sum -c checksums.txt --ignore-missing
           mv ado-aw-linux-x64 ado-aw
           chmod +x ado-aw
         displayName: "Download agentic pipeline compiler (v{{ compiler_version }})"
 
       - bash: |
           ls -la "$(Pipeline.Workspace)/agentic-pipeline-compiler"
-          chmod +x $(Pipeline.Workspace)/agentic-pipeline-compiler/ado-aw
+          chmod +x "$(Pipeline.Workspace)/agentic-pipeline-compiler/ado-aw"
           echo "##vso[task.prependpath]$(Pipeline.Workspace)/agentic-pipeline-compiler"
         displayName: Add agentic compiler to path
 

--- a/tests/compiler_tests.rs
+++ b/tests/compiler_tests.rs
@@ -145,8 +145,8 @@ fn test_compiled_yaml_structure() {
         "Template should download the compiler from GitHub Releases"
     );
     assert!(
-        template_content.contains("sha256sum -c checksums.txt --ignore-missing | grep -q \": OK\""),
-        "Template should verify checksum using checksums.txt with grep confirmation"
+        template_content.contains("sha256sum -c checksums.txt --ignore-missing"),
+        "Template should verify checksum using checksums.txt"
     );
 
     // Verify AWF (Agentic Workflow Firewall) is downloaded from GitHub Releases, not ADO pipeline artifacts


### PR DESCRIPTION
Addresses merlinbot feedback on generated pipeline YAML:

**Unquoted chmod path** — `chmod +x $(Pipeline.Workspace)/...` could break if the workspace path contains spaces or glob characters. Now quoted consistently.

**Fragile sha256sum pipe** — `sha256sum -c ... | grep -q ": OK"` can mask a failing checksum without `pipefail`. Replaced with plain `sha256sum -c ...` which already exits non-zero on failure.

### Changes
- `templates/base.yml`: Fix 5 sha256sum pipes + 1 unquoted chmod
- `templates/1es-base.yml`: Fix 3 sha256sum pipes + 1 unquoted chmod
- `tests/compiler_tests.rs`: Update assertion to match new pattern
