### PR TITLE
refactor: unify runtime/tool requirements via CompilerExtension trait

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1447,9 +1447,27 @@ When extending the compiler:
 3. **New front matter fields**: Add fields to `FrontMatter` in `src/compile/types.rs`
 4. **New template markers**: Handle replacements in the target-specific compiler (e.g., `standalone.rs` or `onees.rs`)
 5. **New safe-output tools**: Add to `src/safeoutputs/` — implement `ToolResult`, `Executor`, register in `mod.rs`, `mcp.rs`, `execute.rs`
-6. **New first-class tools**: Add to `src/tools/` — extend `ToolsConfig` in `types.rs`, wire in compilers
-7. **New runtimes**: Add to `src/runtimes/` — extend `RuntimesConfig` in `types.rs`, wire in compilers
-7. **Validation**: Add compile-time validation for safe outputs and permissions
+6. **New first-class tools**: Add to `src/tools/` — extend `ToolsConfig` in `types.rs`, implement `CompilerExtension` trait in `src/compile/extensions.rs`, add collection in `collect_extensions()`
+7. **New runtimes**: Add to `src/runtimes/` — extend `RuntimesConfig` in `types.rs`, implement `CompilerExtension` trait in `src/compile/extensions.rs`, add collection in `collect_extensions()`
+8. **Validation**: Add compile-time validation for safe outputs and permissions
+
+#### `CompilerExtension` Trait
+
+Runtimes and first-party tools declare their compilation requirements via the `CompilerExtension` trait (`src/compile/extensions.rs`). Instead of scattering special-case `if` blocks across the compiler, each runtime/tool implements this trait and the compiler collects requirements generically:
+
+```rust
+pub trait CompilerExtension: Send {
+    fn name(&self) -> &str;                                    // Display name
+    fn required_hosts(&self) -> Vec<String>;                   // AWF network allowlist
+    fn required_bash_commands(&self) -> Vec<String>;           // Agent bash allow-list
+    fn prompt_supplement(&self) -> Option<String>;              // Agent prompt markdown
+    fn prepare_steps(&self) -> Vec<String>;                    // Pipeline steps (install, etc.)
+    fn mcpg_servers(&self, ctx) -> Result<Vec<(String, McpgServerConfig)>>; // MCPG entries
+    fn validate(&self, ctx) -> Result<Vec<String>>;            // Compile-time warnings
+}
+```
+
+To add a new runtime or tool: (1) create a struct implementing `CompilerExtension`, (2) add a collection check in `collect_extensions()`. No other files need modification.
 
 ### Security Considerations
 

--- a/src/compile/common.rs
+++ b/src/compile/common.rs
@@ -3,6 +3,7 @@
 use anyhow::{Context, Result};
 
 use super::types::{FrontMatter, PipelineParameter, Repository, TriggerConfig};
+use super::extensions::CompilerExtension;
 use crate::compile::types::McpConfig;
 use crate::fuzzy_schedule;
 
@@ -470,7 +471,10 @@ const DEFAULT_BASH_COMMANDS: &[&str] = &[
 ];
 
 /// Generate copilot CLI params from front matter configuration
-pub fn generate_copilot_params(front_matter: &FrontMatter) -> Result<String> {
+pub fn generate_copilot_params(
+    front_matter: &FrontMatter,
+    extensions: &[super::extensions::Extension],
+) -> Result<String> {
     let mut allowed_tools: Vec<String> = vec!["github".to_string(), "safeoutputs".to_string()];
 
     // Edit tool: enabled by default, can be disabled with `edit: false`
@@ -484,7 +488,7 @@ pub fn generate_copilot_params(front_matter: &FrontMatter) -> Result<String> {
     }
 
     // Bash tool: use configured list, or defaults if not specified
-    let mut bash_commands: Vec<&str> =
+    let mut bash_commands: Vec<String> =
         match front_matter.tools.as_ref().and_then(|t| t.bash.as_ref()) {
             Some(cmds) if cmds.len() == 1 && cmds[0] == ":*" => {
                 // Unrestricted: single wildcard entry
@@ -497,50 +501,32 @@ pub fn generate_copilot_params(front_matter: &FrontMatter) -> Result<String> {
             }
             Some(cmds) => {
                 // Explicit list of commands
-                cmds.iter().map(|s| s.as_str()).collect()
+                cmds.clone()
             }
             None => {
                 // Default safe commands
-                DEFAULT_BASH_COMMANDS.to_vec()
+                DEFAULT_BASH_COMMANDS.iter().map(|s| (*s).to_string()).collect()
             }
         };
 
-    // Auto-add lean/lake/elan when runtimes.lean is enabled
-    let has_lean = front_matter
-        .runtimes
-        .as_ref()
-        .and_then(|r| r.lean.as_ref())
-        .is_some_and(|l| l.is_enabled());
-
+    // Auto-add extension-declared bash commands (runtimes + first-party tools)
     let is_unrestricted_bash = front_matter
         .tools
         .as_ref()
         .and_then(|t| t.bash.as_ref())
         .is_some_and(|cmds| cmds.len() == 1 && cmds[0] == ":*");
 
-    if has_lean && !is_unrestricted_bash {
-        let bash_disabled = front_matter
-            .tools
-            .as_ref()
-            .and_then(|t| t.bash.as_ref())
-            .is_some_and(|cmds| cmds.is_empty());
-
-        if bash_disabled {
-            eprintln!(
-                "Warning: Agent '{}' has runtimes.lean enabled but tools.bash is empty. \
-                Lean requires bash access (lean, lake, elan commands).",
-                front_matter.name
-            );
-        } else {
-            for cmd in crate::runtimes::lean::LEAN_BASH_COMMANDS {
-                if !bash_commands.contains(cmd) {
+    if !is_unrestricted_bash {
+        for ext in extensions {
+            for cmd in ext.required_bash_commands() {
+                if !bash_commands.contains(&cmd) {
                     bash_commands.push(cmd);
                 }
             }
         }
     }
 
-    for cmd in bash_commands {
+    for cmd in &bash_commands {
         // Reject single quotes in bash commands — copilot_params are embedded inside
         // a single-quoted bash string in the AWF command.
         if cmd.contains('\'') {
@@ -1336,7 +1322,7 @@ mod tests {
             cache_memory: None,
             azure_devops: None,
         });
-        let params = generate_copilot_params(&fm).unwrap();
+        let params = generate_copilot_params(&fm, &crate::compile::extensions::collect_extensions(&fm)).unwrap();
         assert!(params.contains("--allow-tool \"shell(:*)\""));
     }
 
@@ -1349,7 +1335,7 @@ mod tests {
             cache_memory: None,
             azure_devops: None,
         });
-        let params = generate_copilot_params(&fm).unwrap();
+        let params = generate_copilot_params(&fm, &crate::compile::extensions::collect_extensions(&fm)).unwrap();
         assert!(!params.contains("shell("));
     }
 
@@ -1359,7 +1345,7 @@ mod tests {
         fm.runtimes = Some(crate::compile::types::RuntimesConfig {
             lean: Some(crate::runtimes::lean::LeanRuntimeConfig::Enabled(true)),
         });
-        let params = generate_copilot_params(&fm).unwrap();
+        let params = generate_copilot_params(&fm, &crate::compile::extensions::collect_extensions(&fm)).unwrap();
         assert!(params.contains("shell(lean)"), "lean command should be allowed");
         assert!(params.contains("shell(lake)"), "lake command should be allowed");
         assert!(params.contains("shell(elan)"), "elan command should be allowed");
@@ -1379,7 +1365,7 @@ mod tests {
         fm.runtimes = Some(crate::compile::types::RuntimesConfig {
             lean: Some(crate::runtimes::lean::LeanRuntimeConfig::Enabled(true)),
         });
-        let params = generate_copilot_params(&fm).unwrap();
+        let params = generate_copilot_params(&fm, &crate::compile::extensions::collect_extensions(&fm)).unwrap();
         assert!(params.contains("shell(:*)"), "unrestricted should be preserved");
         // Should NOT add individual lean commands when unrestricted
         assert!(!params.contains("shell(lean)"), "lean not needed with :*");
@@ -1395,7 +1381,7 @@ mod tests {
                 ..Default::default()
             }),
         );
-        let params = generate_copilot_params(&fm).unwrap();
+        let params = generate_copilot_params(&fm, &crate::compile::extensions::collect_extensions(&fm)).unwrap();
         assert!(!params.contains("--mcp my-tool"));
     }
 
@@ -1404,7 +1390,7 @@ mod tests {
         let mut fm = minimal_front_matter();
         fm.mcp_servers
             .insert("ado".to_string(), McpConfig::Enabled(true));
-        let params = generate_copilot_params(&fm).unwrap();
+        let params = generate_copilot_params(&fm, &crate::compile::extensions::collect_extensions(&fm)).unwrap();
         // Copilot CLI has no built-in MCPs — all MCPs are handled via the MCP firewall
         assert!(!params.contains("--mcp ado"));
     }
@@ -1415,14 +1401,14 @@ mod tests {
             "---\nname: test\ndescription: test\nengine:\n  model: claude-opus-4.5\n  max-turns: 50\n---\n",
         )
         .unwrap();
-        let params = generate_copilot_params(&fm).unwrap();
+        let params = generate_copilot_params(&fm, &crate::compile::extensions::collect_extensions(&fm)).unwrap();
         assert!(!params.contains("--max-turns"), "max-turns should not be emitted as a CLI arg");
     }
 
     #[test]
     fn test_copilot_params_no_max_turns_when_simple_engine() {
         let fm = minimal_front_matter();
-        let params = generate_copilot_params(&fm).unwrap();
+        let params = generate_copilot_params(&fm, &crate::compile::extensions::collect_extensions(&fm)).unwrap();
         assert!(!params.contains("--max-turns"));
     }
 
@@ -1432,14 +1418,14 @@ mod tests {
             "---\nname: test\ndescription: test\nengine:\n  model: claude-opus-4.5\n  timeout-minutes: 30\n---\n",
         )
         .unwrap();
-        let params = generate_copilot_params(&fm).unwrap();
+        let params = generate_copilot_params(&fm, &crate::compile::extensions::collect_extensions(&fm)).unwrap();
         assert!(!params.contains("--max-timeout"), "timeout-minutes should not be emitted as a CLI arg");
     }
 
     #[test]
     fn test_copilot_params_no_max_timeout_when_simple_engine() {
         let fm = minimal_front_matter();
-        let params = generate_copilot_params(&fm).unwrap();
+        let params = generate_copilot_params(&fm, &crate::compile::extensions::collect_extensions(&fm)).unwrap();
         assert!(!params.contains("--max-timeout"));
     }
 
@@ -1449,7 +1435,7 @@ mod tests {
             "---\nname: test\ndescription: test\nengine:\n  model: claude-opus-4.5\n  max-turns: 0\n---\n",
         )
         .unwrap();
-        let params = generate_copilot_params(&fm).unwrap();
+        let params = generate_copilot_params(&fm, &crate::compile::extensions::collect_extensions(&fm)).unwrap();
         assert!(!params.contains("--max-turns"), "max-turns should not be emitted as a CLI arg");
     }
 
@@ -1459,7 +1445,7 @@ mod tests {
             "---\nname: test\ndescription: test\nengine:\n  model: claude-opus-4.5\n  timeout-minutes: 0\n---\n",
         )
         .unwrap();
-        let params = generate_copilot_params(&fm).unwrap();
+        let params = generate_copilot_params(&fm, &crate::compile::extensions::collect_extensions(&fm)).unwrap();
         assert!(!params.contains("--max-timeout"), "timeout-minutes should not be emitted as a CLI arg");
     }
 
@@ -2384,7 +2370,7 @@ mod tests {
         )
         .unwrap();
         fm.engine = crate::compile::types::EngineConfig::Simple("model' && echo pwned".to_string());
-        let result = generate_copilot_params(&fm);
+        let result = generate_copilot_params(&fm, &crate::compile::extensions::collect_extensions(&fm));
         assert!(result.is_err());
         assert!(result.unwrap_err().to_string().contains("invalid characters"));
     }
@@ -2393,7 +2379,7 @@ mod tests {
     fn test_model_name_rejects_space() {
         let mut fm = minimal_front_matter();
         fm.engine = crate::compile::types::EngineConfig::Simple("model && curl evil.com".to_string());
-        let result = generate_copilot_params(&fm);
+        let result = generate_copilot_params(&fm, &crate::compile::extensions::collect_extensions(&fm));
         assert!(result.is_err());
     }
 
@@ -2402,7 +2388,7 @@ mod tests {
         for name in &["claude-opus-4.5", "gpt-5.2-codex", "gemini-3-pro-preview", "my_model:latest"] {
             let mut fm = minimal_front_matter();
             fm.engine = crate::compile::types::EngineConfig::Simple(name.to_string());
-            let result = generate_copilot_params(&fm);
+            let result = generate_copilot_params(&fm, &crate::compile::extensions::collect_extensions(&fm));
             assert!(result.is_ok(), "Model name '{}' should be valid", name);
         }
     }
@@ -2416,7 +2402,7 @@ mod tests {
             cache_memory: None,
             azure_devops: None,
         });
-        let result = generate_copilot_params(&fm);
+        let result = generate_copilot_params(&fm, &crate::compile::extensions::collect_extensions(&fm));
         assert!(result.is_err());
         assert!(result.unwrap_err().to_string().contains("single quote"));
     }

--- a/src/compile/extensions.rs
+++ b/src/compile/extensions.rs
@@ -169,6 +169,12 @@ pub trait CompilerExtension {
     /// Compile-time warnings to emit. Errors in the `Result` abort
     /// compilation; the inner `Vec<String>` contains non-fatal warnings
     /// printed to stderr.
+    ///
+    /// **Note:** `validate` is called early in compilation before
+    /// `inferred_org` is available (it requires an async git remote
+    /// lookup). Org-dependent validation (e.g., verifying an ADO org
+    /// can be resolved) should go in [`mcpg_servers`](Self::mcpg_servers)
+    /// instead, which receives the fully populated [`CompileContext`].
     fn validate(&self, _ctx: &CompileContext) -> Result<Vec<String>> {
         Ok(vec![])
     }
@@ -606,16 +612,19 @@ pub fn collect_extensions(front_matter: &FrontMatter) -> Vec<Extension> {
 /// This is the generic wrapper used by the compiler to append extension
 /// prompt supplements to the agent prompt file. Each line of content is
 /// indented by 4 spaces to match the YAML block scalar indentation.
-pub fn wrap_prompt_append(content: &str, display_name: &str) -> String {
-    // Guard against names that would break bash echo or YAML displayName.
-    // All current extension names are hardcoded alphanumeric strings, but
-    // this catches future extensions whose name() might contain shell
-    // metacharacters.
-    debug_assert!(
+///
+/// Returns an error if `display_name` contains characters unsafe for
+/// embedding in bash `echo` or YAML `displayName` fields.
+pub fn wrap_prompt_append(content: &str, display_name: &str) -> Result<String> {
+    // Reject names that would break bash echo or YAML displayName.
+    // This is a runtime guard (not debug_assert) because wrap_prompt_append
+    // is pub and callable from future extension implementations.
+    anyhow::ensure!(
         display_name
             .chars()
             .all(|c| c.is_ascii_alphanumeric() || matches!(c, ' ' | '-' | '_')),
-        "Extension display_name '{}' contains characters unsafe for bash/YAML embedding",
+        "Extension display_name '{}' contains characters unsafe for bash/YAML embedding. \
+         Only ASCII alphanumerics, spaces, hyphens, and underscores are allowed.",
         display_name
     );
 
@@ -640,7 +649,7 @@ pub fn wrap_prompt_append(content: &str, display_name: &str) -> String {
         .collect::<Vec<_>>()
         .join("\n");
 
-    format!(
+    Ok(format!(
         r#"- bash: |
     cat >> "/tmp/awf-tools/agent-prompt.md" << '{delimiter}'
 {indented_content}
@@ -651,7 +660,7 @@ pub fn wrap_prompt_append(content: &str, display_name: &str) -> String {
         delimiter = delimiter,
         indented_content = indented_content,
         display_name = display_name,
-    )
+    ))
 }
 
 // ──────────────────────────────────────────────────────────────────────
@@ -910,10 +919,19 @@ mod tests {
     #[test]
     fn test_wrap_prompt_append_generates_valid_yaml_step() {
         let content = "## Test\n\nSome instructions.";
-        let step = wrap_prompt_append(content, "Test Feature");
+        let step = wrap_prompt_append(content, "Test Feature").unwrap();
         assert!(step.contains("cat >>"));
         assert!(step.contains("agent-prompt.md"));
         assert!(step.contains("TEST_FEATURE_EOF"));
         assert!(step.contains("Test Feature"));
+    }
+
+    #[test]
+    fn test_wrap_prompt_append_rejects_unsafe_display_name() {
+        let result = wrap_prompt_append("content", "My \"Ext\"");
+        assert!(result.is_err());
+
+        let result = wrap_prompt_append("content", "ext$(rm -rf)");
+        assert!(result.is_err());
     }
 }

--- a/src/compile/extensions.rs
+++ b/src/compile/extensions.rs
@@ -1,0 +1,822 @@
+//! Compiler extension trait and MCPG types.
+//!
+//! The [`CompilerExtension`] trait provides a unified interface for runtimes
+//! and first-party tools to declare their compilation requirements (network
+//! hosts, bash commands, prompt supplements, prepare steps, MCPG entries).
+//!
+//! Instead of scattering special-case `if` blocks across the compiler,
+//! each runtime/tool implements this trait and the compiler collects
+//! requirements via [`collect_extensions`].
+//!
+//! ## Adding a new runtime or tool
+//!
+//! 1. Create a struct wrapping your config type
+//! 2. Implement [`CompilerExtension`] for it
+//! 3. Add a variant to the [`Extension`] enum and update [`collect_extensions`]
+
+use anyhow::Result;
+use serde::Serialize;
+use std::collections::HashMap;
+
+use super::types::FrontMatter;
+
+// ──────────────────────────────────────────────────────────────────────
+// MCPG types (used by both the trait and standalone compiler)
+// ──────────────────────────────────────────────────────────────────────
+
+/// MCPG server configuration for a single MCP upstream.
+#[derive(Debug, Serialize, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct McpgServerConfig {
+    /// Server type: "stdio" for container-based, "http" for HTTP backends
+    #[serde(rename = "type")]
+    pub server_type: String,
+    /// Docker container image (for stdio type, per MCPG spec §4.1.2)
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub container: Option<String>,
+    /// Container entrypoint override (for stdio type)
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub entrypoint: Option<String>,
+    /// Arguments passed to the container entrypoint (for stdio type)
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub entrypoint_args: Option<Vec<String>>,
+    /// Volume mounts for containerized servers (format: "source:dest:mode")
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub mounts: Option<Vec<String>>,
+    /// Additional Docker runtime arguments (inserted before image in `docker run`)
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub args: Option<Vec<String>>,
+    /// URL for HTTP backends
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub url: Option<String>,
+    /// HTTP headers (e.g., Authorization)
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub headers: Option<HashMap<String, String>>,
+    /// Environment variables for the server process
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub env: Option<HashMap<String, String>>,
+    /// Tool allow-list (if empty or absent, all tools are allowed)
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tools: Option<Vec<String>>,
+}
+
+/// MCPG gateway configuration.
+#[derive(Debug, Serialize, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct McpgGatewayConfig {
+    pub port: u16,
+    pub domain: String,
+    pub api_key: String,
+    pub payload_dir: String,
+}
+
+/// Top-level MCPG configuration.
+#[derive(Debug, Serialize, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct McpgConfig {
+    pub mcp_servers: HashMap<String, McpgServerConfig>,
+    pub gateway: McpgGatewayConfig,
+}
+
+// ──────────────────────────────────────────────────────────────────────
+// Compile context
+// ──────────────────────────────────────────────────────────────────────
+
+/// Shared context passed to extension methods that need cross-cutting information.
+pub struct CompileContext<'a> {
+    /// The agent name from front matter.
+    pub agent_name: &'a str,
+    /// The full front matter (for cross-cutting checks like bash access level).
+    pub front_matter: &'a FrontMatter,
+    /// ADO org inferred from the git remote at compile time. Used by
+    /// `AzureDevOpsExtension` when no explicit `org:` is provided.
+    pub inferred_org: Option<&'a str>,
+}
+
+// ──────────────────────────────────────────────────────────────────────
+// CompilerExtension trait
+// ──────────────────────────────────────────────────────────────────────
+
+/// Unified interface for runtimes and first-party tools to declare
+/// compilation requirements.
+///
+/// The compiler calls [`collect_extensions`] to gather all enabled
+/// extensions, then iterates over them to merge requirements into the
+/// generated pipeline.
+pub trait CompilerExtension {
+    /// Human-readable name for logging and diagnostics (e.g., "Lean 4").
+    fn name(&self) -> &str;
+
+    /// Network hosts this extension requires (added to AWF allowlist).
+    fn required_hosts(&self) -> Vec<String> {
+        vec![]
+    }
+
+    /// Bash commands this extension needs in the agent's allow-list.
+    fn required_bash_commands(&self) -> Vec<String> {
+        vec![]
+    }
+
+    /// Markdown prompt content to append to the agent prompt.
+    ///
+    /// The compiler wraps the returned content in a `cat >>` pipeline
+    /// step so it is appended to the agent prompt file.
+    fn prompt_supplement(&self) -> Option<String> {
+        None
+    }
+
+    /// Pipeline steps (YAML strings) to run before the agent.
+    ///
+    /// Each element is a complete YAML step (e.g., `- bash: |...`).
+    fn prepare_steps(&self) -> Vec<String> {
+        vec![]
+    }
+
+    /// MCPG server entries this extension contributes.
+    ///
+    /// Returns `(server_name, config)` pairs inserted into the MCPG
+    /// JSON configuration. Only consumed by the standalone compiler.
+    fn mcpg_servers(&self, _ctx: &CompileContext) -> Result<Vec<(String, McpgServerConfig)>> {
+        Ok(vec![])
+    }
+
+    /// Compile-time warnings to emit. Errors in the `Result` abort
+    /// compilation; the inner `Vec<String>` contains non-fatal warnings
+    /// printed to stderr.
+    fn validate(&self, _ctx: &CompileContext) -> Result<Vec<String>> {
+        Ok(vec![])
+    }
+}
+
+// ──────────────────────────────────────────────────────────────────────
+// Extension enum (static dispatch)
+// ──────────────────────────────────────────────────────────────────────
+
+/// Delegates every [`CompilerExtension`] method on an enum to the
+/// inner variant, eliminating boilerplate when adding new extensions.
+///
+/// Usage:
+/// ```ignore
+/// extension_enum! {
+///     pub enum Extension {
+///         Lean(LeanExtension),
+///         AzureDevOps(AzureDevOpsExtension),
+///         CacheMemory(CacheMemoryExtension),
+///     }
+/// }
+/// ```
+macro_rules! extension_enum {
+    (
+        $(#[$meta:meta])*
+        pub enum $Enum:ident {
+            $( $Variant:ident($Inner:ty) ),+ $(,)?
+        }
+    ) => {
+        $(#[$meta])*
+        pub enum $Enum {
+            $( $Variant($Inner), )+
+        }
+
+        impl CompilerExtension for $Enum {
+            fn name(&self) -> &str {
+                match self { $( $Enum::$Variant(e) => e.name(), )+ }
+            }
+            fn required_hosts(&self) -> Vec<String> {
+                match self { $( $Enum::$Variant(e) => e.required_hosts(), )+ }
+            }
+            fn required_bash_commands(&self) -> Vec<String> {
+                match self { $( $Enum::$Variant(e) => e.required_bash_commands(), )+ }
+            }
+            fn prompt_supplement(&self) -> Option<String> {
+                match self { $( $Enum::$Variant(e) => e.prompt_supplement(), )+ }
+            }
+            fn prepare_steps(&self) -> Vec<String> {
+                match self { $( $Enum::$Variant(e) => e.prepare_steps(), )+ }
+            }
+            fn mcpg_servers(&self, ctx: &CompileContext) -> Result<Vec<(String, McpgServerConfig)>> {
+                match self { $( $Enum::$Variant(e) => e.mcpg_servers(ctx), )+ }
+            }
+            fn validate(&self, ctx: &CompileContext) -> Result<Vec<String>> {
+                match self { $( $Enum::$Variant(e) => e.validate(ctx), )+ }
+            }
+        }
+    };
+}
+
+extension_enum! {
+    /// All known compiler extensions, collected via [`collect_extensions`].
+    ///
+    /// Uses static dispatch (no `Box<dyn>`) — each variant delegates to
+    /// the inner type's [`CompilerExtension`] implementation.
+    pub enum Extension {
+        Lean(LeanExtension),
+        AzureDevOps(AzureDevOpsExtension),
+        CacheMemory(CacheMemoryExtension),
+    }
+}
+
+// ──────────────────────────────────────────────────────────────────────
+// Extension implementations
+// ──────────────────────────────────────────────────────────────────────
+
+// ─── Lean 4 ──────────────────────────────────────────────────────────
+
+use crate::runtimes::lean::{
+    self, LeanRuntimeConfig, LEAN_BASH_COMMANDS, LEAN_REQUIRED_HOSTS,
+};
+
+/// Lean 4 runtime extension.
+///
+/// Injects: network hosts (elan, lean-lang), bash commands (lean, lake,
+/// elan), install steps (elan + toolchain), and a prompt supplement.
+pub struct LeanExtension {
+    config: LeanRuntimeConfig,
+}
+
+impl LeanExtension {
+    pub fn new(config: LeanRuntimeConfig) -> Self {
+        Self { config }
+    }
+}
+
+impl CompilerExtension for LeanExtension {
+    fn name(&self) -> &str {
+        "Lean 4"
+    }
+
+    fn required_hosts(&self) -> Vec<String> {
+        LEAN_REQUIRED_HOSTS.iter().map(|h| (*h).to_string()).collect()
+    }
+
+    fn required_bash_commands(&self) -> Vec<String> {
+        LEAN_BASH_COMMANDS.iter().map(|c| (*c).to_string()).collect()
+    }
+
+    fn prompt_supplement(&self) -> Option<String> {
+        Some(
+            "\n\
+---\n\
+\n\
+## Lean 4 Formal Verification\n\
+\n\
+Lean 4 is installed and available. Use `lean` to typecheck `.lean` files, \
+`lake build` to build Lake projects, and `lake env printPaths` to inspect \
+the toolchain. Lean files use the `.lean` extension.\n"
+                .to_string(),
+        )
+    }
+
+    fn prepare_steps(&self) -> Vec<String> {
+        vec![lean::generate_lean_install(&self.config)]
+    }
+
+    fn validate(&self, ctx: &CompileContext) -> Result<Vec<String>> {
+        let mut warnings = Vec::new();
+
+        let is_bash_disabled = ctx
+            .front_matter
+            .tools
+            .as_ref()
+            .and_then(|t| t.bash.as_ref())
+            .is_some_and(|cmds| cmds.is_empty());
+
+        if is_bash_disabled {
+            warnings.push(format!(
+                "Agent '{}' has runtimes.lean enabled but tools.bash is empty. \
+                 Lean requires bash access (lean, lake, elan commands).",
+                ctx.agent_name
+            ));
+        }
+
+        Ok(warnings)
+    }
+}
+
+// ─── Azure DevOps MCP ────────────────────────────────────────────────
+
+use crate::allowed_hosts::mcp_required_hosts;
+use super::common::{ADO_MCP_IMAGE, ADO_MCP_ENTRYPOINT, ADO_MCP_PACKAGE, ADO_MCP_SERVER_NAME};
+use super::types::AzureDevOpsToolConfig;
+
+/// Azure DevOps first-party tool extension.
+///
+/// Injects: network hosts (ADO domains), MCPG server entry (containerized
+/// ADO MCP), and compile-time validation (org inference, duplicate MCP).
+pub struct AzureDevOpsExtension {
+    config: AzureDevOpsToolConfig,
+}
+
+impl AzureDevOpsExtension {
+    pub fn new(config: AzureDevOpsToolConfig) -> Self {
+        Self { config }
+    }
+}
+
+impl CompilerExtension for AzureDevOpsExtension {
+    fn name(&self) -> &str {
+        "Azure DevOps MCP"
+    }
+
+    fn required_hosts(&self) -> Vec<String> {
+        mcp_required_hosts("ado")
+            .iter()
+            .map(|h| (*h).to_string())
+            .collect()
+    }
+
+    fn mcpg_servers(&self, ctx: &CompileContext) -> Result<Vec<(String, McpgServerConfig)>> {
+        // Build entrypoint args: npx -y @azure-devops/mcp <org> [-d toolset1 toolset2 ...]
+        let mut entrypoint_args = vec!["-y".to_string(), ADO_MCP_PACKAGE.to_string()];
+
+        // Org: use explicit override, then compile-time inferred, then fail
+        let org = if let Some(explicit) = self.config.org() {
+            explicit.to_string()
+        } else if let Some(inferred) = ctx.inferred_org {
+            inferred.to_string()
+        } else {
+            anyhow::bail!(
+                "Agent '{}' has tools.azure-devops enabled but no ADO organization could be \
+                 determined. Either set tools.azure-devops.org explicitly, or compile from \
+                 within a git repository with an Azure DevOps remote URL.",
+                ctx.agent_name
+            );
+        };
+        if !org.chars().all(|c| c.is_ascii_alphanumeric() || c == '-') {
+            anyhow::bail!(
+                "Invalid ADO org name '{}': must contain only alphanumerics and hyphens",
+                org
+            );
+        }
+        entrypoint_args.push(org);
+
+        // Toolsets: passed as -d flag followed by space-separated toolset names
+        if !self.config.toolsets().is_empty() {
+            entrypoint_args.push("-d".to_string());
+            for toolset in self.config.toolsets() {
+                if !toolset
+                    .chars()
+                    .all(|c| c.is_ascii_alphanumeric() || c == '-')
+                {
+                    anyhow::bail!(
+                        "Invalid ADO toolset name '{}': must contain only alphanumerics and hyphens",
+                        toolset
+                    );
+                }
+                entrypoint_args.push(toolset.clone());
+            }
+        }
+
+        // Tool allow-list for MCPG filtering
+        let tools = if self.config.allowed().is_empty() {
+            None
+        } else {
+            Some(self.config.allowed().to_vec())
+        };
+
+        // ADO MCP needs the PAT token passed via environment
+        let env = Some(HashMap::from([(
+            "AZURE_DEVOPS_EXT_PAT".to_string(),
+            String::new(), // Passthrough from pipeline
+        )]));
+
+        Ok(vec![(
+            ADO_MCP_SERVER_NAME.to_string(),
+            McpgServerConfig {
+                server_type: "stdio".to_string(),
+                container: Some(ADO_MCP_IMAGE.to_string()),
+                entrypoint: Some(ADO_MCP_ENTRYPOINT.to_string()),
+                entrypoint_args: Some(entrypoint_args),
+                mounts: None,
+                args: None,
+                url: None,
+                headers: None,
+                env,
+                tools,
+            },
+        )])
+    }
+
+    fn validate(&self, ctx: &CompileContext) -> Result<Vec<String>> {
+        let mut warnings = Vec::new();
+
+        // Warn if user also has a manual mcp-servers entry for azure-devops
+        if ctx
+            .front_matter
+            .mcp_servers
+            .contains_key(ADO_MCP_SERVER_NAME)
+        {
+            warnings.push(format!(
+                "Agent '{}' has both tools.azure-devops and mcp-servers.azure-devops configured. \
+                 The tools.azure-devops auto-configuration takes precedence. \
+                 Remove the mcp-servers entry to silence this warning.",
+                ctx.agent_name
+            ));
+        }
+
+        Ok(warnings)
+    }
+}
+
+// ─── Cache Memory ────────────────────────────────────────────────────
+
+use super::types::CacheMemoryToolConfig;
+
+/// Cache memory tool extension.
+///
+/// Injects: prepare steps (download/restore previous memory), and a
+/// prompt supplement informing the agent about its memory directory.
+pub struct CacheMemoryExtension {
+    #[allow(dead_code)]
+    config: CacheMemoryToolConfig,
+}
+
+impl CacheMemoryExtension {
+    pub fn new(config: CacheMemoryToolConfig) -> Self {
+        Self { config }
+    }
+}
+
+impl CompilerExtension for CacheMemoryExtension {
+    fn name(&self) -> &str {
+        "Cache Memory"
+    }
+
+    fn prepare_steps(&self) -> Vec<String> {
+        vec![generate_memory_download()]
+    }
+
+    fn prompt_supplement(&self) -> Option<String> {
+        Some(
+            "\n\
+---\n\
+\n\
+## Agent Memory\n\
+\n\
+You have persistent memory across runs. Your memory directory is located at `/tmp/awf-tools/staging/agent_memory/`.\n\
+\n\
+- **Read** previous memory files from this directory to recall context from prior runs.\n\
+- **Write** new files or update existing ones in this directory to persist knowledge for future runs.\n\
+- Use this memory to track patterns, accumulate findings, remember decisions, and improve over time.\n\
+- The memory directory is yours to organize as you see fit (files, subdirectories, any structure).\n\
+- Memory files are sanitized between runs for security; avoid including pipeline commands or secrets.\n"
+                .to_string(),
+        )
+    }
+}
+
+/// Generate the steps to download agent memory from the previous successful run
+/// and restore it to the staging directory.
+fn generate_memory_download() -> String {
+    r#"- task: DownloadPipelineArtifact@2
+  displayName: "Download previous agent memory"
+  condition: eq(${{ parameters.clearMemory }}, false)
+  continueOnError: true
+  inputs:
+    source: "specific"
+    project: "$(System.TeamProject)"
+    pipeline: "$(System.DefinitionId)"
+    runVersion: "latestFromBranch"
+    branchName: "$(Build.SourceBranch)"
+    artifact: "safe_outputs"
+    targetPath: "$(Agent.TempDirectory)/previous_memory"
+    allowPartiallySucceededBuilds: true
+
+- bash: |
+    mkdir -p /tmp/awf-tools/staging/agent_memory
+    if [ -d "$(Agent.TempDirectory)/previous_memory/agent_memory" ]; then
+      cp -a "$(Agent.TempDirectory)/previous_memory/agent_memory/." /tmp/awf-tools/staging/agent_memory/ 2>/dev/null || true
+      echo "Previous agent memory restored to /tmp/awf-tools/staging/agent_memory"
+      ls -laR /tmp/awf-tools/staging/agent_memory
+    else
+      echo "No previous agent memory found - empty memory directory created"
+    fi
+  displayName: "Restore previous agent memory"
+  condition: eq(${{ parameters.clearMemory }}, false)
+  continueOnError: true
+
+- bash: |
+    mkdir -p /tmp/awf-tools/staging/agent_memory
+    echo "Memory cleared by pipeline parameter - starting fresh"
+  displayName: "Initialize empty agent memory (clearMemory=true)"
+  condition: eq(${{ parameters.clearMemory }}, true)"#
+        .to_string()
+}
+
+// ──────────────────────────────────────────────────────────────────────
+// Collection
+// ──────────────────────────────────────────────────────────────────────
+
+/// Collect all enabled compiler extensions from front matter.
+///
+/// Runtimes are collected first, then first-party tools. The order
+/// determines the merge order for prepare steps and prompt supplements.
+pub fn collect_extensions(front_matter: &FrontMatter) -> Vec<Extension> {
+    let mut extensions = Vec::new();
+
+    // ── Runtimes ──
+    if let Some(lean) = front_matter
+        .runtimes
+        .as_ref()
+        .and_then(|r| r.lean.as_ref())
+    {
+        if lean.is_enabled() {
+            extensions.push(Extension::Lean(LeanExtension::new(lean.clone())));
+        }
+    }
+
+    // ── First-party tools ──
+    if let Some(tools) = front_matter.tools.as_ref() {
+        if let Some(ado) = tools.azure_devops.as_ref() {
+            if ado.is_enabled() {
+                extensions.push(Extension::AzureDevOps(AzureDevOpsExtension::new(
+                    ado.clone(),
+                )));
+            }
+        }
+        if let Some(memory) = tools.cache_memory.as_ref() {
+            if memory.is_enabled() {
+                extensions.push(Extension::CacheMemory(CacheMemoryExtension::new(
+                    memory.clone(),
+                )));
+            }
+        }
+    }
+
+    extensions
+}
+
+/// Wrap prompt supplement content in a `cat >>` pipeline step.
+///
+/// This is the generic wrapper used by the compiler to append extension
+/// prompt supplements to the agent prompt file. Each line of content is
+/// indented by 4 spaces to match the YAML block scalar indentation.
+pub fn wrap_prompt_append(content: &str, display_name: &str) -> String {
+    // Generate a unique heredoc delimiter from the display name
+    let delimiter = display_name
+        .to_uppercase()
+        .replace(' ', "_")
+        .replace(|c: char| !c.is_ascii_alphanumeric() && c != '_', "");
+    let delimiter = format!("{}_EOF", delimiter);
+
+    // Indent every line of content by 4 spaces to match the heredoc indentation
+    let indented_content: String = content
+        .trim()
+        .lines()
+        .map(|line| {
+            if line.is_empty() {
+                String::new()
+            } else {
+                format!("    {}", line)
+            }
+        })
+        .collect::<Vec<_>>()
+        .join("\n");
+
+    format!(
+        r#"- bash: |
+    cat >> "/tmp/awf-tools/agent-prompt.md" << '{delimiter}'
+{indented_content}
+    {delimiter}
+
+    echo "{display_name} prompt appended"
+  displayName: "Append {display_name} prompt""#,
+        delimiter = delimiter,
+        indented_content = indented_content,
+        display_name = display_name,
+    )
+}
+
+// ──────────────────────────────────────────────────────────────────────
+// Tests
+// ──────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::compile::common::parse_markdown;
+
+    fn minimal_front_matter() -> FrontMatter {
+        let (fm, _) = parse_markdown("---\nname: test-agent\ndescription: test\n---\n").unwrap();
+        fm
+    }
+
+    fn ctx_from(fm: &FrontMatter) -> CompileContext<'_> {
+        CompileContext {
+            agent_name: &fm.name,
+            front_matter: fm,
+            inferred_org: None,
+        }
+    }
+
+    // ── collect_extensions ──────────────────────────────────────────
+
+    #[test]
+    fn test_collect_extensions_empty_front_matter() {
+        let fm = minimal_front_matter();
+        let exts = collect_extensions(&fm);
+        assert!(exts.is_empty());
+    }
+
+    #[test]
+    fn test_collect_extensions_lean_enabled() {
+        let (fm, _) = parse_markdown(
+            "---\nname: test\ndescription: test\nruntimes:\n  lean: true\n---\n",
+        )
+        .unwrap();
+        let exts = collect_extensions(&fm);
+        assert_eq!(exts.len(), 1);
+        assert_eq!(exts[0].name(), "Lean 4");
+    }
+
+    #[test]
+    fn test_collect_extensions_lean_disabled() {
+        let (fm, _) = parse_markdown(
+            "---\nname: test\ndescription: test\nruntimes:\n  lean: false\n---\n",
+        )
+        .unwrap();
+        let exts = collect_extensions(&fm);
+        assert!(exts.is_empty());
+    }
+
+    #[test]
+    fn test_collect_extensions_azure_devops_enabled() {
+        let (fm, _) = parse_markdown(
+            "---\nname: test\ndescription: test\ntools:\n  azure-devops: true\n---\n",
+        )
+        .unwrap();
+        let exts = collect_extensions(&fm);
+        assert_eq!(exts.len(), 1);
+        assert_eq!(exts[0].name(), "Azure DevOps MCP");
+    }
+
+    #[test]
+    fn test_collect_extensions_cache_memory_enabled() {
+        let (fm, _) = parse_markdown(
+            "---\nname: test\ndescription: test\ntools:\n  cache-memory: true\n---\n",
+        )
+        .unwrap();
+        let exts = collect_extensions(&fm);
+        assert_eq!(exts.len(), 1);
+        assert_eq!(exts[0].name(), "Cache Memory");
+    }
+
+    #[test]
+    fn test_collect_extensions_all_enabled() {
+        let (fm, _) = parse_markdown(
+            "---\nname: test\ndescription: test\nruntimes:\n  lean: true\ntools:\n  azure-devops: true\n  cache-memory: true\n---\n",
+        )
+        .unwrap();
+        let exts = collect_extensions(&fm);
+        assert_eq!(exts.len(), 3);
+        assert_eq!(exts[0].name(), "Lean 4");
+        assert_eq!(exts[1].name(), "Azure DevOps MCP");
+        assert_eq!(exts[2].name(), "Cache Memory");
+    }
+
+    // ── LeanExtension ──────────────────────────────────────────────
+
+    #[test]
+    fn test_lean_required_hosts() {
+        let ext = LeanExtension::new(LeanRuntimeConfig::Enabled(true));
+        let hosts = ext.required_hosts();
+        assert!(hosts.contains(&"elan.lean-lang.org".to_string()));
+        assert!(hosts.contains(&"leanprover.github.io".to_string()));
+        assert!(hosts.contains(&"lean-lang.org".to_string()));
+    }
+
+    #[test]
+    fn test_lean_required_bash_commands() {
+        let ext = LeanExtension::new(LeanRuntimeConfig::Enabled(true));
+        let cmds = ext.required_bash_commands();
+        assert!(cmds.contains(&"lean".to_string()));
+        assert!(cmds.contains(&"lake".to_string()));
+        assert!(cmds.contains(&"elan".to_string()));
+    }
+
+    #[test]
+    fn test_lean_prompt_supplement() {
+        let ext = LeanExtension::new(LeanRuntimeConfig::Enabled(true));
+        let prompt = ext.prompt_supplement().unwrap();
+        assert!(prompt.contains("Lean 4"));
+        assert!(prompt.contains("lake build"));
+    }
+
+    #[test]
+    fn test_lean_prepare_steps() {
+        let ext = LeanExtension::new(LeanRuntimeConfig::Enabled(true));
+        let steps = ext.prepare_steps();
+        assert_eq!(steps.len(), 1);
+        assert!(steps[0].contains("elan-init.sh"));
+    }
+
+    #[test]
+    fn test_lean_validate_bash_disabled_warning() {
+        let (fm, _) = parse_markdown(
+            "---\nname: test\ndescription: test\ntools:\n  bash: []\n---\n",
+        )
+        .unwrap();
+        let ext = LeanExtension::new(LeanRuntimeConfig::Enabled(true));
+        let ctx = ctx_from(&fm);
+        let warnings = ext.validate(&ctx).unwrap();
+        assert_eq!(warnings.len(), 1);
+        assert!(warnings[0].contains("tools.bash is empty"));
+    }
+
+    #[test]
+    fn test_lean_validate_bash_not_disabled_no_warning() {
+        let fm = minimal_front_matter();
+        let ext = LeanExtension::new(LeanRuntimeConfig::Enabled(true));
+        let ctx = ctx_from(&fm);
+        let warnings = ext.validate(&ctx).unwrap();
+        assert!(warnings.is_empty());
+    }
+
+    // ── AzureDevOpsExtension ───────────────────────────────────────
+
+    #[test]
+    fn test_ado_required_hosts() {
+        let ext = AzureDevOpsExtension::new(AzureDevOpsToolConfig::Enabled(true));
+        let hosts = ext.required_hosts();
+        assert!(hosts.contains(&"dev.azure.com".to_string()));
+    }
+
+    #[test]
+    fn test_ado_mcpg_servers_with_inferred_org() {
+        let fm = minimal_front_matter();
+        let ctx = CompileContext {
+            agent_name: &fm.name,
+            front_matter: &fm,
+            inferred_org: Some("myorg"),
+        };
+        let ext = AzureDevOpsExtension::new(AzureDevOpsToolConfig::Enabled(true));
+        let servers = ext.mcpg_servers(&ctx).unwrap();
+        assert_eq!(servers.len(), 1);
+        assert_eq!(servers[0].0, ADO_MCP_SERVER_NAME);
+        assert_eq!(servers[0].1.server_type, "stdio");
+        assert!(servers[0]
+            .1
+            .entrypoint_args
+            .as_ref()
+            .unwrap()
+            .contains(&"myorg".to_string()));
+    }
+
+    #[test]
+    fn test_ado_mcpg_servers_no_org_fails() {
+        let fm = minimal_front_matter();
+        let ctx = CompileContext {
+            agent_name: &fm.name,
+            front_matter: &fm,
+            inferred_org: None,
+        };
+        let ext = AzureDevOpsExtension::new(AzureDevOpsToolConfig::Enabled(true));
+        assert!(ext.mcpg_servers(&ctx).is_err());
+    }
+
+    #[test]
+    fn test_ado_validate_duplicate_mcp_warning() {
+        let (mut fm, _) = parse_markdown(
+            "---\nname: test\ndescription: test\n---\n",
+        )
+        .unwrap();
+        fm.mcp_servers.insert(
+            ADO_MCP_SERVER_NAME.to_string(),
+            crate::compile::types::McpConfig::Enabled(true),
+        );
+        let ctx = ctx_from(&fm);
+        let ext = AzureDevOpsExtension::new(AzureDevOpsToolConfig::Enabled(true));
+        let warnings = ext.validate(&ctx).unwrap();
+        assert_eq!(warnings.len(), 1);
+        assert!(warnings[0].contains("both tools.azure-devops and mcp-servers"));
+    }
+
+    // ── CacheMemoryExtension ───────────────────────────────────────
+
+    #[test]
+    fn test_cache_memory_prepare_steps() {
+        let ext = CacheMemoryExtension::new(CacheMemoryToolConfig::Enabled(true));
+        let steps = ext.prepare_steps();
+        assert_eq!(steps.len(), 1);
+        assert!(steps[0].contains("DownloadPipelineArtifact"));
+    }
+
+    #[test]
+    fn test_cache_memory_prompt_supplement() {
+        let ext = CacheMemoryExtension::new(CacheMemoryToolConfig::Enabled(true));
+        let prompt = ext.prompt_supplement().unwrap();
+        assert!(prompt.contains("Agent Memory"));
+        assert!(prompt.contains("/tmp/awf-tools/staging/agent_memory/"));
+    }
+
+    // ── wrap_prompt_append ─────────────────────────────────────────
+
+    #[test]
+    fn test_wrap_prompt_append_generates_valid_yaml_step() {
+        let content = "## Test\n\nSome instructions.";
+        let step = wrap_prompt_append(content, "Test Feature");
+        assert!(step.contains("cat >>"));
+        assert!(step.contains("agent-prompt.md"));
+        assert!(step.contains("TEST_FEATURE_EOF"));
+        assert!(step.contains("Test Feature"));
+    }
+}

--- a/src/compile/extensions.rs
+++ b/src/compile/extensions.rs
@@ -97,15 +97,41 @@ pub struct CompileContext<'a> {
 // CompilerExtension trait
 // ──────────────────────────────────────────────────────────────────────
 
+/// Execution phase for extension ordering.
+///
+/// Extensions are collected and processed in phase order. Runtimes run
+/// before tools because tools may depend on runtimes (e.g., `uv` requires
+/// a Python runtime to already be installed).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub enum ExtensionPhase {
+    /// Language runtimes (Lean, Python, Node, etc.) — installed first.
+    Runtime = 0,
+    /// First-party tools (azure-devops, cache-memory, etc.) — may depend
+    /// on runtimes being available.
+    Tool = 1,
+}
+
 /// Unified interface for runtimes and first-party tools to declare
 /// compilation requirements.
 ///
 /// The compiler calls [`collect_extensions`] to gather all enabled
-/// extensions, then iterates over them to merge requirements into the
-/// generated pipeline.
+/// extensions, then iterates over them **in phase order** to merge
+/// requirements into the generated pipeline.
+///
+/// ## Ordering policy
+///
+/// Extensions declare their [`phase`](CompilerExtension::phase) which
+/// controls the order in which `prepare_steps` and `prompt_supplement`
+/// are emitted. Runtimes ([`ExtensionPhase::Runtime`]) always run
+/// before tools ([`ExtensionPhase::Tool`]) because tools may depend on
+/// runtimes being installed (e.g., a Python-based tool needs the Python
+/// runtime first).
 pub trait CompilerExtension {
     /// Human-readable name for logging and diagnostics (e.g., "Lean 4").
     fn name(&self) -> &str;
+
+    /// The execution phase of this extension, controlling ordering.
+    fn phase(&self) -> ExtensionPhase;
 
     /// Network hosts this extension requires (added to AWF allowlist).
     fn required_hosts(&self) -> Vec<String> {
@@ -181,6 +207,9 @@ macro_rules! extension_enum {
             fn name(&self) -> &str {
                 match self { $( $Enum::$Variant(e) => e.name(), )+ }
             }
+            fn phase(&self) -> ExtensionPhase {
+                match self { $( $Enum::$Variant(e) => e.phase(), )+ }
+            }
             fn required_hosts(&self) -> Vec<String> {
                 match self { $( $Enum::$Variant(e) => e.required_hosts(), )+ }
             }
@@ -242,6 +271,10 @@ impl LeanExtension {
 impl CompilerExtension for LeanExtension {
     fn name(&self) -> &str {
         "Lean 4"
+    }
+
+    fn phase(&self) -> ExtensionPhase {
+        ExtensionPhase::Runtime
     }
 
     fn required_hosts(&self) -> Vec<String> {
@@ -315,6 +348,10 @@ impl AzureDevOpsExtension {
 impl CompilerExtension for AzureDevOpsExtension {
     fn name(&self) -> &str {
         "Azure DevOps MCP"
+    }
+
+    fn phase(&self) -> ExtensionPhase {
+        ExtensionPhase::Tool
     }
 
     fn required_hosts(&self) -> Vec<String> {
@@ -444,6 +481,10 @@ impl CompilerExtension for CacheMemoryExtension {
         "Cache Memory"
     }
 
+    fn phase(&self) -> ExtensionPhase {
+        ExtensionPhase::Tool
+    }
+
     fn prepare_steps(&self) -> Vec<String> {
         vec![generate_memory_download()]
     }
@@ -511,12 +552,20 @@ fn generate_memory_download() -> String {
 
 /// Collect all enabled compiler extensions from front matter.
 ///
-/// Runtimes are collected first, then first-party tools. The order
-/// determines the merge order for prepare steps and prompt supplements.
+/// ## Ordering policy
+///
+/// Extensions are sorted by [`ExtensionPhase`] before being returned:
+/// runtimes run before tools. This guarantees that runtime install steps
+/// execute before tool steps — critical when a tool depends on a runtime
+/// (e.g., a Python-based tool like `uv` needs the Python runtime first).
+///
+/// Within the same phase, extensions preserve definition order
+/// (runtimes in `RuntimesConfig` field order, tools in `ToolsConfig`
+/// field order).
 pub fn collect_extensions(front_matter: &FrontMatter) -> Vec<Extension> {
     let mut extensions = Vec::new();
 
-    // ── Runtimes ──
+    // ── Runtimes (ExtensionPhase::Runtime) ──
     if let Some(lean) = front_matter
         .runtimes
         .as_ref()
@@ -527,7 +576,7 @@ pub fn collect_extensions(front_matter: &FrontMatter) -> Vec<Extension> {
         }
     }
 
-    // ── First-party tools ──
+    // ── First-party tools (ExtensionPhase::Tool) ──
     if let Some(tools) = front_matter.tools.as_ref() {
         if let Some(ado) = tools.azure_devops.as_ref() {
             if ado.is_enabled() {
@@ -544,6 +593,10 @@ pub fn collect_extensions(front_matter: &FrontMatter) -> Vec<Extension> {
             }
         }
     }
+
+    // Enforce phase ordering: runtimes before tools.
+    // sort_by_key is stable, preserving definition order within the same phase.
+    extensions.sort_by_key(|ext| ext.phase());
 
     extensions
 }
@@ -686,6 +739,35 @@ mod tests {
         assert_eq!(exts[0].name(), "Lean 4");
         assert_eq!(exts[1].name(), "Azure DevOps MCP");
         assert_eq!(exts[2].name(), "Cache Memory");
+    }
+
+    #[test]
+    fn test_collect_extensions_runtimes_always_before_tools() {
+        // Verify the phase ordering policy: all Runtime-phase extensions
+        // must appear before any Tool-phase extensions, regardless of
+        // front matter field order.
+        let (fm, _) = parse_markdown(
+            "---\nname: test\ndescription: test\ntools:\n  azure-devops: true\n  cache-memory: true\nruntimes:\n  lean: true\n---\n",
+        )
+        .unwrap();
+        let exts = collect_extensions(&fm);
+        assert_eq!(exts.len(), 3);
+
+        // Find the boundary: last Runtime and first Tool
+        let last_runtime_idx = exts
+            .iter()
+            .rposition(|e| e.phase() == ExtensionPhase::Runtime);
+        let first_tool_idx = exts
+            .iter()
+            .position(|e| e.phase() == ExtensionPhase::Tool);
+
+        if let (Some(last_rt), Some(first_tool)) = (last_runtime_idx, first_tool_idx) {
+            assert!(
+                last_rt < first_tool,
+                "Runtime extensions must come before Tool extensions. \
+                 Last runtime at index {last_rt}, first tool at index {first_tool}"
+            );
+        }
     }
 
     // ── LeanExtension ──────────────────────────────────────────────

--- a/src/compile/extensions.rs
+++ b/src/compile/extensions.rs
@@ -426,6 +426,9 @@ use super::types::CacheMemoryToolConfig;
 /// Injects: prepare steps (download/restore previous memory), and a
 /// prompt supplement informing the agent about its memory directory.
 pub struct CacheMemoryExtension {
+    /// Config options (e.g., `allowed-extensions`) are consumed at Stage 2
+    /// execution time, not at compile time. Retained here for potential
+    /// future compile-time validation.
     #[allow(dead_code)]
     config: CacheMemoryToolConfig,
 }
@@ -551,6 +554,18 @@ pub fn collect_extensions(front_matter: &FrontMatter) -> Vec<Extension> {
 /// prompt supplements to the agent prompt file. Each line of content is
 /// indented by 4 spaces to match the YAML block scalar indentation.
 pub fn wrap_prompt_append(content: &str, display_name: &str) -> String {
+    // Guard against names that would break bash echo or YAML displayName.
+    // All current extension names are hardcoded alphanumeric strings, but
+    // this catches future extensions whose name() might contain shell
+    // metacharacters.
+    debug_assert!(
+        display_name
+            .chars()
+            .all(|c| c.is_ascii_alphanumeric() || matches!(c, ' ' | '-' | '_')),
+        "Extension display_name '{}' contains characters unsafe for bash/YAML embedding",
+        display_name
+    );
+
     // Generate a unique heredoc delimiter from the display name
     let delimiter = display_name
         .to_uppercase()

--- a/src/compile/mod.rs
+++ b/src/compile/mod.rs
@@ -7,6 +7,7 @@
 //! - **1ES**: Integration with 1ES Pipeline Templates using the agencyJob type
 
 mod common;
+pub mod extensions;
 mod onees;
 mod standalone;
 mod types;

--- a/src/compile/onees.rs
+++ b/src/compile/onees.rs
@@ -28,6 +28,7 @@ use super::common::{
     validate_resolve_pr_thread_statuses, validate_submit_pr_review_events,
     validate_update_pr_votes, validate_update_work_item_target, validate_write_permissions,
 };
+use super::extensions::CompilerExtension;
 use super::types::{FrontMatter, McpConfig};
 
 /// 1ES Pipeline Template compiler.
@@ -65,6 +66,21 @@ impl Compiler for OneESCompiler {
         let checkout_steps = generate_checkout_steps(&front_matter.checkout);
         let checkout_self = generate_checkout_self();
         let extensions = super::extensions::collect_extensions(front_matter);
+
+        // Run extension validations (warnings + errors)
+        {
+            let validation_ctx = super::extensions::CompileContext {
+                agent_name: &front_matter.name,
+                front_matter,
+                inferred_org: None,
+            };
+            for ext in &extensions {
+                for warning in ext.validate(&validation_ctx)? {
+                    eprintln!("Warning: {}", warning);
+                }
+            }
+        }
+
         let copilot_params = generate_copilot_params(front_matter, &extensions)?;
         let has_memory = front_matter
             .tools

--- a/src/compile/onees.rs
+++ b/src/compile/onees.rs
@@ -64,7 +64,8 @@ impl Compiler for OneESCompiler {
         let repositories = generate_repositories(&front_matter.repositories);
         let checkout_steps = generate_checkout_steps(&front_matter.checkout);
         let checkout_self = generate_checkout_self();
-        let copilot_params = generate_copilot_params(front_matter)?;
+        let extensions = super::extensions::collect_extensions(front_matter);
+        let copilot_params = generate_copilot_params(front_matter, &extensions)?;
         let has_memory = front_matter
             .tools
             .as_ref()

--- a/src/compile/standalone.rs
+++ b/src/compile/standalone.rs
@@ -15,7 +15,6 @@ use std::path::Path;
 use super::Compiler;
 use super::common::{
     self, AWF_VERSION, COPILOT_CLI_VERSION, DEFAULT_POOL, MCPG_PORT, MCPG_VERSION, MCPG_IMAGE,
-    ADO_MCP_IMAGE, ADO_MCP_ENTRYPOINT, ADO_MCP_PACKAGE, ADO_MCP_SERVER_NAME,
     build_parameters, compute_effective_workspace, generate_acquire_ado_token,
     generate_cancel_previous_builds, generate_checkout_self, generate_checkout_steps,
     generate_ci_trigger, generate_copilot_ado_env, generate_copilot_params,
@@ -27,9 +26,9 @@ use super::common::{
     validate_submit_pr_review_events, validate_update_pr_votes, validate_update_work_item_target,
     validate_write_permissions,
 };
+use super::extensions::{CompilerExtension, McpgServerConfig, McpgGatewayConfig, McpgConfig};
 use super::types::{FrontMatter, McpConfig};
 use crate::allowed_hosts::{CORE_ALLOWED_HOSTS, mcp_required_hosts};
-use serde::Serialize;
 use std::collections::HashSet;
 
 /// Standalone pipeline compiler.
@@ -66,8 +65,26 @@ impl Compiler for StandaloneCompiler {
         let repositories = generate_repositories(&front_matter.repositories);
         let checkout_steps = generate_checkout_steps(&front_matter.checkout);
         let checkout_self = generate_checkout_self();
-        let copilot_params = generate_copilot_params(front_matter)?;
         let agent_name = sanitize_filename(&front_matter.name);
+
+        // Collect compiler extensions (runtimes + first-party tools)
+        let extensions = super::extensions::collect_extensions(front_matter);
+
+        // Run extension validations (warnings + errors)
+        {
+            let validation_ctx = super::extensions::CompileContext {
+                agent_name: &front_matter.name,
+                front_matter,
+                inferred_org: None, // Not yet available; ADO org validation happens in mcpg_servers()
+            };
+            for ext in &extensions {
+                for warning in ext.validate(&validation_ctx)? {
+                    eprintln!("Warning: {}", warning);
+                }
+            }
+        }
+
+        let copilot_params = generate_copilot_params(front_matter, &extensions)?;
 
         // Compute effective workspace
         let effective_workspace = compute_effective_workspace(
@@ -89,7 +106,7 @@ impl Compiler for StandaloneCompiler {
         let pipeline_path = generate_pipeline_path(output_path);
 
         // Generate comma-separated domain list for AWF
-        let allowed_domains = generate_allowed_domains(front_matter)?;
+        let allowed_domains = generate_allowed_domains(front_matter, &extensions)?;
 
         // Generate --enabled-tools args for SafeOutputs tool filtering
         let enabled_tools_args = generate_enabled_tools_args(front_matter);
@@ -110,17 +127,11 @@ impl Compiler for StandaloneCompiler {
             .and_then(|t| t.cache_memory.as_ref())
             .is_some_and(|cm| cm.is_enabled());
 
-        let lean_config = front_matter
-            .runtimes
-            .as_ref()
-            .and_then(|r| r.lean.as_ref())
-            .filter(|l| l.is_enabled());
-
         // Build parameters list: user-defined + auto-injected clearMemory for memory
         let parameters = build_parameters(&front_matter.parameters, has_memory);
         let parameters_yaml = generate_parameters(&parameters)?;
 
-        let prepare_steps = generate_prepare_steps(&front_matter.steps, has_memory, lean_config);
+        let prepare_steps = generate_prepare_steps(&front_matter.steps, &extensions);
         let finalize_steps = generate_finalize_steps(&front_matter.post_steps);
         let agentic_depends_on = generate_agentic_depends_on(&front_matter.setup);
         let job_timeout = generate_job_timeout(front_matter);
@@ -264,7 +275,7 @@ impl Compiler for StandaloneCompiler {
 
         // Always generate MCPG config — safeoutputs is always required regardless
         // of whether additional mcp-servers are configured in front matter.
-        let config = generate_mcpg_config(front_matter, inferred_org.as_deref())?;
+        let config = generate_mcpg_config(front_matter, inferred_org.as_deref(), &extensions)?;
         let mcpg_config_json =
             serde_json::to_string_pretty(&config).context("Failed to serialize MCPG config")?;
 
@@ -293,8 +304,11 @@ impl Compiler for StandaloneCompiler {
 /// 1. Core Azure DevOps/GitHub endpoints
 /// 2. MCP-specific endpoints for each enabled MCP
 /// 3. User-specified additional hosts from network.allow
-fn generate_allowed_domains(front_matter: &FrontMatter) -> Result<String> {
-    // Collect enabled MCP names
+fn generate_allowed_domains(
+    front_matter: &FrontMatter,
+    extensions: &[super::extensions::Extension],
+) -> Result<String> {
+    // Collect enabled MCP names (user-defined MCPs, not first-party tools)
     let enabled_mcps: Vec<String> = front_matter
         .mcp_servers
         .iter()
@@ -314,7 +328,7 @@ fn generate_allowed_domains(front_matter: &FrontMatter) -> Result<String> {
         .map(|n| n.allow.clone())
         .unwrap_or_default();
 
-    // Generate the allowlist by combining core + MCP + user hosts
+    // Generate the allowlist by combining core + MCP + extension + user hosts
     let mut hosts: HashSet<String> = HashSet::new();
 
     // Add core hosts
@@ -327,34 +341,17 @@ fn generate_allowed_domains(front_matter: &FrontMatter) -> Result<String> {
     // that always use MCPG.
     hosts.insert("host.docker.internal".to_string());
 
-    // Add MCP-specific hosts
+    // Add MCP-specific hosts (user-defined MCPs via mcp_required_hosts lookup)
     for mcp in &enabled_mcps {
         for host in mcp_required_hosts(mcp) {
             hosts.insert((*host).to_string());
         }
     }
 
-    // Add ADO-specific hosts when tools.azure-devops is enabled
-    if front_matter
-        .tools
-        .as_ref()
-        .and_then(|t| t.azure_devops.as_ref())
-        .is_some_and(|ado| ado.is_enabled())
-    {
-        for host in mcp_required_hosts("ado") {
-            hosts.insert((*host).to_string());
-        }
-    }
-
-    // Add Lean-specific hosts when runtimes.lean is enabled
-    if front_matter
-        .runtimes
-        .as_ref()
-        .and_then(|r| r.lean.as_ref())
-        .is_some_and(|l| l.is_enabled())
-    {
-        for host in crate::runtimes::lean::LEAN_REQUIRED_HOSTS {
-            hosts.insert((*host).to_string());
+    // Add extension-declared hosts (runtimes + first-party tools)
+    for ext in extensions {
+        for host in ext.required_hosts() {
+            hosts.insert(host);
         }
     }
 
@@ -446,25 +443,21 @@ fn generate_teardown_job(
     )
 }
 
-/// Generate prepare steps (inline), including memory download/restore/prompt if enabled
-/// and Lean 4 installation if enabled
+/// Generate prepare steps (inline), including extension steps and user-defined steps.
 fn generate_prepare_steps(
     prepare_steps: &[serde_yaml::Value],
-    has_memory: bool,
-    lean_config: Option<&crate::runtimes::lean::LeanRuntimeConfig>,
+    extensions: &[super::extensions::Extension],
 ) -> String {
     let mut parts = Vec::new();
 
-    // Memory steps run before user prepare steps
-    if has_memory {
-        parts.push(generate_memory_download());
-        parts.push(generate_memory_prompt());
-    }
-
-    // Lean install and prompt
-    if let Some(lean) = lean_config {
-        parts.push(crate::runtimes::lean::generate_lean_install(lean));
-        parts.push(crate::runtimes::lean::generate_lean_prompt());
+    // Extension prepare steps and prompt supplements (runtimes + first-party tools)
+    for ext in extensions {
+        for step in ext.prepare_steps() {
+            parts.push(step);
+        }
+        if let Some(prompt) = ext.prompt_supplement() {
+            parts.push(super::extensions::wrap_prompt_append(&prompt, ext.name()));
+        }
     }
 
     if !prepare_steps.is_empty() {
@@ -492,60 +485,6 @@ fn generate_agentic_depends_on(setup_steps: &[serde_yaml::Value]) -> String {
     }
 }
 
-/// MCPG server configuration for a single MCP upstream.
-#[derive(Debug, Serialize, Clone)]
-#[serde(rename_all = "camelCase")]
-pub struct McpgServerConfig {
-    /// Server type: "stdio" for container-based, "http" for HTTP backends
-    #[serde(rename = "type")]
-    pub server_type: String,
-    /// Docker container image (for stdio type, per MCPG spec §4.1.2)
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub container: Option<String>,
-    /// Container entrypoint override (for stdio type)
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub entrypoint: Option<String>,
-    /// Arguments passed to the container entrypoint (for stdio type)
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub entrypoint_args: Option<Vec<String>>,
-    /// Volume mounts for containerized servers (format: "source:dest:mode")
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub mounts: Option<Vec<String>>,
-    /// Additional Docker runtime arguments (inserted before image in `docker run`)
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub args: Option<Vec<String>>,
-    /// URL for HTTP backends
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub url: Option<String>,
-    /// HTTP headers (e.g., Authorization)
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub headers: Option<HashMap<String, String>>,
-    /// Environment variables for the server process
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub env: Option<HashMap<String, String>>,
-    /// Tool allow-list (if empty or absent, all tools are allowed)
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub tools: Option<Vec<String>>,
-}
-
-/// MCPG gateway configuration.
-#[derive(Debug, Serialize, Clone)]
-#[serde(rename_all = "camelCase")]
-pub struct McpgGatewayConfig {
-    pub port: u16,
-    pub domain: String,
-    pub api_key: String,
-    pub payload_dir: String,
-}
-
-/// Top-level MCPG configuration.
-#[derive(Debug, Serialize, Clone)]
-#[serde(rename_all = "camelCase")]
-pub struct McpgConfig {
-    pub mcp_servers: HashMap<String, McpgServerConfig>,
-    pub gateway: McpgGatewayConfig,
-}
-
 /// Generate MCPG configuration from front matter.
 ///
 /// Converts the front matter `mcp-servers` definitions into MCPG-compatible JSON.
@@ -558,7 +497,11 @@ pub struct McpgConfig {
 ///
 /// Returns an error if `tools.azure-devops` is enabled but no org can be determined
 /// (neither explicit override nor git remote inference).
-pub fn generate_mcpg_config(front_matter: &FrontMatter, inferred_org: Option<&str>) -> Result<McpgConfig> {
+pub fn generate_mcpg_config(
+    front_matter: &FrontMatter,
+    inferred_org: Option<&str>,
+    extensions: &[super::extensions::Extension],
+) -> Result<McpgConfig> {
     let mut mcp_servers = HashMap::new();
 
     // SafeOutputs is always included as an HTTP backend.
@@ -584,90 +527,15 @@ pub fn generate_mcpg_config(front_matter: &FrontMatter, inferred_org: Option<&st
         },
     );
 
-    // Auto-configure ADO MCP when tools.azure-devops is enabled.
-    // This generates a containerized stdio MCP entry using the ADO MCP npm package.
-    if let Some(ado_config) = front_matter
-        .tools
-        .as_ref()
-        .and_then(|t| t.azure_devops.as_ref())
-    {
-        if ado_config.is_enabled() {
-            // Warn if user also has a manual mcp-servers entry for azure-devops
-            if front_matter.mcp_servers.contains_key(ADO_MCP_SERVER_NAME) {
-                eprintln!(
-                    "Warning: Agent '{}' has both tools.azure-devops and mcp-servers.azure-devops configured. \
-                    The tools.azure-devops auto-configuration takes precedence. \
-                    Remove the mcp-servers entry to silence this warning.",
-                    front_matter.name
-                );
-            }
-
-            // Build entrypoint args: npx -y @azure-devops/mcp <org> [-d toolset1 toolset2 ...]
-            let mut entrypoint_args = vec!["-y".to_string(), ADO_MCP_PACKAGE.to_string()];
-
-            // Org: use explicit override, then compile-time inferred, then fail
-            let org = if let Some(explicit) = ado_config.org() {
-                explicit.to_string()
-            } else if let Some(inferred) = inferred_org {
-                inferred.to_string()
-            } else {
-                anyhow::bail!(
-                    "Agent '{}' has tools.azure-devops enabled but no ADO organization could be \
-                    determined. Either set tools.azure-devops.org explicitly, or compile from \
-                    within a git repository with an Azure DevOps remote URL.",
-                    front_matter.name
-                );
-            };
-            if !org.chars().all(|c| c.is_ascii_alphanumeric() || c == '-') {
-                anyhow::bail!(
-                    "Invalid ADO org name '{}': must contain only alphanumerics and hyphens",
-                    org
-                );
-            }
-            entrypoint_args.push(org);
-
-            // Toolsets: passed as -d flag followed by space-separated toolset names
-            if !ado_config.toolsets().is_empty() {
-                entrypoint_args.push("-d".to_string());
-                for toolset in ado_config.toolsets() {
-                    if !toolset.chars().all(|c| c.is_ascii_alphanumeric() || c == '-') {
-                        anyhow::bail!(
-                            "Invalid ADO toolset name '{}': must contain only alphanumerics and hyphens",
-                            toolset
-                        );
-                    }
-                    entrypoint_args.push(toolset.clone());
-                }
-            }
-
-            // Tool allow-list for MCPG filtering
-            let tools = if ado_config.allowed().is_empty() {
-                None
-            } else {
-                Some(ado_config.allowed().to_vec())
-            };
-
-            // ADO MCP needs the PAT token passed via environment
-            let env = Some(HashMap::from([(
-                "AZURE_DEVOPS_EXT_PAT".to_string(),
-                String::new(), // Passthrough from pipeline
-            )]));
-
-            mcp_servers.insert(
-                ADO_MCP_SERVER_NAME.to_string(),
-                McpgServerConfig {
-                    server_type: "stdio".to_string(),
-                    container: Some(ADO_MCP_IMAGE.to_string()),
-                    entrypoint: Some(ADO_MCP_ENTRYPOINT.to_string()),
-                    entrypoint_args: Some(entrypoint_args),
-                    mounts: None,
-                    args: None,
-                    url: None,
-                    headers: None,
-                    env,
-                    tools,
-                },
-            );
+    // Add extension-contributed MCPG server entries (e.g., azure-devops)
+    let ctx = super::extensions::CompileContext {
+        agent_name: &front_matter.name,
+        front_matter,
+        inferred_org,
+    };
+    for ext in extensions {
+        for (name, config) in ext.mcpg_servers(&ctx)? {
+            mcp_servers.insert(name, config);
         }
     }
 
@@ -680,8 +548,8 @@ pub fn generate_mcpg_config(front_matter: &FrontMatter, inferred_org: Option<&st
             continue;
         }
 
-        // Skip if already auto-configured by tools.azure-devops
-        if name == ADO_MCP_SERVER_NAME && mcp_servers.contains_key(ADO_MCP_SERVER_NAME) {
+        // Skip if already auto-configured by an extension (e.g., tools.azure-devops)
+        if mcp_servers.contains_key(name) {
             continue;
         }
 
@@ -1091,74 +959,12 @@ pub fn generate_mcpg_docker_env(front_matter: &FrontMatter) -> String {
     }
 }
 
-/// Generate the steps to download agent memory from the previous successful run
-/// and restore it to the staging directory.
-///
-/// When the `clearMemory` parameter is true, the download step is skipped
-/// and only an empty memory directory is created.
-fn generate_memory_download() -> String {
-    r#"- task: DownloadPipelineArtifact@2
-  displayName: "Download previous agent memory"
-  condition: eq(${{ parameters.clearMemory }}, false)
-  continueOnError: true
-  inputs:
-    source: "specific"
-    project: "$(System.TeamProject)"
-    pipeline: "$(System.DefinitionId)"
-    runVersion: "latestFromBranch"
-    branchName: "$(Build.SourceBranch)"
-    artifact: "safe_outputs"
-    targetPath: "$(Agent.TempDirectory)/previous_memory"
-    allowPartiallySucceededBuilds: true
-
-- bash: |
-    mkdir -p /tmp/awf-tools/staging/agent_memory
-    if [ -d "$(Agent.TempDirectory)/previous_memory/agent_memory" ]; then
-      cp -a "$(Agent.TempDirectory)/previous_memory/agent_memory/." /tmp/awf-tools/staging/agent_memory/ 2>/dev/null || true
-      echo "Previous agent memory restored to /tmp/awf-tools/staging/agent_memory"
-      ls -laR /tmp/awf-tools/staging/agent_memory
-    else
-      echo "No previous agent memory found - empty memory directory created"
-    fi
-  displayName: "Restore previous agent memory"
-  condition: eq(${{ parameters.clearMemory }}, false)
-  continueOnError: true
-
-- bash: |
-    mkdir -p /tmp/awf-tools/staging/agent_memory
-    echo "Memory cleared by pipeline parameter - starting fresh"
-  displayName: "Initialize empty agent memory (clearMemory=true)"
-  condition: eq(${{ parameters.clearMemory }}, true)"#
-        .to_string()
-}
-
-/// Generate the prompt append step to inform the agent about its memory location.
-fn generate_memory_prompt() -> String {
-    r#"- bash: |
-    cat >> "/tmp/awf-tools/agent-prompt.md" << 'MEMORY_PROMPT_EOF'
-
-    ---
-
-    ## Agent Memory
-
-    You have persistent memory across runs. Your memory directory is located at `/tmp/awf-tools/staging/agent_memory/`.
-
-    - **Read** previous memory files from this directory to recall context from prior runs.
-    - **Write** new files or update existing ones in this directory to persist knowledge for future runs.
-    - Use this memory to track patterns, accumulate findings, remember decisions, and improve over time.
-    - The memory directory is yours to organize as you see fit (files, subdirectories, any structure).
-    - Memory files are sanitized between runs for security; avoid including pipeline commands or secrets.
-    MEMORY_PROMPT_EOF
-
-    echo "Agent memory prompt appended"
-  displayName: "Append memory prompt""#
-        .to_string()
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::compile::common::parse_markdown;
+    use crate::compile::common::{
+        parse_markdown, ADO_MCP_IMAGE, ADO_MCP_ENTRYPOINT, ADO_MCP_PACKAGE, ADO_MCP_SERVER_NAME,
+    };
     use crate::compile::types::{McpConfig, McpOptions};
 
     fn minimal_front_matter() -> FrontMatter {
@@ -1179,7 +985,7 @@ mod tests {
                 ..Default::default()
             }),
         );
-        let config = generate_mcpg_config(&fm, None).unwrap();
+        let config = generate_mcpg_config(&fm, None, &super::super::extensions::collect_extensions(&fm)).unwrap();
         let server = config.mcp_servers.get("my-tool").unwrap();
         assert_eq!(server.server_type, "stdio");
         assert_eq!(server.container.as_ref().unwrap(), "node:20-slim");
@@ -1200,7 +1006,7 @@ mod tests {
         // An MCP with no container or url should be skipped
         fm.mcp_servers
             .insert("phantom".to_string(), McpConfig::Enabled(true));
-        let config = generate_mcpg_config(&fm, None).unwrap();
+        let config = generate_mcpg_config(&fm, None, &super::super::extensions::collect_extensions(&fm)).unwrap();
         assert!(!config.mcp_servers.contains_key("phantom"));
         // safeoutputs is always present
         assert!(config.mcp_servers.contains_key("safeoutputs"));
@@ -1211,14 +1017,14 @@ mod tests {
         let mut fm = minimal_front_matter();
         fm.mcp_servers
             .insert("my-tool".to_string(), McpConfig::Enabled(false));
-        let config = generate_mcpg_config(&fm, None).unwrap();
+        let config = generate_mcpg_config(&fm, None, &super::super::extensions::collect_extensions(&fm)).unwrap();
         assert!(!config.mcp_servers.contains_key("my-tool"));
     }
 
     #[test]
     fn test_generate_mcpg_config_empty_mcp_servers() {
         let fm = minimal_front_matter();
-        let config = generate_mcpg_config(&fm, None).unwrap();
+        let config = generate_mcpg_config(&fm, None, &super::super::extensions::collect_extensions(&fm)).unwrap();
         // Only safeoutputs should be present
         assert_eq!(config.mcp_servers.len(), 1);
         assert!(config.mcp_servers.contains_key("safeoutputs"));
@@ -1227,7 +1033,7 @@ mod tests {
     #[test]
     fn test_generate_mcpg_config_gateway_defaults() {
         let fm = minimal_front_matter();
-        let config = generate_mcpg_config(&fm, None).unwrap();
+        let config = generate_mcpg_config(&fm, None, &super::super::extensions::collect_extensions(&fm)).unwrap();
         assert_eq!(config.gateway.port, 80);
         assert_eq!(config.gateway.domain, "host.docker.internal");
         assert_eq!(config.gateway.api_key, "${MCP_GATEWAY_API_KEY}");
@@ -1247,7 +1053,7 @@ mod tests {
                 ..Default::default()
             }),
         );
-        let config = generate_mcpg_config(&fm, None).unwrap();
+        let config = generate_mcpg_config(&fm, None, &super::super::extensions::collect_extensions(&fm)).unwrap();
         let json = serde_json::to_string_pretty(&config).expect("Config should serialize to JSON");
         let parsed: serde_json::Value =
             serde_json::from_str(&json).expect("Serialized JSON should parse back");
@@ -1272,7 +1078,7 @@ mod tests {
     #[test]
     fn test_generate_mcpg_config_safeoutputs_variable_placeholders() {
         let fm = minimal_front_matter();
-        let config = generate_mcpg_config(&fm, None).unwrap();
+        let config = generate_mcpg_config(&fm, None, &super::super::extensions::collect_extensions(&fm)).unwrap();
         let so = config.mcp_servers.get("safeoutputs").unwrap();
 
         // URL should reference the runtime-substituted port
@@ -1294,7 +1100,7 @@ mod tests {
     #[test]
     fn test_generate_mcpg_config_safeoutputs_is_http_type() {
         let fm = minimal_front_matter();
-        let config = generate_mcpg_config(&fm, None).unwrap();
+        let config = generate_mcpg_config(&fm, None, &super::super::extensions::collect_extensions(&fm)).unwrap();
         let so = config.mcp_servers.get("safeoutputs").unwrap();
         assert_eq!(so.server_type, "http");
         assert!(
@@ -1318,7 +1124,7 @@ mod tests {
                 ..Default::default()
             }),
         );
-        let config = generate_mcpg_config(&fm, None).unwrap();
+        let config = generate_mcpg_config(&fm, None, &super::super::extensions::collect_extensions(&fm)).unwrap();
         let srv = config.mcp_servers.get("runner").unwrap();
         assert_eq!(srv.server_type, "stdio");
         assert!(
@@ -1341,7 +1147,7 @@ mod tests {
                 ..Default::default()
             }),
         );
-        let config = generate_mcpg_config(&fm, None).unwrap();
+        let config = generate_mcpg_config(&fm, None, &super::super::extensions::collect_extensions(&fm)).unwrap();
         let srv = config.mcp_servers.get("with-env").unwrap();
         let e = srv.env.as_ref().unwrap();
         assert_eq!(e.get("TOKEN").unwrap(), "secret");
@@ -1357,7 +1163,7 @@ mod tests {
                 ..Default::default()
             }),
         );
-        let config = generate_mcpg_config(&fm, None).unwrap();
+        let config = generate_mcpg_config(&fm, None, &super::super::extensions::collect_extensions(&fm)).unwrap();
         // The reserved entry should still be the HTTP backend, not the user's container
         let so = config.mcp_servers.get("safeoutputs").unwrap();
         assert_eq!(
@@ -1383,7 +1189,7 @@ mod tests {
                 ..Default::default()
             }),
         );
-        let config = generate_mcpg_config(&fm, None).unwrap();
+        let config = generate_mcpg_config(&fm, None, &super::super::extensions::collect_extensions(&fm)).unwrap();
         // The user-defined "SafeOutputs" must not overwrite the built-in entry
         let so = config.mcp_servers.get("safeoutputs").unwrap();
         assert_eq!(so.server_type, "http");
@@ -1408,7 +1214,7 @@ mod tests {
                 ..Default::default()
             }),
         );
-        let config = generate_mcpg_config(&fm, None).unwrap();
+        let config = generate_mcpg_config(&fm, None, &super::super::extensions::collect_extensions(&fm)).unwrap();
         let srv = config.mcp_servers.get("remote").unwrap();
         assert_eq!(srv.server_type, "http");
         assert_eq!(
@@ -1434,7 +1240,7 @@ mod tests {
                 ..Default::default()
             }),
         );
-        let config = generate_mcpg_config(&fm, None).unwrap();
+        let config = generate_mcpg_config(&fm, None, &super::super::extensions::collect_extensions(&fm)).unwrap();
         let srv = config.mcp_servers.get("ado").unwrap();
         assert_eq!(srv.server_type, "stdio");
         assert_eq!(srv.container.as_ref().unwrap(), "node:20-slim");
@@ -1456,7 +1262,7 @@ mod tests {
                 ..Default::default()
             }),
         );
-        let config = generate_mcpg_config(&fm, None).unwrap();
+        let config = generate_mcpg_config(&fm, None, &super::super::extensions::collect_extensions(&fm)).unwrap();
         let srv = config.mcp_servers.get("data-tool").unwrap();
         assert_eq!(
             srv.mounts.as_ref().unwrap(),
@@ -1475,7 +1281,7 @@ mod tests {
                 ..Default::default()
             }),
         );
-        let config = generate_mcpg_config(&fm, None).unwrap();
+        let config = generate_mcpg_config(&fm, None, &super::super::extensions::collect_extensions(&fm)).unwrap();
         assert!(!config.mcp_servers.contains_key("no-transport"));
     }
 
@@ -1643,7 +1449,7 @@ mod tests {
         )
         .unwrap();
         // Pass inferred org since no explicit org is set
-        let config = generate_mcpg_config(&fm, Some("inferred-org")).unwrap();
+        let config = generate_mcpg_config(&fm, Some("inferred-org"), &super::super::extensions::collect_extensions(&fm)).unwrap();
         let ado = config.mcp_servers.get("azure-devops").unwrap();
         assert_eq!(ado.server_type, "stdio");
         assert_eq!(ado.container.as_deref(), Some(ADO_MCP_IMAGE));
@@ -1663,7 +1469,7 @@ mod tests {
             "---\nname: test\ndescription: test\ntools:\n  azure-devops:\n    toolsets: [repos, wit, core]\n---\n",
         )
         .unwrap();
-        let config = generate_mcpg_config(&fm, Some("myorg")).unwrap();
+        let config = generate_mcpg_config(&fm, Some("myorg"), &super::super::extensions::collect_extensions(&fm)).unwrap();
         let ado = config.mcp_servers.get("azure-devops").unwrap();
         let args = ado.entrypoint_args.as_ref().unwrap();
         assert!(args.contains(&"-d".to_string()));
@@ -1679,7 +1485,7 @@ mod tests {
         )
         .unwrap();
         // Explicit org should be used even when inferred_org is None
-        let config = generate_mcpg_config(&fm, None).unwrap();
+        let config = generate_mcpg_config(&fm, None, &super::super::extensions::collect_extensions(&fm)).unwrap();
         let ado = config.mcp_servers.get("azure-devops").unwrap();
         let args = ado.entrypoint_args.as_ref().unwrap();
         assert!(args.contains(&"myorg".to_string()));
@@ -1691,7 +1497,7 @@ mod tests {
             "---\nname: test\ndescription: test\ntools:\n  azure-devops:\n    org: explicit-org\n---\n",
         )
         .unwrap();
-        let config = generate_mcpg_config(&fm, Some("inferred-org")).unwrap();
+        let config = generate_mcpg_config(&fm, Some("inferred-org"), &super::super::extensions::collect_extensions(&fm)).unwrap();
         let ado = config.mcp_servers.get("azure-devops").unwrap();
         let args = ado.entrypoint_args.as_ref().unwrap();
         assert!(args.contains(&"explicit-org".to_string()));
@@ -1705,7 +1511,7 @@ mod tests {
         )
         .unwrap();
         // No explicit org and no inferred org — should fail
-        let result = generate_mcpg_config(&fm, None);
+        let result = generate_mcpg_config(&fm, None, &super::super::extensions::collect_extensions(&fm));
         assert!(result.is_err());
         assert!(
             result.unwrap_err().to_string().contains("no ADO organization"),
@@ -1719,7 +1525,7 @@ mod tests {
             "---\nname: test\ndescription: test\ntools:\n  azure-devops:\n    org: \"my org/bad\"\n---\n",
         )
         .unwrap();
-        let result = generate_mcpg_config(&fm, None);
+        let result = generate_mcpg_config(&fm, None, &super::super::extensions::collect_extensions(&fm));
         assert!(result.is_err());
         assert!(
             result.unwrap_err().to_string().contains("Invalid ADO org name"),
@@ -1733,7 +1539,7 @@ mod tests {
             "---\nname: test\ndescription: test\ntools:\n  azure-devops:\n    org: myorg\n    toolsets: [\"repos\", \"bad toolset\"]\n---\n",
         )
         .unwrap();
-        let result = generate_mcpg_config(&fm, None);
+        let result = generate_mcpg_config(&fm, None, &super::super::extensions::collect_extensions(&fm));
         assert!(result.is_err());
         assert!(
             result.unwrap_err().to_string().contains("Invalid ADO toolset name"),
@@ -1747,7 +1553,7 @@ mod tests {
             "---\nname: test\ndescription: test\ntools:\n  azure-devops:\n    org: myorg\n    allowed:\n      - wit_get_work_item\n      - core_list_projects\n---\n",
         )
         .unwrap();
-        let config = generate_mcpg_config(&fm, None).unwrap();
+        let config = generate_mcpg_config(&fm, None, &super::super::extensions::collect_extensions(&fm)).unwrap();
         let ado = config.mcp_servers.get("azure-devops").unwrap();
         let tools = ado.tools.as_ref().unwrap();
         assert_eq!(tools, &["wit_get_work_item", "core_list_projects"]);
@@ -1759,14 +1565,14 @@ mod tests {
             "---\nname: test\ndescription: test\ntools:\n  azure-devops: false\n---\n",
         )
         .unwrap();
-        let config = generate_mcpg_config(&fm, None).unwrap();
+        let config = generate_mcpg_config(&fm, None, &super::super::extensions::collect_extensions(&fm)).unwrap();
         assert!(!config.mcp_servers.contains_key("azure-devops"));
     }
 
     #[test]
     fn test_ado_tool_not_set_not_generated() {
         let fm = minimal_front_matter();
-        let config = generate_mcpg_config(&fm, None).unwrap();
+        let config = generate_mcpg_config(&fm, None, &super::super::extensions::collect_extensions(&fm)).unwrap();
         assert!(!config.mcp_servers.contains_key("azure-devops"));
     }
 
@@ -1778,7 +1584,7 @@ mod tests {
             "---\nname: test\ndescription: test\ntools:\n  azure-devops:\n    org: auto-org\nmcp-servers:\n  azure-devops:\n    container: \"node:20-slim\"\n    entrypoint: \"npx\"\n    entrypoint-args: [\"-y\", \"@azure-devops/mcp\", \"manual-org\"]\n---\n",
         )
         .unwrap();
-        let config = generate_mcpg_config(&fm, None).unwrap();
+        let config = generate_mcpg_config(&fm, None, &super::super::extensions::collect_extensions(&fm)).unwrap();
         let ado = config.mcp_servers.get("azure-devops").unwrap();
         // Should use the auto-configured org, not the manual one
         let args = ado.entrypoint_args.as_ref().unwrap();
@@ -2033,7 +1839,8 @@ mod tests {
             allow: vec!["evil.example.com".to_string()],
             blocked: vec!["evil.example.com".to_string()],
         });
-        let domains = generate_allowed_domains(&fm).unwrap();
+        let exts = super::super::extensions::collect_extensions(&fm);
+        let domains = generate_allowed_domains(&fm, &exts).unwrap();
         assert!(
             !domains.contains("evil.example.com"),
             "blocked host must be excluded even if also in allow"
@@ -2043,7 +1850,8 @@ mod tests {
     #[test]
     fn test_generate_allowed_domains_host_docker_internal_always_present() {
         let fm = minimal_front_matter();
-        let domains = generate_allowed_domains(&fm).unwrap();
+        let exts = super::super::extensions::collect_extensions(&fm);
+        let domains = generate_allowed_domains(&fm, &exts).unwrap();
         assert!(
             domains.contains("host.docker.internal"),
             "host.docker.internal must always be in the allowlist"
@@ -2057,7 +1865,8 @@ mod tests {
             allow: vec!["api.mycompany.com".to_string()],
             blocked: vec![],
         });
-        let domains = generate_allowed_domains(&fm).unwrap();
+        let exts = super::super::extensions::collect_extensions(&fm);
+        let domains = generate_allowed_domains(&fm, &exts).unwrap();
         assert!(
             domains.contains("api.mycompany.com"),
             "user-specified allow host must be present in the allowlist"
@@ -2074,7 +1883,8 @@ mod tests {
             allow: vec![],
             blocked: vec!["github.com".to_string()],
         });
-        let domains = generate_allowed_domains(&fm).unwrap();
+        let exts = super::super::extensions::collect_extensions(&fm);
+        let domains = generate_allowed_domains(&fm, &exts).unwrap();
         let domain_list: Vec<&str> = domains.split(',').collect();
         assert!(
             !domain_list.contains(&"github.com"),
@@ -2089,7 +1899,8 @@ mod tests {
             allow: vec!["bad host!".to_string()],
             blocked: vec![],
         });
-        let result = generate_allowed_domains(&fm);
+        let exts = super::super::extensions::collect_extensions(&fm);
+        let result = generate_allowed_domains(&fm, &exts);
         assert!(result.is_err(), "invalid DNS characters should return an error");
     }
 
@@ -2099,7 +1910,8 @@ mod tests {
         fm.runtimes = Some(crate::compile::types::RuntimesConfig {
             lean: Some(crate::runtimes::lean::LeanRuntimeConfig::Enabled(true)),
         });
-        let domains = generate_allowed_domains(&fm).unwrap();
+        let exts = super::super::extensions::collect_extensions(&fm);
+        let domains = generate_allowed_domains(&fm, &exts).unwrap();
         assert!(domains.contains("elan.lean-lang.org"), "should include elan domain");
         assert!(domains.contains("leanprover.github.io"), "should include leanprover domain");
         assert!(domains.contains("lean-lang.org"), "should include lean-lang domain");
@@ -2111,7 +1923,8 @@ mod tests {
         fm.runtimes = Some(crate::compile::types::RuntimesConfig {
             lean: Some(crate::runtimes::lean::LeanRuntimeConfig::Enabled(false)),
         });
-        let domains = generate_allowed_domains(&fm).unwrap();
+        let exts = super::super::extensions::collect_extensions(&fm);
+        let domains = generate_allowed_domains(&fm, &exts).unwrap();
         assert!(!domains.contains("elan.lean-lang.org"), "lean disabled should not add lean hosts");
     }
 
@@ -2119,10 +1932,14 @@ mod tests {
 
     #[test]
     fn test_generate_prepare_steps_with_memory_includes_memory_preamble() {
-        let result = generate_prepare_steps(&[], true, None);
+        let (fm, _) = crate::compile::common::parse_markdown(
+            "---\nname: test\ndescription: test\ntools:\n  cache-memory: true\n---\n",
+        ).unwrap();
+        let exts = super::super::extensions::collect_extensions(&fm);
+        let result = generate_prepare_steps(&[], &exts);
         assert!(
             !result.is_empty(),
-            "memory steps must be emitted when has_memory=true"
+            "memory steps must be emitted when cache-memory enabled"
         );
         assert!(
             result.contains("agent_memory"),
@@ -2132,13 +1949,19 @@ mod tests {
 
     #[test]
     fn test_generate_prepare_steps_without_memory_and_no_steps_is_empty() {
-        let result = generate_prepare_steps(&[], false, None);
+        let fm = minimal_front_matter();
+        let exts = super::super::extensions::collect_extensions(&fm);
+        let result = generate_prepare_steps(&[], &exts);
         assert!(result.is_empty(), "no steps and no memory should produce empty output");
     }
 
     #[test]
     fn test_generate_prepare_steps_with_memory_includes_download_and_prompt() {
-        let result = generate_prepare_steps(&[], true, None);
+        let (fm, _) = crate::compile::common::parse_markdown(
+            "---\nname: test\ndescription: test\ntools:\n  cache-memory: true\n---\n",
+        ).unwrap();
+        let exts = super::super::extensions::collect_extensions(&fm);
+        let result = generate_prepare_steps(&[], &exts);
         assert!(
             result.contains("DownloadPipelineArtifact"),
             "memory steps must include the artifact download task"
@@ -2151,23 +1974,27 @@ mod tests {
 
     #[test]
     fn test_generate_prepare_steps_without_memory_with_user_steps() {
-        // User-supplied prepare steps without memory should be included as-is
+        let fm = minimal_front_matter();
+        let exts = super::super::extensions::collect_extensions(&fm);
         let step: serde_yaml::Value =
             serde_yaml::from_str("bash: echo hello\ndisplayName: greet").unwrap();
-        let result = generate_prepare_steps(&[step], false, None);
+        let result = generate_prepare_steps(&[step], &exts);
         assert!(!result.is_empty(), "user steps should be present");
         assert!(
             !result.contains("agent_memory"),
-            "no memory reference when has_memory=false"
+            "no memory reference when cache-memory not enabled"
         );
     }
 
     #[test]
     fn test_generate_prepare_steps_with_memory_and_user_steps() {
-        // When memory is enabled AND user steps are present, both should appear
+        let (fm, _) = crate::compile::common::parse_markdown(
+            "---\nname: test\ndescription: test\ntools:\n  cache-memory: true\n---\n",
+        ).unwrap();
+        let exts = super::super::extensions::collect_extensions(&fm);
         let step: serde_yaml::Value =
             serde_yaml::from_str("bash: echo hello\ndisplayName: greet").unwrap();
-        let result = generate_prepare_steps(&[step], true, None);
+        let result = generate_prepare_steps(&[step], &exts);
         assert!(
             result.contains("agent_memory"),
             "memory reference must be present"
@@ -2180,9 +2007,11 @@ mod tests {
 
     #[test]
     fn test_generate_prepare_steps_with_lean() {
-        use crate::runtimes::lean::LeanRuntimeConfig;
-        let lean = LeanRuntimeConfig::Enabled(true);
-        let result = generate_prepare_steps(&[], false, Some(&lean));
+        let (fm, _) = crate::compile::common::parse_markdown(
+            "---\nname: test\ndescription: test\nruntimes:\n  lean: true\n---\n",
+        ).unwrap();
+        let exts = super::super::extensions::collect_extensions(&fm);
+        let result = generate_prepare_steps(&[], &exts);
         assert!(result.contains("elan-init.sh"), "should include elan installer");
         assert!(result.contains("Lean 4"), "should include Lean prompt");
         assert!(result.contains("--default-toolchain stable"), "should default to stable");
@@ -2191,11 +2020,11 @@ mod tests {
 
     #[test]
     fn test_generate_prepare_steps_with_lean_custom_toolchain() {
-        use crate::runtimes::lean::{LeanRuntimeConfig, LeanOptions};
-        let lean = LeanRuntimeConfig::WithOptions(LeanOptions {
-            toolchain: Some("leanprover/lean4:v4.29.1".to_string()),
-        });
-        let result = generate_prepare_steps(&[], false, Some(&lean));
+        let (fm, _) = crate::compile::common::parse_markdown(
+            "---\nname: test\ndescription: test\nruntimes:\n  lean:\n    toolchain: \"leanprover/lean4:v4.29.1\"\n---\n",
+        ).unwrap();
+        let exts = super::super::extensions::collect_extensions(&fm);
+        let result = generate_prepare_steps(&[], &exts);
         assert!(
             result.contains("--default-toolchain leanprover/lean4:v4.29.1"),
             "should use specified toolchain"
@@ -2204,9 +2033,11 @@ mod tests {
 
     #[test]
     fn test_generate_prepare_steps_with_lean_and_memory() {
-        use crate::runtimes::lean::LeanRuntimeConfig;
-        let lean = LeanRuntimeConfig::Enabled(true);
-        let result = generate_prepare_steps(&[], true, Some(&lean));
+        let (fm, _) = crate::compile::common::parse_markdown(
+            "---\nname: test\ndescription: test\nruntimes:\n  lean: true\ntools:\n  cache-memory: true\n---\n",
+        ).unwrap();
+        let exts = super::super::extensions::collect_extensions(&fm);
+        let result = generate_prepare_steps(&[], &exts);
         assert!(result.contains("agent_memory"), "memory steps present");
         assert!(result.contains("elan-init.sh"), "lean install present");
         assert!(result.contains("Lean 4"), "lean prompt present");

--- a/src/compile/standalone.rs
+++ b/src/compile/standalone.rs
@@ -131,7 +131,7 @@ impl Compiler for StandaloneCompiler {
         let parameters = build_parameters(&front_matter.parameters, has_memory);
         let parameters_yaml = generate_parameters(&parameters)?;
 
-        let prepare_steps = generate_prepare_steps(&front_matter.steps, &extensions);
+        let prepare_steps = generate_prepare_steps(&front_matter.steps, &extensions)?;
         let finalize_steps = generate_finalize_steps(&front_matter.post_steps);
         let agentic_depends_on = generate_agentic_depends_on(&front_matter.setup);
         let job_timeout = generate_job_timeout(front_matter);
@@ -447,7 +447,7 @@ fn generate_teardown_job(
 fn generate_prepare_steps(
     prepare_steps: &[serde_yaml::Value],
     extensions: &[super::extensions::Extension],
-) -> String {
+) -> Result<String> {
     let mut parts = Vec::new();
 
     // Extension prepare steps and prompt supplements (runtimes + first-party tools)
@@ -456,7 +456,7 @@ fn generate_prepare_steps(
             parts.push(step);
         }
         if let Some(prompt) = ext.prompt_supplement() {
-            parts.push(super::extensions::wrap_prompt_append(&prompt, ext.name()));
+            parts.push(super::extensions::wrap_prompt_append(&prompt, ext.name())?);
         }
     }
 
@@ -464,7 +464,7 @@ fn generate_prepare_steps(
         parts.push(common::format_steps_yaml_indented(prepare_steps, 0));
     }
 
-    parts.join("\n\n")
+    Ok(parts.join("\n\n"))
 }
 
 /// Generate finalize steps (inline)
@@ -1936,7 +1936,7 @@ mod tests {
             "---\nname: test\ndescription: test\ntools:\n  cache-memory: true\n---\n",
         ).unwrap();
         let exts = super::super::extensions::collect_extensions(&fm);
-        let result = generate_prepare_steps(&[], &exts);
+        let result = generate_prepare_steps(&[], &exts).unwrap();
         assert!(
             !result.is_empty(),
             "memory steps must be emitted when cache-memory enabled"
@@ -1951,7 +1951,7 @@ mod tests {
     fn test_generate_prepare_steps_without_memory_and_no_steps_is_empty() {
         let fm = minimal_front_matter();
         let exts = super::super::extensions::collect_extensions(&fm);
-        let result = generate_prepare_steps(&[], &exts);
+        let result = generate_prepare_steps(&[], &exts).unwrap();
         assert!(result.is_empty(), "no steps and no memory should produce empty output");
     }
 
@@ -1961,7 +1961,7 @@ mod tests {
             "---\nname: test\ndescription: test\ntools:\n  cache-memory: true\n---\n",
         ).unwrap();
         let exts = super::super::extensions::collect_extensions(&fm);
-        let result = generate_prepare_steps(&[], &exts);
+        let result = generate_prepare_steps(&[], &exts).unwrap();
         assert!(
             result.contains("DownloadPipelineArtifact"),
             "memory steps must include the artifact download task"
@@ -1978,7 +1978,7 @@ mod tests {
         let exts = super::super::extensions::collect_extensions(&fm);
         let step: serde_yaml::Value =
             serde_yaml::from_str("bash: echo hello\ndisplayName: greet").unwrap();
-        let result = generate_prepare_steps(&[step], &exts);
+        let result = generate_prepare_steps(&[step], &exts).unwrap();
         assert!(!result.is_empty(), "user steps should be present");
         assert!(
             !result.contains("agent_memory"),
@@ -1994,7 +1994,7 @@ mod tests {
         let exts = super::super::extensions::collect_extensions(&fm);
         let step: serde_yaml::Value =
             serde_yaml::from_str("bash: echo hello\ndisplayName: greet").unwrap();
-        let result = generate_prepare_steps(&[step], &exts);
+        let result = generate_prepare_steps(&[step], &exts).unwrap();
         assert!(
             result.contains("agent_memory"),
             "memory reference must be present"
@@ -2011,7 +2011,7 @@ mod tests {
             "---\nname: test\ndescription: test\nruntimes:\n  lean: true\n---\n",
         ).unwrap();
         let exts = super::super::extensions::collect_extensions(&fm);
-        let result = generate_prepare_steps(&[], &exts);
+        let result = generate_prepare_steps(&[], &exts).unwrap();
         assert!(result.contains("elan-init.sh"), "should include elan installer");
         assert!(result.contains("Lean 4"), "should include Lean prompt");
         assert!(result.contains("--default-toolchain stable"), "should default to stable");
@@ -2024,7 +2024,7 @@ mod tests {
             "---\nname: test\ndescription: test\nruntimes:\n  lean:\n    toolchain: \"leanprover/lean4:v4.29.1\"\n---\n",
         ).unwrap();
         let exts = super::super::extensions::collect_extensions(&fm);
-        let result = generate_prepare_steps(&[], &exts);
+        let result = generate_prepare_steps(&[], &exts).unwrap();
         assert!(
             result.contains("--default-toolchain leanprover/lean4:v4.29.1"),
             "should use specified toolchain"
@@ -2037,7 +2037,7 @@ mod tests {
             "---\nname: test\ndescription: test\nruntimes:\n  lean: true\ntools:\n  cache-memory: true\n---\n",
         ).unwrap();
         let exts = super::super::extensions::collect_extensions(&fm);
-        let result = generate_prepare_steps(&[], &exts);
+        let result = generate_prepare_steps(&[], &exts).unwrap();
         assert!(result.contains("agent_memory"), "memory steps present");
         assert!(result.contains("elan-init.sh"), "lean install present");
         assert!(result.contains("Lean 4"), "lean prompt present");


### PR DESCRIPTION
## Summary

Introduces a `CompilerExtension` trait that runtimes and first-party tools implement to declare their compilation requirements. Replaces scattered special-case `if` blocks across the compiler with a single generic collection loop.

### Problem

Adding a new runtime or tool required touching 5+ files with bespoke integration code:
- `standalone.rs` — network hosts, MCPG config, prepare steps, prompt injection
- `common.rs` — bash command allowlist
- `allowed_hosts.rs` — domain declarations
- `types.rs` — config structs

### Solution

A unified `CompilerExtension` trait (`src/compile/extensions.rs`) with methods:

| Method | Purpose |
|--------|---------|
| `required_hosts()` | AWF network allowlist |
| `required_bash_commands()` | `--allow-tool shell(cmd)` flags |
| `prompt_supplement()` | Agent prompt markdown sections |
| `prepare_steps()` | Pipeline steps (install, download) |
| `mcpg_servers()` | MCPG server entries |
| `validate()` | Compile-time warnings/errors |

### Extensions implemented

- **`LeanExtension`** — hosts, bash cmds (lean/lake/elan), install steps, prompt, bash-disabled warning
- **`AzureDevOpsExtension`** — hosts, MCPG container entry (with org inference), duplicate MCP warning  
- **`CacheMemoryExtension`** — download/restore steps, prompt supplement

### Adding a new runtime or tool

1. Implement `CompilerExtension` for your config struct
2. Add a collection check in `collect_extensions()`

No other files need modification.

### Regression testing

Built v0.11.0 baseline and compared pipeline YAML output:

| Example | Result |
|---------|--------|
| `sample-agent.md` (no extensions) | Byte-identical ✅ |
| `lean-verifier.md` (Lean + cache-memory) | Functionally identical ✅ (cosmetic: extension ordering, heredoc delimiter names) |

### Changes

- **New**: `src/compile/extensions.rs` (trait, 3 impls, MCPG types, 19 tests)
- **Modified**: `standalone.rs` (−180 lines of special-case code → generic loops)
- **Modified**: `common.rs` (`generate_copilot_params` accepts extensions)
- **Modified**: `onees.rs` (passes extensions to `generate_copilot_params`)
- **Modified**: `AGENTS.md` (updated developer docs)
