### PR TITLE
fix: stale doc comment and unescaped service connection name

### DIFF
--- a/src/compile/common.rs
+++ b/src/compile/common.rs
@@ -81,8 +81,6 @@ pub fn replace_with_indent(template: &str, placeholder: &str, replacement: &str)
     result
 }
 
-/// Generate a schedule YAML block from a ScheduleConfig.
-/// When no explicit schedule branches are configured, defaults to `main`.
 /// Generate the top-level `parameters:` YAML block from front matter parameters.
 ///
 /// Returns a YAML block like:
@@ -898,7 +896,7 @@ pub fn generate_acquire_ado_token(service_connection: Option<&str>, variable_nam
                 r#"  displayName: "Acquire ADO token ({variable_name})""#
             ));
             lines.push("  inputs:".to_string());
-            lines.push(format!("    azureSubscription: '{}'", sc));
+            lines.push(format!("    azureSubscription: '{}'", sc.replace('\'', "''")));
             lines.push("    scriptType: 'bash'".to_string());
             lines.push("    scriptLocation: 'inlineScript'".to_string());
             lines.push("    addSpnToEnvironment: true".to_string());


### PR DESCRIPTION
Two small fixes:

1. **Stale doc comment** (`common.rs:84-85`): Removed orphaned `generate_schedule` doc lines that were accidentally prepended to the `generate_parameters()` doc comment.

2. **Service connection YAML escaping** (`common.rs:901`): The `azureSubscription` value in `generate_acquire_ado_token()` now escapes single quotes (`''` in YAML) to prevent malformed pipeline output if a service connection name contains a quote character.

Ref: issue #228 created for the separate `resolve-pr-thread` naming inconsistency.