### PR TITLE
fix: remove legacy service-connection MCP field

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1564,7 +1564,6 @@ mcp-servers:
 **Common (both types):**
 - `allowed:` - Array of tool names the agent is permitted to call (required for security)
 - `env:` - Environment variables for the MCP server process. Use `""` (empty string) for passthrough from the pipeline environment.
-- `service-connection:` - (1ES target only) Override the service connection name. Defaults to `mcp-<name>-service-connection`
 
 ### Environment Variable Passthrough
 

--- a/prompts/create-ado-agentic-workflow.md
+++ b/prompts/create-ado-agentic-workflow.md
@@ -174,7 +174,7 @@ target: 1es
 | Value | Generates |
 |---|---|
 | `standalone` | Full 3-job pipeline with AWF network sandbox and Squid proxy |
-| `1es` | Pipeline extending `1ES.Unofficial.PipelineTemplate.yml`; no custom proxy; MCPs via service connections |
+| `1es` | Pipeline extending `1ES.Unofficial.PipelineTemplate.yml`; no custom proxy; MCPs via MCPG |
 
 ### Step 8 — MCP Servers
 
@@ -217,9 +217,7 @@ mcp-servers:
 
 > **Security**: All `mcp-servers:` entries must have an explicit `allowed:` list.
 >
-> **Standalone target** (default): Only `mcp-servers:` entries with a `container:` or `url:` field are used. Entries without either field are silently skipped.
->
-> **1ES target**: Custom containerized MCPs are mapped to service connections. Use `tools: azure-devops:` for ADO integration on both targets.
+> **Standalone target** (the default): Built-in MCPs (entries without a `container:` or `url:` field) are silently skipped at compile time — they have no effect and will not be available to the agent. For the standalone target, use only **custom** containerized MCPs with a `container:` field.
 
 ### Step 9 — Safe Outputs
 
@@ -592,4 +590,3 @@ safe-outputs:
 - **No direct writes**: All mutations go through safe outputs — the agent cannot push code or call write APIs directly.
 - **Compile before committing**: Always compile with `ado-aw compile` and commit both the `.md` source and generated `.yml` together.
 - **Check validation**: The compiler will error if write safe-outputs are configured without `permissions.write`.
-- **1ES target limits**: No custom MCPs, no custom network allow-lists — these are handled by OneBranch infrastructure.

--- a/prompts/update-ado-agentic-workflow.md
+++ b/prompts/update-ado-agentic-workflow.md
@@ -250,7 +250,7 @@ Before finalizing any update, verify:
 
 6. **Network domains**: If new MCPs or external services are added, ensure required domains are in `network.allowed`.
 
-7. **Target compatibility**: If `target: 1es`, custom containerized MCPs (with `container:`) are not supported — use `mcp-servers:` entries mapped to service connections instead.
+7. **Target compatibility**: Both `standalone` and `1es` targets support containerized MCPs via MCPG.
 
 8. **Safe output `target` fields**: `comment-on-work-item` requires an explicit `target` field. `update-work-item` fields require explicit opt-in (`status: true`, `title: true`, etc.).
 

--- a/src/compile/types.rs
+++ b/src/compile/types.rs
@@ -707,9 +707,6 @@ pub struct McpOptions {
     /// Environment variables for the MCP server process
     #[serde(default)]
     pub env: HashMap<String, String>,
-    /// Service connection name (1ES only, auto-generated if not specified)
-    #[serde(default, rename = "service-connection")]
-    pub service_connection: Option<String>,
 }
 
 /// Trigger configuration for the pipeline


### PR DESCRIPTION
## Summary

Remove the dead `service_connection` field from `McpOptions` and fix incorrect documentation claiming 1ES uses service connections for MCP routing. Both targets use MCPG — the field was parsed but never read.

## Changes

- **`src/compile/types.rs`**: Remove dead `service_connection` field from `McpOptions`
- **`AGENTS.md`**: Remove `service-connection:` from MCP config docs
- **`prompts/create-ado-agentic-workflow.md`**: Fix 3 incorrect 1ES MCP claims
- **`prompts/update-ado-agentic-workflow.md`**: Fix target compatibility note

See [analysis comment](https://github.com/githubnext/ado-aw/issues/233#issuecomment-4263563340) for full investigation.

Closes #233