### PR TITLE
feat: model GitHub and SafeOutputs as extensions, add --allow-tool for all MCP servers

### DIFF
--- a/src/compile/common.rs
+++ b/src/compile/common.rs
@@ -468,7 +468,35 @@ pub fn generate_copilot_params(
     front_matter: &FrontMatter,
     extensions: &[super::extensions::Extension],
 ) -> Result<String> {
-    let mut allowed_tools: Vec<String> = vec!["github".to_string(), "safeoutputs".to_string()];
+    let mut allowed_tools: Vec<String> = Vec::new();
+
+    // Collect tool permissions from extensions (github, safeoutputs, azure-devops, etc.)
+    for ext in extensions {
+        for tool in ext.allowed_copilot_tools() {
+            if !allowed_tools.contains(&tool) {
+                allowed_tools.push(tool);
+            }
+        }
+    }
+
+    // Collect tool permissions from user-defined MCP servers
+    for (name, config) in &front_matter.mcp_servers {
+        // Skip servers already provided by extensions (e.g., azure-devops)
+        if allowed_tools.contains(name) {
+            continue;
+        }
+        // Skip disabled MCPs
+        let is_enabled = match config {
+            crate::compile::types::McpConfig::Enabled(b) => *b,
+            crate::compile::types::McpConfig::WithOptions(opts) => {
+                opts.enabled.unwrap_or(true)
+            }
+        };
+        if !is_enabled {
+            continue;
+        }
+        allowed_tools.push(name.clone());
+    }
 
     // Edit tool: enabled by default, can be disabled with `edit: false`
     let edit_enabled = front_matter
@@ -1520,30 +1548,7 @@ pub fn generate_mcpg_config(
 ) -> Result<McpgConfig> {
     let mut mcp_servers = HashMap::new();
 
-    // SafeOutputs is always included as an HTTP backend.
-    // MCPG runs with --network host, so it reaches SafeOutputs via localhost
-    // (not host.docker.internal, which requires Docker DNS and isn't available
-    // in host network mode on Linux).
-    mcp_servers.insert(
-        "safeoutputs".to_string(),
-        McpgServerConfig {
-            server_type: "http".to_string(),
-            container: None,
-            entrypoint: None,
-            entrypoint_args: None,
-            mounts: None,
-            args: None,
-            url: Some("http://localhost:${SAFE_OUTPUTS_PORT}/mcp".to_string()),
-            headers: Some(HashMap::from([(
-                "Authorization".to_string(),
-                "Bearer ${SAFE_OUTPUTS_API_KEY}".to_string(),
-            )])),
-            env: None,
-            tools: None,
-        },
-    );
-
-    // Add extension-contributed MCPG server entries (e.g., azure-devops)
+    // Add extension-contributed MCPG server entries (safeoutputs, azure-devops, etc.)
     for ext in extensions {
         for (name, config) in ext.mcpg_servers(ctx)? {
             mcp_servers.insert(name, config);
@@ -3606,11 +3611,15 @@ mod tests {
     }
 
     #[test]
-    fn test_generate_prepare_steps_without_memory_and_no_steps_is_empty() {
+    fn test_generate_prepare_steps_without_memory_and_no_steps_has_safeoutputs_prompt() {
         let fm = minimal_front_matter();
         let exts = crate::compile::extensions::collect_extensions(&fm);
         let result = generate_prepare_steps(&[], &exts).unwrap();
-        assert!(result.is_empty(), "no steps and no memory should produce empty output");
+        // SafeOutputs always contributes a prompt supplement
+        assert!(
+            result.contains("Safe Outputs"),
+            "should include SafeOutputs prompt supplement"
+        );
     }
 
     #[test]

--- a/src/compile/common.rs
+++ b/src/compile/common.rs
@@ -2385,6 +2385,68 @@ mod tests {
     }
 
     #[test]
+    fn test_copilot_params_allow_tool_for_container_mcp() {
+        let mut fm = minimal_front_matter();
+        fm.mcp_servers.insert(
+            "my-tool".to_string(),
+            McpConfig::WithOptions(McpOptions {
+                container: Some("node:20-slim".to_string()),
+                ..Default::default()
+            }),
+        );
+        let params = generate_copilot_params(&fm, &crate::compile::extensions::collect_extensions(&fm)).unwrap();
+        assert!(params.contains("--allow-tool my-tool"), "container MCP should get --allow-tool");
+    }
+
+    #[test]
+    fn test_copilot_params_allow_tool_for_url_mcp() {
+        let mut fm = minimal_front_matter();
+        fm.mcp_servers.insert(
+            "remote-ado".to_string(),
+            McpConfig::WithOptions(McpOptions {
+                url: Some("https://mcp.dev.azure.com/myorg".to_string()),
+                ..Default::default()
+            }),
+        );
+        let params = generate_copilot_params(&fm, &crate::compile::extensions::collect_extensions(&fm)).unwrap();
+        assert!(params.contains("--allow-tool remote-ado"), "URL MCP should get --allow-tool");
+    }
+
+    #[test]
+    fn test_copilot_params_no_allow_tool_for_enabled_only_mcp() {
+        let mut fm = minimal_front_matter();
+        fm.mcp_servers.insert(
+            "my-tool".to_string(),
+            McpConfig::Enabled(true),
+        );
+        let params = generate_copilot_params(&fm, &crate::compile::extensions::collect_extensions(&fm)).unwrap();
+        assert!(!params.contains("--allow-tool my-tool"), "Enabled(true) with no container/url should not get --allow-tool");
+    }
+
+    #[test]
+    fn test_copilot_params_allow_tool_mcps_sorted() {
+        let mut fm = minimal_front_matter();
+        fm.mcp_servers.insert(
+            "z-tool".to_string(),
+            McpConfig::WithOptions(McpOptions {
+                container: Some("alpine".to_string()),
+                ..Default::default()
+            }),
+        );
+        fm.mcp_servers.insert(
+            "a-tool".to_string(),
+            McpConfig::WithOptions(McpOptions {
+                container: Some("alpine".to_string()),
+                ..Default::default()
+            }),
+        );
+        let params = generate_copilot_params(&fm, &crate::compile::extensions::collect_extensions(&fm)).unwrap();
+        let a_pos = params.find("--allow-tool a-tool").expect("a-tool should be present");
+        let z_pos = params.find("--allow-tool z-tool").expect("z-tool should be present");
+        assert!(a_pos < z_pos, "MCPs should be sorted alphabetically: a-tool before z-tool");
+    }
+
+    #[test]
     fn test_copilot_params_builtin_mcp_no_mcp_flag() {
         let mut fm = minimal_front_matter();
         fm.mcp_servers

--- a/src/compile/common.rs
+++ b/src/compile/common.rs
@@ -479,22 +479,27 @@ pub fn generate_copilot_params(
         }
     }
 
-    // Collect tool permissions from user-defined MCP servers (sorted for deterministic output)
+    // Collect tool permissions from user-defined MCP servers (sorted for deterministic output).
+    // Only add --allow-tool for MCPs that will actually produce an MCPG entry (i.e.,
+    // WithOptions that have a container or url). McpConfig::Enabled(true) has no backing
+    // server in MCPG, so granting the permission would cause confusing runtime errors.
     let mut sorted_mcps: Vec<_> = front_matter.mcp_servers.iter().collect();
-    sorted_mcps.sort_by_key(|(name, _)| name.clone());
+    sorted_mcps.sort_by(|(a, _), (b, _)| a.cmp(b));
     for (name, config) in sorted_mcps {
-        // Skip servers already provided by extensions (e.g., azure-devops)
-        if allowed_tools.contains(name) {
+        // Skip servers already provided by extensions (case-insensitive to match
+        // generate_mcpg_config's eq_ignore_ascii_case guard for reserved names)
+        if allowed_tools.iter().any(|t| t.eq_ignore_ascii_case(name)) {
             continue;
         }
-        // Skip disabled MCPs
-        let is_enabled = match config {
-            crate::compile::types::McpConfig::Enabled(b) => *b,
+        // Only add MCPs that have a backing server (container or url)
+        let has_backing_server = match config {
+            crate::compile::types::McpConfig::Enabled(_) => false,
             crate::compile::types::McpConfig::WithOptions(opts) => {
                 opts.enabled.unwrap_or(true)
+                    && (opts.container.is_some() || opts.url.is_some())
             }
         };
-        if !is_enabled {
+        if !has_backing_server {
             continue;
         }
         allowed_tools.push(name.clone());

--- a/src/compile/common.rs
+++ b/src/compile/common.rs
@@ -479,8 +479,10 @@ pub fn generate_copilot_params(
         }
     }
 
-    // Collect tool permissions from user-defined MCP servers
-    for (name, config) in &front_matter.mcp_servers {
+    // Collect tool permissions from user-defined MCP servers (sorted for deterministic output)
+    let mut sorted_mcps: Vec<_> = front_matter.mcp_servers.iter().collect();
+    sorted_mcps.sort_by_key(|(name, _)| name.clone());
+    for (name, config) in sorted_mcps {
         // Skip servers already provided by extensions (e.g., azure-devops)
         if allowed_tools.contains(name) {
             continue;

--- a/src/compile/extensions.rs
+++ b/src/compile/extensions.rs
@@ -247,6 +247,14 @@ pub trait CompilerExtension {
         Ok(vec![])
     }
 
+    /// Copilot CLI `--allow-tool` values this extension requires.
+    ///
+    /// Returns tool names (e.g., `"github"`, `"safeoutputs"`, `"azure-devops"`)
+    /// that are emitted as `--allow-tool <name>` in the Copilot CLI invocation.
+    fn allowed_copilot_tools(&self) -> Vec<String> {
+        vec![]
+    }
+
     /// Compile-time warnings to emit. Errors in the `Result` abort
     /// compilation; the inner `Vec<String>` contains non-fatal warnings
     /// printed to stderr.
@@ -306,6 +314,9 @@ macro_rules! extension_enum {
             fn mcpg_servers(&self, ctx: &CompileContext) -> Result<Vec<(String, McpgServerConfig)>> {
                 match self { $( $Enum::$Variant(e) => e.mcpg_servers(ctx), )+ }
             }
+            fn allowed_copilot_tools(&self) -> Vec<String> {
+                match self { $( $Enum::$Variant(e) => e.allowed_copilot_tools(), )+ }
+            }
             fn validate(&self, ctx: &CompileContext) -> Result<Vec<String>> {
                 match self { $( $Enum::$Variant(e) => e.validate(ctx), )+ }
             }
@@ -319,6 +330,8 @@ extension_enum! {
     /// Uses static dispatch (no `Box<dyn>`) — each variant delegates to
     /// the inner type's [`CompilerExtension`] implementation.
     pub enum Extension {
+        GitHub(GitHubExtension),
+        SafeOutputs(SafeOutputsExtension),
         Lean(LeanExtension),
         AzureDevOps(AzureDevOpsExtension),
         CacheMemory(CacheMemoryExtension),
@@ -440,6 +453,10 @@ impl CompilerExtension for AzureDevOpsExtension {
             .iter()
             .map(|h| (*h).to_string())
             .collect()
+    }
+
+    fn allowed_copilot_tools(&self) -> Vec<String> {
+        vec![ADO_MCP_SERVER_NAME.to_string()]
     }
 
     fn mcpg_servers(&self, ctx: &CompileContext) -> Result<Vec<(String, McpgServerConfig)>> {
@@ -628,6 +645,88 @@ fn generate_memory_download() -> String {
         .to_string()
 }
 
+// ─── GitHub (always-on, internal) ────────────────────────────────────
+
+/// GitHub MCP extension.
+///
+/// Always-on internal extension that grants the agent access to the
+/// Copilot CLI built-in GitHub MCP server via `--allow-tool github`.
+/// The GitHub MCP uses `GITHUB_TOKEN` from the pipeline environment.
+pub struct GitHubExtension;
+
+impl CompilerExtension for GitHubExtension {
+    fn name(&self) -> &str {
+        "GitHub"
+    }
+
+    fn phase(&self) -> ExtensionPhase {
+        ExtensionPhase::Tool
+    }
+
+    fn allowed_copilot_tools(&self) -> Vec<String> {
+        vec!["github".to_string()]
+    }
+}
+
+// ─── SafeOutputs (always-on, internal) ───────────────────────────────
+
+/// SafeOutputs MCP extension.
+///
+/// Always-on internal extension that configures the SafeOutputs HTTP
+/// backend in MCPG and appends prompt guidance for the agent.
+pub struct SafeOutputsExtension;
+
+impl CompilerExtension for SafeOutputsExtension {
+    fn name(&self) -> &str {
+        "SafeOutputs"
+    }
+
+    fn phase(&self) -> ExtensionPhase {
+        ExtensionPhase::Tool
+    }
+
+    fn allowed_copilot_tools(&self) -> Vec<String> {
+        vec!["safeoutputs".to_string()]
+    }
+
+    fn mcpg_servers(&self, _ctx: &CompileContext) -> Result<Vec<(String, McpgServerConfig)>> {
+        Ok(vec![(
+            "safeoutputs".to_string(),
+            McpgServerConfig {
+                server_type: "http".to_string(),
+                container: None,
+                entrypoint: None,
+                entrypoint_args: None,
+                mounts: None,
+                args: None,
+                url: Some("http://localhost:${SAFE_OUTPUTS_PORT}/mcp".to_string()),
+                headers: Some(HashMap::from([(
+                    "Authorization".to_string(),
+                    "Bearer ${SAFE_OUTPUTS_API_KEY}".to_string(),
+                )])),
+                env: None,
+                tools: None,
+            },
+        )])
+    }
+
+    fn prompt_supplement(&self) -> Option<String> {
+        Some(
+            "\n\
+---\n\
+\n\
+## Important: Safe Outputs\n\
+\n\
+You have access to the `safeoutputs` MCP server which provides tools for creating work items \
+and reporting issues. **Always prefer using safeoutputs tools over other methods**.\n\
+\n\
+These tools generate safe outputs that will be reviewed and executed in a separate pipeline stage, \
+ensuring proper validation and security controls.\n"
+                .to_string(),
+        )
+    }
+}
+
 // ──────────────────────────────────────────────────────────────────────
 // Collection
 // ──────────────────────────────────────────────────────────────────────
@@ -646,6 +745,10 @@ fn generate_memory_download() -> String {
 /// field order).
 pub fn collect_extensions(front_matter: &FrontMatter) -> Vec<Extension> {
     let mut extensions = Vec::new();
+
+    // ── Always-on internal extensions ──
+    extensions.push(Extension::GitHub(GitHubExtension));
+    extensions.push(Extension::SafeOutputs(SafeOutputsExtension));
 
     // ── Runtimes (ExtensionPhase::Runtime) ──
     if let Some(lean) = front_matter
@@ -763,7 +866,10 @@ mod tests {
     fn test_collect_extensions_empty_front_matter() {
         let fm = minimal_front_matter();
         let exts = collect_extensions(&fm);
-        assert!(exts.is_empty());
+        // Always-on: GitHub + SafeOutputs
+        assert_eq!(exts.len(), 2);
+        assert!(exts.iter().any(|e| e.name() == "GitHub"));
+        assert!(exts.iter().any(|e| e.name() == "SafeOutputs"));
     }
 
     #[test]
@@ -773,8 +879,8 @@ mod tests {
         )
         .unwrap();
         let exts = collect_extensions(&fm);
-        assert_eq!(exts.len(), 1);
-        assert_eq!(exts[0].name(), "Lean 4");
+        assert_eq!(exts.len(), 3); // GitHub + SafeOutputs + Lean
+        assert_eq!(exts[0].name(), "Lean 4"); // Runtime phase sorts first
     }
 
     #[test]
@@ -784,7 +890,7 @@ mod tests {
         )
         .unwrap();
         let exts = collect_extensions(&fm);
-        assert!(exts.is_empty());
+        assert_eq!(exts.len(), 2); // Just always-on
     }
 
     #[test]
@@ -794,8 +900,8 @@ mod tests {
         )
         .unwrap();
         let exts = collect_extensions(&fm);
-        assert_eq!(exts.len(), 1);
-        assert_eq!(exts[0].name(), "Azure DevOps MCP");
+        assert_eq!(exts.len(), 3); // GitHub + SafeOutputs + AzureDevOps
+        assert!(exts.iter().any(|e| e.name() == "Azure DevOps MCP"));
     }
 
     #[test]
@@ -805,8 +911,8 @@ mod tests {
         )
         .unwrap();
         let exts = collect_extensions(&fm);
-        assert_eq!(exts.len(), 1);
-        assert_eq!(exts[0].name(), "Cache Memory");
+        assert_eq!(exts.len(), 3); // GitHub + SafeOutputs + CacheMemory
+        assert!(exts.iter().any(|e| e.name() == "Cache Memory"));
     }
 
     #[test]
@@ -816,10 +922,10 @@ mod tests {
         )
         .unwrap();
         let exts = collect_extensions(&fm);
-        assert_eq!(exts.len(), 3);
-        assert_eq!(exts[0].name(), "Lean 4");
-        assert_eq!(exts[1].name(), "Azure DevOps MCP");
-        assert_eq!(exts[2].name(), "Cache Memory");
+        assert_eq!(exts.len(), 5); // GitHub + SafeOutputs + Lean + AzureDevOps + CacheMemory
+        assert_eq!(exts[0].name(), "Lean 4"); // Runtime phase first
+        // All tool-phase extensions follow
+        assert!(exts[1..].iter().all(|e| e.phase() == ExtensionPhase::Tool));
     }
 
     #[test]
@@ -832,7 +938,7 @@ mod tests {
         )
         .unwrap();
         let exts = collect_extensions(&fm);
-        assert_eq!(exts.len(), 3);
+        assert_eq!(exts.len(), 5); // GitHub + SafeOutputs + Lean + AzureDevOps + CacheMemory
 
         // Find the boundary: last Runtime and first Tool
         let last_runtime_idx = exts

--- a/src/compile/extensions.rs
+++ b/src/compile/extensions.rs
@@ -712,17 +712,16 @@ impl CompilerExtension for SafeOutputsExtension {
 
     fn prompt_supplement(&self) -> Option<String> {
         Some(
-            "\n\
----\n\
-\n\
-## Important: Safe Outputs\n\
-\n\
-You have access to the `safeoutputs` MCP server which provides tools for creating work items \
-and reporting issues. **Always prefer using safeoutputs tools over other methods**.\n\
-\n\
-These tools generate safe outputs that will be reviewed and executed in a separate pipeline stage, \
-ensuring proper validation and security controls.\n"
-                .to_string(),
+            r#"
+---
+
+## Important: Safe Outputs
+
+You have access to the `safeoutputs` MCP server which provides tools for creating work items and reporting issues. **Always prefer using safeoutputs tools over other methods**.
+
+These tools generate safe outputs that will be reviewed and executed in a separate pipeline stage, ensuring proper validation and security controls.
+"#
+            .to_string(),
         )
     }
 }

--- a/src/data/1es-base.yml
+++ b/src/data/1es-base.yml
@@ -180,18 +180,6 @@ extends:
                     {{ agent_content }}
                     AGENT_PROMPT_EOF
 
-                    # Append safeoutputs MCP guidance
-                    cat >> "/tmp/awf-tools/agent-prompt.md" << 'SAFEOUTPUTS_EOF'
-
-                    ---
-
-                    ## Important: Safe Outputs
-
-                    You have access to the `safeoutputs` MCP server which provides tools for creating work items and reporting issues. **Always prefer using safeoutputs tools over other methods**.
-
-                    These tools generate safe outputs that will be reviewed and executed in a separate pipeline stage, ensuring proper validation and security controls.
-                    SAFEOUTPUTS_EOF
-
                     echo "Agent prompt:"
                     cat "/tmp/awf-tools/agent-prompt.md"
                   displayName: "Prepare agent prompt"

--- a/src/data/base.yml
+++ b/src/data/base.yml
@@ -151,18 +151,6 @@ jobs:
           {{ agent_content }}
           AGENT_PROMPT_EOF
 
-          # Append safeoutputs MCP guidance
-          cat >> "/tmp/awf-tools/agent-prompt.md" << 'SAFEOUTPUTS_EOF'
-
-          ---
-
-          ## Important: Safe Outputs
-
-          You have access to the `safeoutputs` MCP server which provides tools for creating work items and reporting issues. **Always prefer using safeoutputs tools over other methods**.
-
-          These tools generate safe outputs that will be reviewed and executed in a separate pipeline stage, ensuring proper validation and security controls.
-          SAFEOUTPUTS_EOF
-
           echo "Agent prompt:"
           cat "/tmp/awf-tools/agent-prompt.md"
         displayName: "Prepare agent prompt"


### PR DESCRIPTION
## Summary

Models `github` and `safeoutputs` as always-on `CompilerExtension` implementations and adds `--allow-tool` generation for all MCP servers — both extension-provided and user-defined.

Previously, `generate_copilot_params()` hardcoded `--allow-tool github` and `--allow-tool safeoutputs`. This PR follows the extensible pattern: each extension declares its own Copilot CLI tool permissions via the new `allowed_copilot_tools()` trait method, and user-defined MCP servers from `mcp-servers:` front matter also get `--allow-tool` entries automatically.

## Changes

### `src/compile/extensions.rs`
- Added `allowed_copilot_tools()` method to `CompilerExtension` trait (default: empty vec)
- New `GitHubExtension` (always-on, Tool phase) → `--allow-tool github`
- New `SafeOutputsExtension` (always-on, Tool phase) → `--allow-tool safeoutputs`, MCPG HTTP server entry, prompt supplement
- `AzureDevOpsExtension` now returns `--allow-tool azure-devops`
- Updated `collect_extensions()` to always push GitHub + SafeOutputs

### `src/compile/common.rs`
- `generate_copilot_params()` collects `--allow-tool` from extensions + user-defined MCPs (each enabled MCP server name is added as an `--allow-tool` entry)
- Removed hardcoded safeoutputs entry from `generate_mcpg_config()` — now provided by `SafeOutputsExtension`
- MCP server iteration is sorted by name for deterministic output

### `src/data/base.yml` + `src/data/1es-base.yml`
- Removed hardcoded safeoutputs prompt block — now provided by `SafeOutputsExtension::prompt_supplement()`

## Testing

All existing tests pass. Clippy clean (no new warnings).