### PR TITLE
docs: clarify $(MCP_GATEWAY_API_KEY) expansion in mcp-config.json heredoc

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -803,6 +803,8 @@ MCPG runs in routed mode by default, exposing each backend at `/mcp/{serverID}`.
 - `headers` — Bearer auth with the gateway API key (ADO variable `$(MCP_GATEWAY_API_KEY)`)
 - `tools: ["*"]` — allow all tools (Copilot CLI requirement)
 
+**Variable expansion note:** The `$(MCP_GATEWAY_API_KEY)` token in the generated JSON uses ADO macro syntax. Although the JSON is written to disk via a quoted bash heredoc (`<< 'EOF'`), which prevents bash `$(...)` command substitution, ADO macro expansion processes the entire script body *before* bash executes it. The real API key value is therefore substituted by ADO at pipeline runtime, and the file on disk contains the actual secret — Copilot CLI does not need to perform any variable expansion.
+
 Server names are validated for URL path safety (no `/`, `#`, `?`, `%`, or spaces). Server entries are sorted alphabetically for deterministic output.
 
 Example output:

--- a/src/compile/common.rs
+++ b/src/compile/common.rs
@@ -1834,6 +1834,9 @@ pub fn generate_mcp_client_config(mcpg_config: &McpgConfig) -> Result<String> {
             )),
         );
 
+        // $(MCP_GATEWAY_API_KEY) uses ADO macro syntax. The generated JSON is embedded
+        // in a bash heredoc; ADO expands $(VARNAME) in script bodies before bash runs,
+        // so the real API key value is substituted at pipeline runtime.
         let mut headers = serde_json::Map::new();
         headers.insert(
             "Authorization".to_string(),

--- a/src/data/1es-base.yml
+++ b/src/data/1es-base.yml
@@ -155,6 +155,11 @@ extends:
                     # Generate MCP config for copilot CLI pointing to MCPG gateway on host.
                     # The agent inside AWF reaches MCPG via host.docker.internal using routed
                     # endpoints (/mcp/{serverID}). Each server has its own entry with auth headers.
+                    #
+                    # NOTE: The quoted heredoc (<< 'EOF') prevents bash from expanding $(...)
+                    # as command substitution. However, $(MCP_GATEWAY_API_KEY) in the JSON is
+                    # still expanded by ADO macro expansion, which processes the entire script
+                    # body *before* bash executes it. The real API key value ends up in the file.
                     cat > /tmp/awf-tools/mcp-config.json << 'MCP_CLIENT_CONFIG_EOF'
                     {{ mcp_client_config }}
                     MCP_CLIENT_CONFIG_EOF

--- a/src/data/base.yml
+++ b/src/data/base.yml
@@ -126,6 +126,11 @@ jobs:
           # Generate MCP config for copilot CLI pointing to MCPG gateway on host.
           # The agent inside AWF reaches MCPG via host.docker.internal using routed
           # endpoints (/mcp/{serverID}). Each server has its own entry with auth headers.
+          #
+          # NOTE: The quoted heredoc (<< 'EOF') prevents bash from expanding $(...)
+          # as command substitution. However, $(MCP_GATEWAY_API_KEY) in the JSON is
+          # still expanded by ADO macro expansion, which processes the entire script
+          # body *before* bash executes it. The real API key value ends up in the file.
           cat > /tmp/awf-tools/mcp-config.json << 'MCP_CLIENT_CONFIG_EOF'
           {{ mcp_client_config }}
           MCP_CLIENT_CONFIG_EOF


### PR DESCRIPTION
The `mcp-config.json` heredoc uses a quoted form (`<< 'MCP_CLIENT_CONFIG_EOF'`), which prevents bash from expanding `$(MCP_GATEWAY_API_KEY)` as command substitution. However, ADO macro expansion processes `$(VARNAME)` in script bodies **before** bash executes, so the real API key value is already substituted by the time bash writes the file.

This expansion chain crosses three layers (ADO → bash → file) and is non-obvious. This PR adds comments in the pipeline templates, compiler source, and AGENTS.md to make the contract explicit for future maintainers.

### Changes
- **`src/data/base.yml`** + **`src/data/1es-base.yml`** — Added comments near the quoted heredoc explaining the ADO-then-bash expansion order
- **`src/compile/common.rs`** — Commented the `$(MCP_GATEWAY_API_KEY)` literal in `generate_mcp_client_config()`
- **`AGENTS.md`** — Added a "Variable expansion note" paragraph under the `{{ mcp_client_config }}` section