### PR TITLE
feat(compile): add --skip-integrity flag for debug builds

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -733,6 +733,12 @@ Should be replaced with the path to the compiled pipeline YAML file for runtime 
 
 Used by the pipeline's integrity check step to verify the pipeline hasn't been modified outside the compilation process.
 
+## {{ integrity_check }}
+
+Generates the "Verify pipeline integrity" pipeline step that downloads the released ado-aw compiler and runs `ado-aw check` against the compiled pipeline YAML. This step ensures the pipeline file hasn't been modified outside the compilation process.
+
+When the compiler is built with `--skip-integrity` (debug builds only), this placeholder is replaced with an empty string and the integrity step is omitted from the generated pipeline.
+
 ## {{ pr_trigger }}
 
 Generates PR trigger configuration. When a schedule or pipeline trigger is configured, this generates `pr: none` to disable PR triggers. Otherwise, it generates an empty string, allowing the default PR trigger behavior.
@@ -933,6 +939,7 @@ Global flags (apply to all subcommands): `--verbose, -v` (enable info-level logg
   - The agent auto-downloads the ado-aw compiler and handles the full lifecycle (create → compile → check)
 - `compile [<path>]` - Compile a markdown file to Azure DevOps pipeline YAML. If no path is given, auto-discovers and recompiles all detected agentic pipelines in the current directory.
   - `--output, -o <path>` - Optional output path for generated YAML (only valid when a path is provided)
+  - `--skip-integrity` - *(debug builds only)* Omit the "Verify pipeline integrity" step from the generated pipeline. Useful during local development when the compiled output won't match a released compiler version. This flag is not available in release builds.
 - `check <pipeline>` - Verify that a compiled pipeline matches its source markdown
   - `<pipeline>` - Path to the pipeline YAML file to verify
   - The source markdown path is auto-detected from the `@ado-aw` header in the pipeline file

--- a/src/compile/common.rs
+++ b/src/compile/common.rs
@@ -799,13 +799,16 @@ pub fn generate_source_path(input_path: &std::path::Path) -> String {
 /// returns an empty string and the step is omitted from the pipeline.
 pub fn generate_integrity_check(skip: bool) -> String {
     if skip {
-        eprintln!("Warning: pipeline integrity check step omitted (--skip-integrity)");
         return String::new();
     }
 
-    // The step content that was previously hardcoded in the templates.
     // Indentation is handled by replace_with_indent at the call site.
-    "- bash: |\n    AGENTIC_PIPELINES_PATH=\"$(Pipeline.Workspace)/agentic-pipeline-compiler/ado-aw\"\n    chmod +x \"$AGENTIC_PIPELINES_PATH\"\n    $AGENTIC_PIPELINES_PATH check \"{{ pipeline_path }}\"\n  displayName: \"Verify pipeline integrity\"".to_string()
+    r#"- bash: |
+    AGENTIC_PIPELINES_PATH="$(Pipeline.Workspace)/agentic-pipeline-compiler/ado-aw"
+    chmod +x "$AGENTIC_PIPELINES_PATH"
+    $AGENTIC_PIPELINES_PATH check "{{ pipeline_path }}"
+  displayName: "Verify pipeline integrity""#
+        .to_string()
 }
 
 /// Generate the pipeline YAML path for integrity checking at ADO runtime.
@@ -2751,6 +2754,34 @@ mod tests {
         let abs_path = agents_dir.join("ctf.yml");
         let result = generate_pipeline_path(&abs_path);
         assert_eq!(result, "{{ workspace }}/agents/ctf.yml");
+    }
+
+    // ─── generate_integrity_check ────────────────────────────────────────────
+
+    #[test]
+    fn test_generate_integrity_check_default_produces_step() {
+        let result = generate_integrity_check(false);
+        assert!(
+            result.contains("Verify pipeline integrity"),
+            "Should contain the displayName"
+        );
+        assert!(
+            result.contains("ado-aw"),
+            "Should reference the ado-aw binary"
+        );
+        assert!(
+            result.contains("{{ pipeline_path }}"),
+            "Should contain the pipeline_path placeholder for later resolution"
+        );
+    }
+
+    #[test]
+    fn test_generate_integrity_check_skip_produces_empty() {
+        let result = generate_integrity_check(true);
+        assert!(
+            result.is_empty(),
+            "Should produce empty string when skipping"
+        );
     }
 
     // ─── validate_submit_pr_review_events ────────────────────────────────────

--- a/src/compile/common.rs
+++ b/src/compile/common.rs
@@ -789,6 +789,25 @@ pub fn generate_source_path(input_path: &std::path::Path) -> String {
     format!("{{{{ workspace }}}}/{}", relative)
 }
 
+/// Generate the "Verify pipeline integrity" step for the pipeline YAML.
+///
+/// When `skip` is `false` (the default), returns the full bash step that
+/// downloads the ado-aw compiler and runs `ado-aw check` against the
+/// pipeline path.
+///
+/// When `skip` is `true` (developer builds with `--skip-integrity`),
+/// returns an empty string and the step is omitted from the pipeline.
+pub fn generate_integrity_check(skip: bool) -> String {
+    if skip {
+        eprintln!("Warning: pipeline integrity check step omitted (--skip-integrity)");
+        return String::new();
+    }
+
+    // The step content that was previously hardcoded in the templates.
+    // Indentation is handled by replace_with_indent at the call site.
+    "- bash: |\n    AGENTIC_PIPELINES_PATH=\"$(Pipeline.Workspace)/agentic-pipeline-compiler/ado-aw\"\n    chmod +x \"$AGENTIC_PIPELINES_PATH\"\n    $AGENTIC_PIPELINES_PATH check \"{{ pipeline_path }}\"\n  displayName: \"Verify pipeline integrity\"".to_string()
+}
+
 /// Generate the pipeline YAML path for integrity checking at ADO runtime.
 ///
 /// Returns a path using `{{ workspace }}` as the base, derived from the
@@ -1912,6 +1931,10 @@ pub struct CompileConfig {
     /// target-specific overrides of shared markers (e.g., 1ES-specific
     /// setup/teardown jobs that differ from the standalone defaults).
     pub extra_replacements: Vec<(String, String)>,
+    /// When true, the "Verify pipeline integrity" step is omitted from the
+    /// generated pipeline. This is a developer-only option gated behind
+    /// `cfg(debug_assertions)` at the CLI level.
+    pub skip_integrity: bool,
 }
 
 /// Shared compilation flow used by both standalone and 1ES compilers.
@@ -2052,6 +2075,7 @@ pub async fn compile_shared(
 
     // 13. Shared replacements
     let compiler_version = env!("CARGO_PKG_VERSION");
+    let integrity_check = generate_integrity_check(config.skip_integrity);
     let replacements: Vec<(&str, &str)> = vec![
         ("{{ parameters }}", &parameters_yaml),
         ("{{ compiler_version }}", compiler_version),
@@ -2075,6 +2099,9 @@ pub async fn compile_shared(
         ("{{ agent_description }}", &front_matter.description),
         ("{{ copilot_params }}", &copilot_params),
         ("{{ source_path }}", &source_path),
+        // integrity_check must come before pipeline_path because the
+        // integrity step content itself contains {{ pipeline_path }}.
+        ("{{ integrity_check }}", &integrity_check),
         ("{{ pipeline_path }}", &pipeline_path),
         ("{{ working_directory }}", &working_directory),
         ("{{ workspace }}", &working_directory),

--- a/src/compile/mod.rs
+++ b/src/compile/mod.rs
@@ -34,6 +34,7 @@ pub trait Compiler: Send + Sync {
         output_path: &Path,
         front_matter: &FrontMatter,
         markdown_body: &str,
+        skip_integrity: bool,
     ) -> Result<String>;
 
     /// Get the target name for logging.
@@ -43,7 +44,11 @@ pub trait Compiler: Send + Sync {
 /// Main compilation function - entry point for the CLI.
 ///
 /// Parses the input markdown file, determines the target, and delegates to the appropriate compiler.
-pub async fn compile_pipeline(input_path: &str, output_path: Option<&str>) -> Result<()> {
+pub async fn compile_pipeline(
+    input_path: &str,
+    output_path: Option<&str>,
+    skip_integrity: bool,
+) -> Result<()> {
     let input_path = Path::new(input_path);
     info!("Compiling pipeline from: {}", input_path.display());
 
@@ -89,7 +94,7 @@ pub async fn compile_pipeline(input_path: &str, output_path: Option<&str>) -> Re
 
     // Compile
     let pipeline_yaml = compiler
-        .compile(input_path, &yaml_output_path, &front_matter, &markdown_body)
+        .compile(input_path, &yaml_output_path, &front_matter, &markdown_body, skip_integrity)
         .await?;
 
     // Clean up spacing artifacts from empty placeholder replacements
@@ -119,7 +124,7 @@ pub async fn compile_pipeline(input_path: &str, output_path: Option<&str>) -> Re
 /// Scans for compiled YAML files containing the `# @ado-aw source=...` header,
 /// resolves each source markdown path, and recompiles. Pipelines whose source
 /// files are missing are reported but don't abort the batch.
-pub async fn compile_all_pipelines() -> Result<()> {
+pub async fn compile_all_pipelines(skip_integrity: bool) -> Result<()> {
     let root = Path::new(".");
     info!("Auto-discovering agentic pipelines for recompilation");
 
@@ -163,7 +168,7 @@ pub async fn compile_all_pipelines() -> Result<()> {
         let source_str = source_path.to_string_lossy();
         let output_str = yaml_output_path.to_string_lossy();
 
-        match compile_pipeline(&source_str, Some(&output_str)).await {
+        match compile_pipeline(&source_str, Some(&output_str), skip_integrity).await {
             Ok(()) => success_count += 1,
             Err(e) => {
                 eprintln!(
@@ -271,6 +276,7 @@ pub async fn check_pipeline(pipeline_path: &str) -> Result<()> {
             pipeline_path,
             &front_matter,
             &markdown_body,
+            false,
         )
         .await?;
     let pipeline_yaml = clean_generated_yaml(&pipeline_yaml);

--- a/src/compile/onees.rs
+++ b/src/compile/onees.rs
@@ -36,6 +36,7 @@ impl Compiler for OneESCompiler {
         output_path: &Path,
         front_matter: &FrontMatter,
         markdown_body: &str,
+        skip_integrity: bool,
     ) -> Result<String> {
         info!("Compiling for 1ES target");
 
@@ -76,6 +77,7 @@ impl Compiler for OneESCompiler {
                 ("{{ setup_job }}".into(), setup_job),
                 ("{{ teardown_job }}".into(), teardown_job),
             ],
+            skip_integrity,
         };
 
         compile_shared(input_path, output_path, front_matter, markdown_body, &extensions, &ctx, config).await

--- a/src/compile/standalone.rs
+++ b/src/compile/standalone.rs
@@ -37,6 +37,7 @@ impl Compiler for StandaloneCompiler {
         output_path: &Path,
         front_matter: &FrontMatter,
         markdown_body: &str,
+        skip_integrity: bool,
     ) -> Result<String> {
         info!("Compiling for standalone target");
 
@@ -69,6 +70,7 @@ impl Compiler for StandaloneCompiler {
                 ("{{ mcpg_config }}".into(), mcpg_config_json),
                 ("{{ mcpg_docker_env }}".into(), mcpg_docker_env),
             ],
+            skip_integrity,
         };
 
         compile_shared(input_path, output_path, front_matter, markdown_body, &extensions, &ctx, config).await

--- a/src/data/1es-base.yml
+++ b/src/data/1es-base.yml
@@ -101,11 +101,7 @@ extends:
                     chmod +x ado-aw
                   displayName: "Download agentic pipeline compiler (v{{ compiler_version }})"
 
-                - bash: |
-                    AGENTIC_PIPELINES_PATH="$(Pipeline.Workspace)/agentic-pipeline-compiler/ado-aw"
-                    chmod +x "$AGENTIC_PIPELINES_PATH"
-                    $AGENTIC_PIPELINES_PATH check "{{ pipeline_path }}"
-                  displayName: "Verify pipeline integrity"
+                {{ integrity_check }}
 
                 - bash: |
                     mkdir -p "$(Agent.TempDirectory)/staging"

--- a/src/data/base.yml
+++ b/src/data/base.yml
@@ -72,11 +72,7 @@ jobs:
           chmod +x ado-aw
         displayName: "Download agentic pipeline compiler (v{{ compiler_version }})"
 
-      - bash: |
-          AGENTIC_PIPELINES_PATH="$(Pipeline.Workspace)/agentic-pipeline-compiler/ado-aw"
-          chmod +x "$AGENTIC_PIPELINES_PATH"
-          $AGENTIC_PIPELINES_PATH check "{{ pipeline_path }}"
-        displayName: "Verify pipeline integrity"
+      {{ integrity_check }}
 
       - bash: |
           mkdir -p "$(Agent.TempDirectory)/staging"

--- a/src/main.rs
+++ b/src/main.rs
@@ -164,6 +164,10 @@ async fn main() -> Result<()> {
                 #[cfg(not(debug_assertions))]
                 let skip_integrity = false;
 
+                if skip_integrity {
+                    eprintln!("Warning: pipeline integrity check step omitted (--skip-integrity)");
+                }
+
                 match path {
                     Some(p) => compile::compile_pipeline(&p, output.as_deref(), skip_integrity).await?,
                     None => {

--- a/src/main.rs
+++ b/src/main.rs
@@ -31,6 +31,11 @@ enum Commands {
         /// Optional output path for the generated YAML file
         #[arg(short, long)]
         output: Option<String>,
+        /// Omit the "Verify pipeline integrity" step from the generated pipeline.
+        /// Only available in debug builds.
+        #[cfg(debug_assertions)]
+        #[arg(long)]
+        skip_integrity: bool,
     },
     /// Check that a compiled pipeline matches its source markdown
     Check {
@@ -150,18 +155,28 @@ async fn main() -> Result<()> {
 
     if let Some(command) = args.command {
         match command {
-            Commands::Compile { path, output } => match path {
-                Some(p) => compile::compile_pipeline(&p, output.as_deref()).await?,
-                None => {
-                    if output.is_some() {
-                        anyhow::bail!(
-                            "--output cannot be used with auto-discovery mode. \
-                             Specify a path to compile a single file with a custom output."
-                        );
+            Commands::Compile {
+                path,
+                output,
+                #[cfg(debug_assertions)]
+                skip_integrity,
+            } => {
+                #[cfg(not(debug_assertions))]
+                let skip_integrity = false;
+
+                match path {
+                    Some(p) => compile::compile_pipeline(&p, output.as_deref(), skip_integrity).await?,
+                    None => {
+                        if output.is_some() {
+                            anyhow::bail!(
+                                "--output cannot be used with auto-discovery mode. \
+                                 Specify a path to compile a single file with a custom output."
+                            );
+                        }
+                        compile::compile_all_pipelines(skip_integrity).await?
                     }
-                    compile::compile_all_pipelines().await?
                 }
-            },
+            }
             Commands::Check { pipeline } => {
                 compile::check_pipeline(&pipeline).await?;
             }

--- a/tests/compiler_tests.rs
+++ b/tests/compiler_tests.rs
@@ -112,6 +112,10 @@ fn test_compiled_yaml_structure() {
         template_content.contains("{{ compiler_version }}"),
         "Template should contain compiler_version marker"
     );
+    assert!(
+        template_content.contains("{{ integrity_check }}"),
+        "Template should contain integrity_check marker"
+    );
 
     // Verify template doesn't accidentally use ${{ }} where {{ }} should be used
     // (The ${{ }} syntax is for Azure DevOps pipeline expressions and should be preserved)


### PR DESCRIPTION
## Summary

Adds a `--skip-integrity` flag to the `compile` subcommand that omits the "Verify pipeline integrity" step from generated pipelines. The flag is gated behind `cfg(debug_assertions)` so it **only exists in debug builds** and cannot be used in release builds.

## Motivation

During local development, the "Verify pipeline integrity" step downloads the **released** ado-aw binary and runs `ado-aw check`. Since the locally compiled output won't match any released version, this step always fails. Developers need a way to skip it while iterating locally.

## Changes

| File | Change |
|------|--------|
| `src/main.rs` | `--skip-integrity` flag on `Compile` command, gated by `#[cfg(debug_assertions)]` |
| `src/compile/mod.rs` | Thread `skip_integrity: bool` through `compile_pipeline()`, `compile_all_pipelines()`, and `Compiler` trait |
| `src/compile/common.rs` | `generate_integrity_check()` function, `skip_integrity` field on `CompileConfig`, `{{ integrity_check }}` shared replacement |
| `src/compile/standalone.rs` | Forward the flag via `CompileConfig` |
| `src/compile/onees.rs` | Forward the flag via `CompileConfig` |
| `src/data/base.yml` | Replace hardcoded integrity step with `{{ integrity_check }}` placeholder |
| `src/data/1es-base.yml` | Replace hardcoded integrity step with `{{ integrity_check }}` placeholder |
| `AGENTS.md` | Document the flag and the new template marker |

## Usage

```bash
# Debug build (flag available)
cargo run -- compile --skip-integrity ./path/to/agent.md

# Release build (flag does not exist)
cargo run --release -- compile ./path/to/agent.md
```

When `--skip-integrity` is used, a warning is emitted to stderr:
```
Warning: pipeline integrity check step omitted (--skip-integrity)
```

## Design decisions

- **`cfg(debug_assertions)` gating**: The flag is compiled out in release builds, making it impossible to accidentally ship pipelines without integrity checks.
- **Template placeholder approach**: Consistent with the existing `{{ ... }}` placeholder pattern used throughout the codebase. The `{{ integrity_check }}` replacement is ordered before `{{ pipeline_path }}` so the nested placeholder inside the step content resolves correctly.
- **No Cargo feature flag**: A CLI flag is simpler and more explicit — developers opt in per invocation rather than per build.

## Testing

- All 66 existing tests pass
- Verified flag appears in `compile --help` for debug builds
- Verified flag is absent from `compile --help` for release builds
