### PR TITLE
refactor: redesign CompileContext with rich metadata and async constructor

### DIFF
--- a/src/compile/extensions.rs
+++ b/src/compile/extensions.rs
@@ -99,8 +99,6 @@ pub struct CompileContext<'a> {
     /// ADO context inferred from the git remote (org URL, project, repo name).
     /// `None` if the compile directory has no ADO remote.
     pub ado_context: Option<AdoContext>,
-    /// Directory containing the input file (for relative path resolution).
-    pub compile_dir: &'a Path,
 }
 
 impl<'a> CompileContext<'a> {
@@ -108,25 +106,21 @@ impl<'a> CompileContext<'a> {
     ///
     /// Infers ADO context from the git remote in `compile_dir`. This is
     /// async because it shells out to `git remote get-url origin`.
-    pub async fn new(front_matter: &'a FrontMatter, compile_dir: &'a Path) -> Self {
+    pub async fn new(front_matter: &'a FrontMatter, compile_dir: &Path) -> Self {
         let ado_context = Self::infer_ado_context(compile_dir).await;
         Self {
             agent_name: &front_matter.name,
             front_matter,
             ado_context,
-            compile_dir,
         }
     }
 
     /// Convenience accessor: extract the ADO org name from the inferred context.
     pub fn ado_org(&self) -> Option<&str> {
-        self.ado_context.as_ref().map(|ctx| {
-            ctx.org_url
-                .trim_end_matches('/')
-                .rsplit('/')
-                .next()
-                .unwrap_or("")
-        }).filter(|org| !org.is_empty())
+        self.ado_context.as_ref().and_then(|ctx| {
+            let org = ctx.org_url.trim_end_matches('/').rsplit('/').next()?;
+            if org.is_empty() { None } else { Some(org) }
+        })
     }
 
     async fn infer_ado_context(dir: &Path) -> Option<AdoContext> {
@@ -162,7 +156,6 @@ impl<'a> CompileContext<'a> {
             agent_name: &front_matter.name,
             front_matter,
             ado_context: None,
-            compile_dir: Path::new("."),
         }
     }
 
@@ -177,7 +170,6 @@ impl<'a> CompileContext<'a> {
                 project: "test-project".to_string(),
                 repo_name: "test-repo".to_string(),
             }),
-            compile_dir: Path::new("."),
         }
     }
 }

--- a/src/compile/extensions.rs
+++ b/src/compile/extensions.rs
@@ -82,15 +82,104 @@ pub struct McpgConfig {
 // Compile context
 // ──────────────────────────────────────────────────────────────────────
 
-/// Shared context passed to extension methods that need cross-cutting information.
+use crate::configure::AdoContext;
+use std::path::Path;
+
+/// Metadata resolved at compile time from the local environment.
+///
+/// Built once via [`CompileContext::new`] and passed to all extension
+/// methods. Follows the same pattern as
+/// [`ExecutionContext`](crate::safeoutputs::result::ExecutionContext)
+/// for Stage 2 — a single context struct with all resolved metadata.
 pub struct CompileContext<'a> {
     /// The agent name from front matter.
     pub agent_name: &'a str,
     /// The full front matter (for cross-cutting checks like bash access level).
     pub front_matter: &'a FrontMatter,
-    /// ADO org inferred from the git remote at compile time. Used by
-    /// `AzureDevOpsExtension` when no explicit `org:` is provided.
-    pub inferred_org: Option<&'a str>,
+    /// ADO context inferred from the git remote (org URL, project, repo name).
+    /// `None` if the compile directory has no ADO remote.
+    pub ado_context: Option<AdoContext>,
+    /// Directory containing the input file (for relative path resolution).
+    pub compile_dir: &'a Path,
+}
+
+impl<'a> CompileContext<'a> {
+    /// Build a fully-resolved compile context.
+    ///
+    /// Infers ADO context from the git remote in `compile_dir`. This is
+    /// async because it shells out to `git remote get-url origin`.
+    pub async fn new(front_matter: &'a FrontMatter, compile_dir: &'a Path) -> Self {
+        let ado_context = Self::infer_ado_context(compile_dir).await;
+        Self {
+            agent_name: &front_matter.name,
+            front_matter,
+            ado_context,
+            compile_dir,
+        }
+    }
+
+    /// Convenience accessor: extract the ADO org name from the inferred context.
+    pub fn ado_org(&self) -> Option<&str> {
+        self.ado_context.as_ref().map(|ctx| {
+            ctx.org_url
+                .trim_end_matches('/')
+                .rsplit('/')
+                .next()
+                .unwrap_or("")
+        }).filter(|org| !org.is_empty())
+    }
+
+    async fn infer_ado_context(dir: &Path) -> Option<AdoContext> {
+        match crate::configure::get_git_remote_url(dir).await {
+            Ok(url) => match crate::configure::parse_ado_remote(&url) {
+                Ok(ctx) => {
+                    log::info!(
+                        "Inferred ADO org from git remote: {}",
+                        ctx.org_url
+                            .trim_end_matches('/')
+                            .rsplit('/')
+                            .next()
+                            .unwrap_or("?")
+                    );
+                    Some(ctx)
+                }
+                Err(_) => {
+                    log::debug!("Git remote is not an ADO URL — cannot infer org");
+                    None
+                }
+            },
+            Err(_) => {
+                log::debug!("No git remote found — cannot infer ADO context");
+                None
+            }
+        }
+    }
+
+    /// Create a context for tests (no async, no git remote inference).
+    #[cfg(test)]
+    pub fn for_test(front_matter: &'a FrontMatter) -> Self {
+        Self {
+            agent_name: &front_matter.name,
+            front_matter,
+            ado_context: None,
+            compile_dir: Path::new("."),
+        }
+    }
+
+    /// Create a context for tests with a specific ADO org.
+    #[cfg(test)]
+    pub fn for_test_with_org(front_matter: &'a FrontMatter, org: &str) -> Self {
+        Self {
+            agent_name: &front_matter.name,
+            front_matter,
+            ado_context: Some(AdoContext {
+                org_url: format!("https://dev.azure.com/{}", org),
+                project: "test-project".to_string(),
+                repo_name: "test-repo".to_string(),
+            }),
+            compile_dir: Path::new("."),
+        }
+    }
 }
 
 // ──────────────────────────────────────────────────────────────────────
@@ -169,12 +258,6 @@ pub trait CompilerExtension {
     /// Compile-time warnings to emit. Errors in the `Result` abort
     /// compilation; the inner `Vec<String>` contains non-fatal warnings
     /// printed to stderr.
-    ///
-    /// **Note:** `validate` is called early in compilation before
-    /// `inferred_org` is available (it requires an async git remote
-    /// lookup). Org-dependent validation (e.g., verifying an ADO org
-    /// can be resolved) should go in [`mcpg_servers`](Self::mcpg_servers)
-    /// instead, which receives the fully populated [`CompileContext`].
     fn validate(&self, _ctx: &CompileContext) -> Result<Vec<String>> {
         Ok(vec![])
     }
@@ -371,19 +454,20 @@ impl CompilerExtension for AzureDevOpsExtension {
         // Build entrypoint args: npx -y @azure-devops/mcp <org> [-d toolset1 toolset2 ...]
         let mut entrypoint_args = vec!["-y".to_string(), ADO_MCP_PACKAGE.to_string()];
 
-        // Org: use explicit override, then compile-time inferred, then fail
-        let org = if let Some(explicit) = self.config.org() {
-            explicit.to_string()
-        } else if let Some(inferred) = ctx.inferred_org {
-            inferred.to_string()
-        } else {
-            anyhow::bail!(
-                "Agent '{}' has tools.azure-devops enabled but no ADO organization could be \
-                 determined. Either set tools.azure-devops.org explicitly, or compile from \
-                 within a git repository with an Azure DevOps remote URL.",
-                ctx.agent_name
-            );
-        };
+        // Org: use explicit override, then inferred from git remote, then fail
+        let org = self
+            .config
+            .org()
+            .map(|s| s.to_string())
+            .or_else(|| ctx.ado_org().map(|s| s.to_string()))
+            .ok_or_else(|| {
+                anyhow::anyhow!(
+                    "Agent '{}' has tools.azure-devops enabled but no ADO organization could be \
+                     determined. Either set tools.azure-devops.org explicitly, or compile from \
+                     within a git repository with an Azure DevOps remote URL.",
+                    ctx.agent_name
+                )
+            })?;
         if !org.chars().all(|c| c.is_ascii_alphanumeric() || c == '-') {
             anyhow::bail!(
                 "Invalid ADO org name '{}': must contain only alphanumerics and hyphens",
@@ -678,11 +762,7 @@ mod tests {
     }
 
     fn ctx_from(fm: &FrontMatter) -> CompileContext<'_> {
-        CompileContext {
-            agent_name: &fm.name,
-            front_matter: fm,
-            inferred_org: None,
-        }
+        CompileContext::for_test(fm)
     }
 
     // ── collect_extensions ──────────────────────────────────────────
@@ -849,11 +929,7 @@ mod tests {
     #[test]
     fn test_ado_mcpg_servers_with_inferred_org() {
         let fm = minimal_front_matter();
-        let ctx = CompileContext {
-            agent_name: &fm.name,
-            front_matter: &fm,
-            inferred_org: Some("myorg"),
-        };
+        let ctx = CompileContext::for_test_with_org(&fm, "myorg");
         let ext = AzureDevOpsExtension::new(AzureDevOpsToolConfig::Enabled(true));
         let servers = ext.mcpg_servers(&ctx).unwrap();
         assert_eq!(servers.len(), 1);
@@ -870,11 +946,7 @@ mod tests {
     #[test]
     fn test_ado_mcpg_servers_no_org_fails() {
         let fm = minimal_front_matter();
-        let ctx = CompileContext {
-            agent_name: &fm.name,
-            front_matter: &fm,
-            inferred_org: None,
-        };
+        let ctx = CompileContext::for_test(&fm);
         let ext = AzureDevOpsExtension::new(AzureDevOpsToolConfig::Enabled(true));
         assert!(ext.mcpg_servers(&ctx).is_err());
     }

--- a/src/compile/onees.rs
+++ b/src/compile/onees.rs
@@ -67,17 +67,14 @@ impl Compiler for OneESCompiler {
         let checkout_self = generate_checkout_self();
         let extensions = super::extensions::collect_extensions(front_matter);
 
+        // Build compile context with inferred metadata
+        let input_dir = input_path.parent().unwrap_or(std::path::Path::new("."));
+        let ctx = super::extensions::CompileContext::new(front_matter, input_dir).await;
+
         // Run extension validations (warnings + errors)
-        {
-            let validation_ctx = super::extensions::CompileContext {
-                agent_name: &front_matter.name,
-                front_matter,
-                inferred_org: None,
-            };
-            for ext in &extensions {
-                for warning in ext.validate(&validation_ctx)? {
-                    eprintln!("Warning: {}", warning);
-                }
+        for ext in &extensions {
+            for warning in ext.validate(&ctx)? {
+                eprintln!("Warning: {}", warning);
             }
         }
 

--- a/src/compile/standalone.rs
+++ b/src/compile/standalone.rs
@@ -70,17 +70,14 @@ impl Compiler for StandaloneCompiler {
         // Collect compiler extensions (runtimes + first-party tools)
         let extensions = super::extensions::collect_extensions(front_matter);
 
+        // Build compile context with inferred metadata (ADO org from git remote, etc.)
+        let input_dir = input_path.parent().unwrap_or(std::path::Path::new("."));
+        let ctx = super::extensions::CompileContext::new(front_matter, input_dir).await;
+
         // Run extension validations (warnings + errors)
-        {
-            let validation_ctx = super::extensions::CompileContext {
-                agent_name: &front_matter.name,
-                front_matter,
-                inferred_org: None, // Not yet available; ADO org validation happens in mcpg_servers()
-            };
-            for ext in &extensions {
-                for warning in ext.validate(&validation_ctx)? {
-                    eprintln!("Warning: {}", warning);
-                }
+        for ext in &extensions {
+            for warning in ext.validate(&ctx)? {
+                eprintln!("Warning: {}", warning);
             }
         }
 
@@ -234,48 +231,9 @@ impl Compiler for StandaloneCompiler {
                 replace_with_indent(&yaml, placeholder, replacement)
             });
 
-        // Infer ADO org from git remote at compile time (for tools.azure-devops)
-        let inferred_org = if front_matter
-            .tools
-            .as_ref()
-            .and_then(|t| t.azure_devops.as_ref())
-            .is_some_and(|ado| ado.is_enabled() && ado.org().is_none())
-        {
-            let input_dir = input_path.parent().unwrap_or(std::path::Path::new("."));
-            match crate::configure::get_git_remote_url(input_dir).await {
-                Ok(url) => match crate::configure::parse_ado_remote(&url) {
-                    Ok(ctx) => {
-                        let org = ctx
-                            .org_url
-                            .trim_end_matches('/')
-                            .rsplit('/')
-                            .next()
-                            .unwrap_or("")
-                            .to_string();
-                        if org.is_empty() {
-                            None
-                        } else {
-                            info!("Inferred ADO org '{}' from git remote", org);
-                            Some(org)
-                        }
-                    }
-                    Err(_) => {
-                        log::debug!("Git remote is not an ADO URL — cannot infer org");
-                        None
-                    }
-                },
-                Err(_) => {
-                    log::debug!("No git remote found — cannot infer org");
-                    None
-                }
-            }
-        } else {
-            None
-        };
-
         // Always generate MCPG config — safeoutputs is always required regardless
         // of whether additional mcp-servers are configured in front matter.
-        let config = generate_mcpg_config(front_matter, inferred_org.as_deref(), &extensions)?;
+        let config = generate_mcpg_config(front_matter, &ctx, &extensions)?;
         let mcpg_config_json =
             serde_json::to_string_pretty(&config).context("Failed to serialize MCPG config")?;
 
@@ -488,18 +446,11 @@ fn generate_agentic_depends_on(setup_steps: &[serde_yaml::Value]) -> String {
 /// Generate MCPG configuration from front matter.
 ///
 /// Converts the front matter `mcp-servers` definitions into MCPG-compatible JSON.
-/// SafeOutputs is always included as an HTTP backend. Custom MCPs with explicit
-/// `command:` are included as stdio servers.
-///
-/// `inferred_org` is the ADO organization name extracted from the git remote URL
-/// at compile time. Used as the default org for `tools.azure-devops` when no
-/// explicit `org:` override is provided.
-///
-/// Returns an error if `tools.azure-devops` is enabled but no org can be determined
-/// (neither explicit override nor git remote inference).
+/// SafeOutputs is always included as an HTTP backend. Extension-contributed MCPG
+/// entries (e.g., azure-devops) are included via the `extensions` parameter.
 pub fn generate_mcpg_config(
     front_matter: &FrontMatter,
-    inferred_org: Option<&str>,
+    ctx: &super::extensions::CompileContext,
     extensions: &[super::extensions::Extension],
 ) -> Result<McpgConfig> {
     let mut mcp_servers = HashMap::new();
@@ -528,13 +479,8 @@ pub fn generate_mcpg_config(
     );
 
     // Add extension-contributed MCPG server entries (e.g., azure-devops)
-    let ctx = super::extensions::CompileContext {
-        agent_name: &front_matter.name,
-        front_matter,
-        inferred_org,
-    };
     for ext in extensions {
-        for (name, config) in ext.mcpg_servers(&ctx)? {
+        for (name, config) in ext.mcpg_servers(ctx)? {
             mcp_servers.insert(name, config);
         }
     }
@@ -985,7 +931,7 @@ mod tests {
                 ..Default::default()
             }),
         );
-        let config = generate_mcpg_config(&fm, None, &super::super::extensions::collect_extensions(&fm)).unwrap();
+        let config = generate_mcpg_config(&fm, &super::super::extensions::CompileContext::for_test(&fm), &super::super::extensions::collect_extensions(&fm)).unwrap();
         let server = config.mcp_servers.get("my-tool").unwrap();
         assert_eq!(server.server_type, "stdio");
         assert_eq!(server.container.as_ref().unwrap(), "node:20-slim");
@@ -1006,7 +952,7 @@ mod tests {
         // An MCP with no container or url should be skipped
         fm.mcp_servers
             .insert("phantom".to_string(), McpConfig::Enabled(true));
-        let config = generate_mcpg_config(&fm, None, &super::super::extensions::collect_extensions(&fm)).unwrap();
+        let config = generate_mcpg_config(&fm, &super::super::extensions::CompileContext::for_test(&fm), &super::super::extensions::collect_extensions(&fm)).unwrap();
         assert!(!config.mcp_servers.contains_key("phantom"));
         // safeoutputs is always present
         assert!(config.mcp_servers.contains_key("safeoutputs"));
@@ -1017,14 +963,14 @@ mod tests {
         let mut fm = minimal_front_matter();
         fm.mcp_servers
             .insert("my-tool".to_string(), McpConfig::Enabled(false));
-        let config = generate_mcpg_config(&fm, None, &super::super::extensions::collect_extensions(&fm)).unwrap();
+        let config = generate_mcpg_config(&fm, &super::super::extensions::CompileContext::for_test(&fm), &super::super::extensions::collect_extensions(&fm)).unwrap();
         assert!(!config.mcp_servers.contains_key("my-tool"));
     }
 
     #[test]
     fn test_generate_mcpg_config_empty_mcp_servers() {
         let fm = minimal_front_matter();
-        let config = generate_mcpg_config(&fm, None, &super::super::extensions::collect_extensions(&fm)).unwrap();
+        let config = generate_mcpg_config(&fm, &super::super::extensions::CompileContext::for_test(&fm), &super::super::extensions::collect_extensions(&fm)).unwrap();
         // Only safeoutputs should be present
         assert_eq!(config.mcp_servers.len(), 1);
         assert!(config.mcp_servers.contains_key("safeoutputs"));
@@ -1033,7 +979,7 @@ mod tests {
     #[test]
     fn test_generate_mcpg_config_gateway_defaults() {
         let fm = minimal_front_matter();
-        let config = generate_mcpg_config(&fm, None, &super::super::extensions::collect_extensions(&fm)).unwrap();
+        let config = generate_mcpg_config(&fm, &super::super::extensions::CompileContext::for_test(&fm), &super::super::extensions::collect_extensions(&fm)).unwrap();
         assert_eq!(config.gateway.port, 80);
         assert_eq!(config.gateway.domain, "host.docker.internal");
         assert_eq!(config.gateway.api_key, "${MCP_GATEWAY_API_KEY}");
@@ -1053,7 +999,7 @@ mod tests {
                 ..Default::default()
             }),
         );
-        let config = generate_mcpg_config(&fm, None, &super::super::extensions::collect_extensions(&fm)).unwrap();
+        let config = generate_mcpg_config(&fm, &super::super::extensions::CompileContext::for_test(&fm), &super::super::extensions::collect_extensions(&fm)).unwrap();
         let json = serde_json::to_string_pretty(&config).expect("Config should serialize to JSON");
         let parsed: serde_json::Value =
             serde_json::from_str(&json).expect("Serialized JSON should parse back");
@@ -1078,7 +1024,7 @@ mod tests {
     #[test]
     fn test_generate_mcpg_config_safeoutputs_variable_placeholders() {
         let fm = minimal_front_matter();
-        let config = generate_mcpg_config(&fm, None, &super::super::extensions::collect_extensions(&fm)).unwrap();
+        let config = generate_mcpg_config(&fm, &super::super::extensions::CompileContext::for_test(&fm), &super::super::extensions::collect_extensions(&fm)).unwrap();
         let so = config.mcp_servers.get("safeoutputs").unwrap();
 
         // URL should reference the runtime-substituted port
@@ -1100,7 +1046,7 @@ mod tests {
     #[test]
     fn test_generate_mcpg_config_safeoutputs_is_http_type() {
         let fm = minimal_front_matter();
-        let config = generate_mcpg_config(&fm, None, &super::super::extensions::collect_extensions(&fm)).unwrap();
+        let config = generate_mcpg_config(&fm, &super::super::extensions::CompileContext::for_test(&fm), &super::super::extensions::collect_extensions(&fm)).unwrap();
         let so = config.mcp_servers.get("safeoutputs").unwrap();
         assert_eq!(so.server_type, "http");
         assert!(
@@ -1124,7 +1070,7 @@ mod tests {
                 ..Default::default()
             }),
         );
-        let config = generate_mcpg_config(&fm, None, &super::super::extensions::collect_extensions(&fm)).unwrap();
+        let config = generate_mcpg_config(&fm, &super::super::extensions::CompileContext::for_test(&fm), &super::super::extensions::collect_extensions(&fm)).unwrap();
         let srv = config.mcp_servers.get("runner").unwrap();
         assert_eq!(srv.server_type, "stdio");
         assert!(
@@ -1147,7 +1093,7 @@ mod tests {
                 ..Default::default()
             }),
         );
-        let config = generate_mcpg_config(&fm, None, &super::super::extensions::collect_extensions(&fm)).unwrap();
+        let config = generate_mcpg_config(&fm, &super::super::extensions::CompileContext::for_test(&fm), &super::super::extensions::collect_extensions(&fm)).unwrap();
         let srv = config.mcp_servers.get("with-env").unwrap();
         let e = srv.env.as_ref().unwrap();
         assert_eq!(e.get("TOKEN").unwrap(), "secret");
@@ -1163,7 +1109,7 @@ mod tests {
                 ..Default::default()
             }),
         );
-        let config = generate_mcpg_config(&fm, None, &super::super::extensions::collect_extensions(&fm)).unwrap();
+        let config = generate_mcpg_config(&fm, &super::super::extensions::CompileContext::for_test(&fm), &super::super::extensions::collect_extensions(&fm)).unwrap();
         // The reserved entry should still be the HTTP backend, not the user's container
         let so = config.mcp_servers.get("safeoutputs").unwrap();
         assert_eq!(
@@ -1189,7 +1135,7 @@ mod tests {
                 ..Default::default()
             }),
         );
-        let config = generate_mcpg_config(&fm, None, &super::super::extensions::collect_extensions(&fm)).unwrap();
+        let config = generate_mcpg_config(&fm, &super::super::extensions::CompileContext::for_test(&fm), &super::super::extensions::collect_extensions(&fm)).unwrap();
         // The user-defined "SafeOutputs" must not overwrite the built-in entry
         let so = config.mcp_servers.get("safeoutputs").unwrap();
         assert_eq!(so.server_type, "http");
@@ -1214,7 +1160,7 @@ mod tests {
                 ..Default::default()
             }),
         );
-        let config = generate_mcpg_config(&fm, None, &super::super::extensions::collect_extensions(&fm)).unwrap();
+        let config = generate_mcpg_config(&fm, &super::super::extensions::CompileContext::for_test(&fm), &super::super::extensions::collect_extensions(&fm)).unwrap();
         let srv = config.mcp_servers.get("remote").unwrap();
         assert_eq!(srv.server_type, "http");
         assert_eq!(
@@ -1240,7 +1186,7 @@ mod tests {
                 ..Default::default()
             }),
         );
-        let config = generate_mcpg_config(&fm, None, &super::super::extensions::collect_extensions(&fm)).unwrap();
+        let config = generate_mcpg_config(&fm, &super::super::extensions::CompileContext::for_test(&fm), &super::super::extensions::collect_extensions(&fm)).unwrap();
         let srv = config.mcp_servers.get("ado").unwrap();
         assert_eq!(srv.server_type, "stdio");
         assert_eq!(srv.container.as_ref().unwrap(), "node:20-slim");
@@ -1262,7 +1208,7 @@ mod tests {
                 ..Default::default()
             }),
         );
-        let config = generate_mcpg_config(&fm, None, &super::super::extensions::collect_extensions(&fm)).unwrap();
+        let config = generate_mcpg_config(&fm, &super::super::extensions::CompileContext::for_test(&fm), &super::super::extensions::collect_extensions(&fm)).unwrap();
         let srv = config.mcp_servers.get("data-tool").unwrap();
         assert_eq!(
             srv.mounts.as_ref().unwrap(),
@@ -1281,7 +1227,7 @@ mod tests {
                 ..Default::default()
             }),
         );
-        let config = generate_mcpg_config(&fm, None, &super::super::extensions::collect_extensions(&fm)).unwrap();
+        let config = generate_mcpg_config(&fm, &super::super::extensions::CompileContext::for_test(&fm), &super::super::extensions::collect_extensions(&fm)).unwrap();
         assert!(!config.mcp_servers.contains_key("no-transport"));
     }
 
@@ -1449,7 +1395,7 @@ mod tests {
         )
         .unwrap();
         // Pass inferred org since no explicit org is set
-        let config = generate_mcpg_config(&fm, Some("inferred-org"), &super::super::extensions::collect_extensions(&fm)).unwrap();
+        let config = generate_mcpg_config(&fm, &super::super::extensions::CompileContext::for_test_with_org(&fm, "inferred-org"), &super::super::extensions::collect_extensions(&fm)).unwrap();
         let ado = config.mcp_servers.get("azure-devops").unwrap();
         assert_eq!(ado.server_type, "stdio");
         assert_eq!(ado.container.as_deref(), Some(ADO_MCP_IMAGE));
@@ -1469,7 +1415,7 @@ mod tests {
             "---\nname: test\ndescription: test\ntools:\n  azure-devops:\n    toolsets: [repos, wit, core]\n---\n",
         )
         .unwrap();
-        let config = generate_mcpg_config(&fm, Some("myorg"), &super::super::extensions::collect_extensions(&fm)).unwrap();
+        let config = generate_mcpg_config(&fm, &super::super::extensions::CompileContext::for_test_with_org(&fm, "myorg"), &super::super::extensions::collect_extensions(&fm)).unwrap();
         let ado = config.mcp_servers.get("azure-devops").unwrap();
         let args = ado.entrypoint_args.as_ref().unwrap();
         assert!(args.contains(&"-d".to_string()));
@@ -1485,7 +1431,7 @@ mod tests {
         )
         .unwrap();
         // Explicit org should be used even when inferred_org is None
-        let config = generate_mcpg_config(&fm, None, &super::super::extensions::collect_extensions(&fm)).unwrap();
+        let config = generate_mcpg_config(&fm, &super::super::extensions::CompileContext::for_test(&fm), &super::super::extensions::collect_extensions(&fm)).unwrap();
         let ado = config.mcp_servers.get("azure-devops").unwrap();
         let args = ado.entrypoint_args.as_ref().unwrap();
         assert!(args.contains(&"myorg".to_string()));
@@ -1497,7 +1443,7 @@ mod tests {
             "---\nname: test\ndescription: test\ntools:\n  azure-devops:\n    org: explicit-org\n---\n",
         )
         .unwrap();
-        let config = generate_mcpg_config(&fm, Some("inferred-org"), &super::super::extensions::collect_extensions(&fm)).unwrap();
+        let config = generate_mcpg_config(&fm, &super::super::extensions::CompileContext::for_test_with_org(&fm, "inferred-org"), &super::super::extensions::collect_extensions(&fm)).unwrap();
         let ado = config.mcp_servers.get("azure-devops").unwrap();
         let args = ado.entrypoint_args.as_ref().unwrap();
         assert!(args.contains(&"explicit-org".to_string()));
@@ -1511,7 +1457,7 @@ mod tests {
         )
         .unwrap();
         // No explicit org and no inferred org — should fail
-        let result = generate_mcpg_config(&fm, None, &super::super::extensions::collect_extensions(&fm));
+        let result = generate_mcpg_config(&fm, &super::super::extensions::CompileContext::for_test(&fm), &super::super::extensions::collect_extensions(&fm));
         assert!(result.is_err());
         assert!(
             result.unwrap_err().to_string().contains("no ADO organization"),
@@ -1525,7 +1471,7 @@ mod tests {
             "---\nname: test\ndescription: test\ntools:\n  azure-devops:\n    org: \"my org/bad\"\n---\n",
         )
         .unwrap();
-        let result = generate_mcpg_config(&fm, None, &super::super::extensions::collect_extensions(&fm));
+        let result = generate_mcpg_config(&fm, &super::super::extensions::CompileContext::for_test(&fm), &super::super::extensions::collect_extensions(&fm));
         assert!(result.is_err());
         assert!(
             result.unwrap_err().to_string().contains("Invalid ADO org name"),
@@ -1539,7 +1485,7 @@ mod tests {
             "---\nname: test\ndescription: test\ntools:\n  azure-devops:\n    org: myorg\n    toolsets: [\"repos\", \"bad toolset\"]\n---\n",
         )
         .unwrap();
-        let result = generate_mcpg_config(&fm, None, &super::super::extensions::collect_extensions(&fm));
+        let result = generate_mcpg_config(&fm, &super::super::extensions::CompileContext::for_test(&fm), &super::super::extensions::collect_extensions(&fm));
         assert!(result.is_err());
         assert!(
             result.unwrap_err().to_string().contains("Invalid ADO toolset name"),
@@ -1553,7 +1499,7 @@ mod tests {
             "---\nname: test\ndescription: test\ntools:\n  azure-devops:\n    org: myorg\n    allowed:\n      - wit_get_work_item\n      - core_list_projects\n---\n",
         )
         .unwrap();
-        let config = generate_mcpg_config(&fm, None, &super::super::extensions::collect_extensions(&fm)).unwrap();
+        let config = generate_mcpg_config(&fm, &super::super::extensions::CompileContext::for_test(&fm), &super::super::extensions::collect_extensions(&fm)).unwrap();
         let ado = config.mcp_servers.get("azure-devops").unwrap();
         let tools = ado.tools.as_ref().unwrap();
         assert_eq!(tools, &["wit_get_work_item", "core_list_projects"]);
@@ -1565,14 +1511,14 @@ mod tests {
             "---\nname: test\ndescription: test\ntools:\n  azure-devops: false\n---\n",
         )
         .unwrap();
-        let config = generate_mcpg_config(&fm, None, &super::super::extensions::collect_extensions(&fm)).unwrap();
+        let config = generate_mcpg_config(&fm, &super::super::extensions::CompileContext::for_test(&fm), &super::super::extensions::collect_extensions(&fm)).unwrap();
         assert!(!config.mcp_servers.contains_key("azure-devops"));
     }
 
     #[test]
     fn test_ado_tool_not_set_not_generated() {
         let fm = minimal_front_matter();
-        let config = generate_mcpg_config(&fm, None, &super::super::extensions::collect_extensions(&fm)).unwrap();
+        let config = generate_mcpg_config(&fm, &super::super::extensions::CompileContext::for_test(&fm), &super::super::extensions::collect_extensions(&fm)).unwrap();
         assert!(!config.mcp_servers.contains_key("azure-devops"));
     }
 
@@ -1584,7 +1530,7 @@ mod tests {
             "---\nname: test\ndescription: test\ntools:\n  azure-devops:\n    org: auto-org\nmcp-servers:\n  azure-devops:\n    container: \"node:20-slim\"\n    entrypoint: \"npx\"\n    entrypoint-args: [\"-y\", \"@azure-devops/mcp\", \"manual-org\"]\n---\n",
         )
         .unwrap();
-        let config = generate_mcpg_config(&fm, None, &super::super::extensions::collect_extensions(&fm)).unwrap();
+        let config = generate_mcpg_config(&fm, &super::super::extensions::CompileContext::for_test(&fm), &super::super::extensions::collect_extensions(&fm)).unwrap();
         let ado = config.mcp_servers.get("azure-devops").unwrap();
         // Should use the auto-configured org, not the manual one
         let args = ado.entrypoint_args.as_ref().unwrap();


### PR DESCRIPTION
## Summary

Redesigns `CompileContext` to follow the `ExecutionContext` pattern — a single struct built eagerly with all resolved metadata, passed uniformly to every extension method.

### Problem

`CompileContext.inferred_org` was:
- `None` at `validate()` time (not yet resolved)
- Only populated later when `generate_mcpg_config()` was called
- Resolved inline in `standalone.rs::compile()` as a 30-line block that was tightly coupled to the ADO extension

### Solution

```rust
pub struct CompileContext<'a> {
    pub agent_name: &'a str,
    pub front_matter: &'a FrontMatter,
    pub ado_context: Option<AdoContext>,  // was: inferred_org: Option<&str>
    pub compile_dir: &'a Path,         // new: for future path resolution
}
```

- `CompileContext::new().await` — async constructor that infers ADO context from git remote
- `ctx.ado_org()` — convenience accessor for the org name
- Built **once, early** in both `standalone.rs` and `onees.rs`
- All extension methods (`validate`, `mcpg_servers`) receive the same fully-populated context

### Changes

| File | Change |
|------|--------|
| `extensions.rs` | Expanded `CompileContext` with `ado_context`, `compile_dir`, `async fn new()`, test helpers |
| `standalone.rs` | Removed 30-line inline org inference block, builds context once early |
| `onees.rs` | Builds `CompileContext::new().await` (same as standalone) |

All 842 tests pass.
