### PR TITLE
fix: pin prompt URLs to version tag instead of main branch

### DIFF
--- a/src/init.rs
+++ b/src/init.rs
@@ -44,7 +44,7 @@ pub async fn run(path: Option<&std::path::Path>, force: bool) -> Result<()> {
     println!("  \"Create an ADO agentic workflow that <describe your workflow>\"");
     println!();
     println!("Or use the prompt directly with any AI agent:");
-    println!("  https://raw.githubusercontent.com/githubnext/ado-aw/main/prompts/create-ado-agentic-workflow.md");
+    println!("  https://raw.githubusercontent.com/githubnext/ado-aw/v{version}/prompts/create-ado-agentic-workflow.md");
 
     Ok(())
 }

--- a/templates/init-agent.md
+++ b/templates/init-agent.md
@@ -48,7 +48,7 @@ This is a **dispatcher agent** that routes your request to the appropriate speci
 ### Create New Agentic Pipeline
 **Load when**: User wants to create a new agentic pipeline from scratch
 
-**Prompt file**: https://raw.githubusercontent.com/githubnext/ado-aw/main/prompts/create-ado-agentic-workflow.md
+**Prompt file**: https://raw.githubusercontent.com/githubnext/ado-aw/v{{ compiler_version }}/prompts/create-ado-agentic-workflow.md
 
 **Use cases**:
 - "Create an agentic pipeline that reviews PRs weekly"
@@ -58,7 +58,7 @@ This is a **dispatcher agent** that routes your request to the appropriate speci
 ### Update Existing Pipeline
 **Load when**: User wants to modify an existing agent workflow file
 
-**Prompt file**: https://raw.githubusercontent.com/githubnext/ado-aw/main/prompts/update-ado-agentic-workflow.md
+**Prompt file**: https://raw.githubusercontent.com/githubnext/ado-aw/v{{ compiler_version }}/prompts/update-ado-agentic-workflow.md
 
 **Use cases**:
 - "Add the Azure DevOps MCP to my pipeline"
@@ -68,7 +68,7 @@ This is a **dispatcher agent** that routes your request to the appropriate speci
 ### Debug Failing Pipeline
 **Load when**: User needs to troubleshoot a failing agentic pipeline
 
-**Prompt file**: https://raw.githubusercontent.com/githubnext/ado-aw/main/prompts/debug-ado-agentic-workflow.md
+**Prompt file**: https://raw.githubusercontent.com/githubnext/ado-aw/v{{ compiler_version }}/prompts/debug-ado-agentic-workflow.md
 
 **Use cases**:
 - "Why is my agentic pipeline failing?"
@@ -111,4 +111,4 @@ When a user interacts with you:
 - Agent files must be compiled with `ado-aw compile` after YAML frontmatter changes
 - Markdown body (agent instructions) changes do NOT require recompilation
 - The agent never has direct write access — all mutations go through safe outputs
-- Full reference: https://raw.githubusercontent.com/githubnext/ado-aw/main/AGENTS.md
+- Full reference: https://raw.githubusercontent.com/githubnext/ado-aw/v{{ compiler_version }}/AGENTS.md


### PR DESCRIPTION
## Problem

The `init` command generates agent files (`.github/agents/ado-aw.agent.md`) that reference prompt URLs pointing at the `main` branch. If prompt files are moved or renamed in the future, all previously deployed agent files would silently break.

## Solution

Replace `main` with `v{{ compiler_version }}` in all prompt and AGENTS.md URLs within the init-agent template and the console output hint. This pins each deployed agent file to the exact release version that generated it.

This leverages the existing `{{ compiler_version }}` substitution mechanism — the same one already used for binary download URLs in the same template.

### Changed files

| File | Change |
|------|--------|
| `templates/init-agent.md` | 4 URLs pinned: 3 prompt files + AGENTS.md |
| `src/init.rs` | Console-printed URL now uses compiled version |

### Example

Before:
```
https://raw.githubusercontent.com/githubnext/ado-aw/main/prompts/create-ado-agentic-workflow.md
```

After (`ado-aw init` at version 0.13.0):
```
https://raw.githubusercontent.com/githubnext/ado-aw/v0.13.0/prompts/create-ado-agentic-workflow.md
```
