### PR TITLE
docs: fix documentation drift in prompts guide, README, and AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1136,6 +1136,220 @@ Reports that a tool or capability needed to complete the task is not available.
 - `tool_name` - Name of the tool that was expected but not found
 - `context` - Optional context about why the tool was needed
 
+#### report-incomplete
+Reports that a task could not be completed.
+
+**Agent parameters:**
+- `reason` - Why the task could not be completed (required, at least 10 characters)
+- `context` - Optional additional context about what was attempted
+
+#### add-pr-comment
+Adds a new comment thread to a pull request.
+
+**Agent parameters:**
+- `pull_request_id` - The PR ID to comment on (required, must be positive)
+- `content` - Comment text in markdown format (required, at least 10 characters)
+- `repository` - Repository alias (default: "self")
+- `file_path` *(optional)* - File path for an inline comment anchored to a specific file
+
+**Configuration options (front matter):**
+```yaml
+safe-outputs:
+  add-pr-comment:
+    comment-prefix: "[Agent Review] "  # Optional — prepended to all comments
+    allowed-repositories: []           # Optional — restrict which repos can be commented on
+    max: 1                             # Maximum per run (default: 1)
+```
+
+#### reply-to-pr-comment
+Replies to an existing review comment thread on a pull request.
+
+**Agent parameters:**
+- `pull_request_id` - The PR ID containing the thread (required)
+- `thread_id` - The thread ID to reply to (required)
+- `content` - Reply text in markdown format (required, at least 10 characters)
+- `repository` - Repository alias (default: "self")
+
+**Configuration options (front matter):**
+```yaml
+safe-outputs:
+  reply-to-pr-comment:
+    comment-prefix: "[Agent] "     # Optional — prepended to all replies
+    allowed-repositories: []       # Optional — restrict which repos can be replied on
+    max: 1                         # Maximum per run (default: 1)
+```
+
+#### resolve-pr-thread
+Resolves or updates the status of a pull request review thread.
+
+**Agent parameters:**
+- `pull_request_id` - The PR ID containing the thread (required)
+- `thread_id` - The thread ID to resolve (required)
+- `status` - Target status: `fixed`, `wont-fix`, `closed`, `by-design`, or `active` (to reactivate)
+- `repository` - Repository alias (default: "self")
+
+**Configuration options (front matter):**
+```yaml
+safe-outputs:
+  resolve-pr-thread:
+    allowed-repositories: []     # Optional — restrict which repos can be operated on
+    allowed-statuses: []         # REQUIRED — empty list rejects all status transitions
+    max: 1                       # Maximum per run (default: 1)
+```
+
+#### submit-pr-review
+Submits a review vote on a pull request.
+
+**Agent parameters:**
+- `pull_request_id` - The PR ID to review (required)
+- `event` - Review decision: `approve`, `approve-with-suggestions`, `request-changes`, or `comment` (required)
+- `body` *(optional)* - Review rationale in markdown (required for `request-changes`, at least 10 characters)
+- `repository` - Repository alias (default: "self")
+
+**Configuration options (front matter):**
+```yaml
+safe-outputs:
+  submit-pr-review:
+    allowed-events: []           # REQUIRED — empty list rejects all events
+    allowed-repositories: []     # Optional — restrict which repos can be reviewed
+    max: 1                       # Maximum per run (default: 1)
+```
+
+#### update-pr
+Updates pull request metadata (reviewers, labels, auto-complete, vote, description).
+
+**Agent parameters:**
+- `pull_request_id` - The PR ID to update (required)
+- `operation` - Update operation: `add-reviewers`, `add-labels`, `set-auto-complete`, `vote`, or `update-description` (required)
+- `reviewers` - Reviewer emails (required for `add-reviewers`)
+- `labels` - Label names (required for `add-labels`)
+- `vote` - Vote value: `approve`, `approve-with-suggestions`, `wait-for-author`, `reject`, or `reset` (required for `vote`)
+- `description` - New PR description in markdown (required for `update-description`, at least 10 characters)
+- `repository` - Repository alias (default: "self")
+
+**Configuration options (front matter):**
+```yaml
+safe-outputs:
+  update-pr:
+    allowed-operations: []          # Optional — restrict which operations are permitted (empty = all)
+    allowed-repositories: []        # Optional — restrict which repos can be updated
+    allowed-votes: []               # REQUIRED for vote operation — empty rejects all votes
+    delete-source-branch: true      # For set-auto-complete (default: true)
+    merge-strategy: "squash"        # For set-auto-complete: squash, noFastForward, rebase, rebaseMerge
+    max: 1                          # Maximum per run (default: 1)
+```
+
+#### link-work-items
+Links two Azure DevOps work items together.
+
+**Agent parameters:**
+- `source_id` - Source work item ID (required, must be positive)
+- `target_id` - Target work item ID (required, must differ from source)
+- `link_type` - Relationship type: `parent`, `child`, `related`, `predecessor`, `successor`, `duplicate`, `duplicate-of` (required)
+- `comment` *(optional)* - Description of the relationship
+
+**Configuration options (front matter):**
+```yaml
+safe-outputs:
+  link-work-items:
+    allowed-link-types: []       # Optional — restrict which link types are allowed (empty = all)
+    target: "*"                  # Scoping policy (same as comment-on-work-item target)
+    max: 5                       # Maximum per run (default: 5)
+```
+
+#### queue-build
+Queues an Azure DevOps pipeline build by definition ID.
+
+**Agent parameters:**
+- `pipeline_id` - Pipeline definition ID to trigger (required, must be positive)
+- `branch` *(optional)* - Branch to build (defaults to configured default or "main")
+- `parameters` *(optional)* - Template parameter key-value pairs
+- `reason` *(optional)* - Human-readable reason for triggering the build (at least 5 characters)
+
+**Configuration options (front matter):**
+```yaml
+safe-outputs:
+  queue-build:
+    allowed-pipelines: []        # REQUIRED — pipeline definition IDs that can be triggered (empty rejects all)
+    allowed-branches: []         # Optional — branches allowed to be built (empty = any)
+    allowed-parameters: []       # Optional — parameter keys allowed to be passed (empty = any)
+    default-branch: "main"       # Optional — default branch when agent doesn't specify one
+    max: 3                       # Maximum per run (default: 3)
+```
+
+#### create-git-tag
+Creates a git tag on a repository ref.
+
+**Agent parameters:**
+- `tag_name` - Tag name (e.g., `v1.2.3`; 3-100 characters, alphanumeric plus `.`, `-`, `_`, `/`)
+- `commit` *(optional)* - Commit SHA to tag (40-character hex; defaults to HEAD of default branch)
+- `message` *(optional)* - Tag annotation message (at least 5 characters; creates annotated tag)
+- `repository` - Repository alias (default: "self")
+
+**Configuration options (front matter):**
+```yaml
+safe-outputs:
+  create-git-tag:
+    tag-pattern: "^v\\d+\\.\\d+\\.\\d+$"  # Optional — regex pattern tag names must match
+    allowed-repositories: []                # Optional — restrict which repos can be tagged
+    message-prefix: "[Release] "            # Optional — prefix prepended to tag message
+    max: 1                                  # Maximum per run (default: 1)
+```
+
+#### add-build-tag
+Adds a tag to an Azure DevOps build.
+
+**Agent parameters:**
+- `build_id` - Build ID to tag (required, must be positive)
+- `tag` - Tag value (1-100 characters, alphanumeric and dashes only)
+
+**Configuration options (front matter):**
+```yaml
+safe-outputs:
+  add-build-tag:
+    allowed-tags: []             # Optional — restrict which tags can be applied (supports prefix wildcards)
+    tag-prefix: "agent-"         # Optional — prefix prepended to all tags
+    allow-any-build: false       # When false, only the current pipeline build can be tagged (default: false)
+    max: 1                       # Maximum per run (default: 1)
+```
+
+#### create-branch
+Creates a new branch from an existing ref.
+
+**Agent parameters:**
+- `branch_name` - Branch name to create (1-200 characters)
+- `source_branch` *(optional)* - Branch to create from (default: "main")
+- `source_commit` *(optional)* - Specific commit SHA to branch from (overrides source_branch; 40-character hex)
+- `repository` - Repository alias (default: "self")
+
+**Configuration options (front matter):**
+```yaml
+safe-outputs:
+  create-branch:
+    branch-pattern: "^agent/.*$"       # Optional — regex pattern branch names must match
+    allowed-repositories: []           # Optional — restrict which repos can have branches created
+    allowed-source-branches: []        # Optional — restrict which source branches can be branched from
+    max: 1                             # Maximum per run (default: 1)
+```
+
+#### upload-attachment
+Uploads a workspace file as an attachment to an Azure DevOps work item.
+
+**Agent parameters:**
+- `work_item_id` - Work item ID to attach the file to (required, must be positive)
+- `file_path` - Relative path to the file in the workspace (no directory traversal)
+- `comment` *(optional)* - Description of the attachment (at least 3 characters)
+
+**Configuration options (front matter):**
+```yaml
+safe-outputs:
+  upload-attachment:
+    max-file-size: 5242880       # Maximum file size in bytes (default: 5 MB)
+    allowed-extensions: []       # Optional — restrict file types (e.g., [".png", ".pdf"])
+    comment-prefix: "[Agent] "   # Optional — prefix prepended to the comment
+    max: 1                       # Maximum per run (default: 1)
+```
+
 #### cache-memory (moved to `tools:`)
 Memory is now configured as a first-class tool under `tools: cache-memory:` instead of `safe-outputs: memory:`. See the [Cache Memory](#cache-memory-cache-memory) section under Tools Configuration for details.
 

--- a/README.md
+++ b/README.md
@@ -334,7 +334,6 @@ actions, and the executor processes them after threat analysis.
 | `create-branch` | Creates a new branch from an existing ref |
 | `add-build-tag` | Adds a tag to an ADO build |
 | `upload-attachment` | Uploads a workspace file as an attachment to a work item |
-| `memory` | Persists files across agent runs |
 | `report-incomplete` | Reports that a task could not be completed |
 | `noop` | Reports no action was needed |
 | `missing-data` | Reports required data was unavailable |

--- a/prompts/create-ado-agentic-workflow.md
+++ b/prompts/create-ado-agentic-workflow.md
@@ -180,7 +180,7 @@ target: 1es
 
 MCP servers give the agent tools at runtime. Two kinds:
 
-**Built-in** (no `command:` field):
+**Built-in** (no `container:` field):
 ```yaml
 mcp-servers:
   ado: true                  # All ADO tools
@@ -200,12 +200,13 @@ mcp-servers:
   calculator: true
 ```
 
-**Custom** (has `command:` field):
+**Custom** (containerized MCP with `container:` field):
 ```yaml
 mcp-servers:
   my-tool:
-    command: "node"
-    args: ["path/to/server.js"]
+    container: "node:20-slim"
+    entrypoint: "node"
+    entrypoint-args: ["path/to/server.js"]
     env:
       API_KEY: "$(MY_SECRET)"
     allowed:
@@ -215,7 +216,7 @@ mcp-servers:
 
 > **Security**: Custom MCPs must have an explicit `allowed:` list. Built-in MCPs default to all tools when set to `true`.
 >
-> **1ES target**: Custom MCPs (`command:`) are not supported — only built-ins with service connections.
+> **1ES target**: Custom containerized MCPs are not supported — only built-ins with service connections.
 
 ### Step 9 — Safe Outputs
 
@@ -251,17 +252,17 @@ safe-outputs:
       branch: main
 ```
 
-**memory** — persistent agent memory across runs:
+**cache-memory** — persistent agent memory across runs (configured under `tools:`, not `safe-outputs:`):
 ```yaml
-safe-outputs:
-  memory:
+tools:
+  cache-memory:
     allowed-extensions:
       - .md
       - .json
       - .txt
 ```
 
-Other safe output tools (no configuration needed): `noop`, `missing-data`, `missing-tool`.
+Other safe output tools (no configuration needed): `noop`, `missing-data`, `missing-tool`, `report-incomplete`.
 
 > **Validation**: The compiler enforces that if `create-pull-request` or `create-work-item` are configured, `permissions.write` must be set.
 


### PR DESCRIPTION
Closes #190.

## Changes

### prompts/create-ado-agentic-workflow.md
- **Step 8**: Replaced incorrect `command:`/`args:` MCP example with correct `container:`/`entrypoint:`/`entrypoint-args:` format matching `McpOptions` struct
- **Step 9**: Replaced stale `safe-outputs: memory:` with `tools: cache-memory:`; added `report-incomplete` to diagnostics list

### README.md
- Removed stale `memory` row from Safe Outputs table (memory is now `tools: cache-memory:`)

### AGENTS.md
- Added documentation sections for 12 previously undocumented safe-output tools:
  `add-pr-comment`, `reply-to-pr-comment`, `resolve-pr-thread`, `submit-pr-review`,
  `update-pr`, `link-work-items`, `queue-build`, `create-git-tag`, `add-build-tag`,
  `create-branch`, `upload-attachment`, `report-incomplete`

All tool documentation was sourced from the actual Rust source code in `src/safeoutputs/`.