### PR TITLE
fix: bypass MCPG run_containerized.sh to fix port validation with --network host

### DIFF
--- a/src/data/1es-base.yml
+++ b/src/data/1es-base.yml
@@ -291,15 +291,23 @@ extends:
                     # The Docker socket mount is required because MCPG spawns stdio-based MCP
                     # servers as sibling containers. This grants significant host access — acceptable
                     # here because the pipeline agent is already trusted and network-isolated by AWF.
+                    #
+                    # WORKAROUND: Override entrypoint to bypass run_containerized.sh which has a
+                    # validate_port_mapping() bug — it calls `docker inspect .NetworkSettings.Ports`
+                    # which is empty with --network host (by design), causing a spurious error:
+                    #   [ERROR] Port 80 is not exposed from the container
+                    # Upstream fix: https://github.com/github/gh-aw-mcpg/issues/TBD
                     echo "$MCPG_CONFIG" | docker run -i --rm \
                       --name mcpg \
                       --network host \
+                      --entrypoint /app/awmg \
                       -v /var/run/docker.sock:/var/run/docker.sock \
                       -e MCP_GATEWAY_PORT="$(MCP_GATEWAY_PORT)" \
                       -e MCP_GATEWAY_DOMAIN="$(MCP_GATEWAY_DOMAIN)" \
                       -e MCP_GATEWAY_API_KEY="$(MCP_GATEWAY_API_KEY)" \
                       {{ mcpg_docker_env }}
-                      {{ mcpg_image }}:v{{ mcpg_version }} &
+                      {{ mcpg_image }}:v{{ mcpg_version }} \
+                      --routed --listen 0.0.0.0:{{ mcpg_port }} --config-stdin --log-dir /tmp/gh-aw/mcp-logs &
                     MCPG_PID=$!
                     echo "MCPG started (PID: $MCPG_PID)"
 

--- a/src/data/base.yml
+++ b/src/data/base.yml
@@ -262,15 +262,23 @@ jobs:
           # The Docker socket mount is required because MCPG spawns stdio-based MCP
           # servers as sibling containers. This grants significant host access — acceptable
           # here because the pipeline agent is already trusted and network-isolated by AWF.
+          #
+          # WORKAROUND: Override entrypoint to bypass run_containerized.sh which has a
+          # validate_port_mapping() bug — it calls `docker inspect .NetworkSettings.Ports`
+          # which is empty with --network host (by design), causing a spurious error:
+          #   [ERROR] Port 80 is not exposed from the container
+          # Upstream fix: https://github.com/github/gh-aw-mcpg/issues/TBD
           echo "$MCPG_CONFIG" | docker run -i --rm \
             --name mcpg \
             --network host \
+            --entrypoint /app/awmg \
             -v /var/run/docker.sock:/var/run/docker.sock \
             -e MCP_GATEWAY_PORT="$(MCP_GATEWAY_PORT)" \
             -e MCP_GATEWAY_DOMAIN="$(MCP_GATEWAY_DOMAIN)" \
             -e MCP_GATEWAY_API_KEY="$(MCP_GATEWAY_API_KEY)" \
             {{ mcpg_docker_env }}
-            {{ mcpg_image }}:v{{ mcpg_version }} &
+            {{ mcpg_image }}:v{{ mcpg_version }} \
+            --routed --listen 0.0.0.0:{{ mcpg_port }} --config-stdin --log-dir /tmp/gh-aw/mcp-logs &
           MCPG_PID=$!
           echo "MCPG started (PID: $MCPG_PID)"
 


### PR DESCRIPTION
## Problem

MCPG's `run_containerized.sh` entrypoint script includes a `validate_port_mapping()` check that calls `docker inspect .NetworkSettings.Ports` to verify the container's port exposure. When running with `--network host` (as our pipelines do), Docker doesn't create NAT port mappings — `.NetworkSettings.Ports` is empty by design. This causes a spurious startup failure:

```
[ERROR] Port 80 is not exposed from the container
```

## Solution

Override the MCPG container entrypoint to call `/app/awmg` directly, bypassing `run_containerized.sh` entirely. The necessary CLI flags (`--routed`, `--listen`, `--config-stdin`, `--log-dir`) are passed explicitly as container arguments.

This is applied to both pipeline templates:
- `src/data/base.yml` (standalone target)
- `src/data/1es-base.yml` (1ES target)

## Details

- Adds `--entrypoint /app/awmg` to the `docker run` command
- Passes MCPG CLI args after the image: `--routed --listen 0.0.0.0:{{ mcpg_port }} --config-stdin --log-dir /tmp/gh-aw/mcp-logs`
- Adds inline comments documenting the workaround and linking to the upstream issue

This is a temporary workaround until the upstream fix lands in [gh-aw-mcpg](https://github.com/github/gh-aw-mcpg).
