### PR TITLE
feat: add ado-aw run subcommand for local development

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1004,6 +1004,14 @@ Global flags (apply to all subcommands): `--verbose, -v` (enable info-level logg
   - `--ado-project <name>` - Azure DevOps project name override
   - `--dry-run` - Validate inputs but skip ADO API calls (useful for local testing and QA review)
 
+- `run <path>` - Run an agent locally (local development mode). Orchestrates the full agent lifecycle: starts SafeOutputs, optionally starts MCPG via Docker, generates configs, runs copilot, and executes safe outputs.
+  - `--pat <pat>` / `AZURE_DEVOPS_EXT_PAT` env var - Azure DevOps PAT for API access (passed to MCPG for ADO MCP, copilot env, and Stage 3 execution)
+  - `--org <url>` - Azure DevOps organization URL (overrides auto-inference from git remote)
+  - `--project <name>` - Azure DevOps project name
+  - `--dry-run` - Skip ADO API calls in the execute stage
+  - `--skip-mcpg` - Skip MCPG/Docker (only SafeOutputs MCP available; auto-enabled when Docker is unavailable)
+  - `--output-dir <path>` - Output directory for safe outputs and artifacts (defaults to a temp directory)
+
 - `configure` - Detect agentic pipelines in a local repository and update the `GITHUB_TOKEN` pipeline variable on their Azure DevOps build definitions
   - `--token <token>` / `GITHUB_TOKEN` env var - The new GITHUB_TOKEN value (prompted if omitted)
   - `--org <url>` - Override: Azure DevOps organization URL (inferred from git remote by default)

--- a/src/compile/mod.rs
+++ b/src/compile/mod.rs
@@ -10,7 +10,7 @@ mod common;
 pub mod extensions;
 mod onees;
 mod standalone;
-mod types;
+pub mod types;
 
 use anyhow::{Context, Result};
 use async_trait::async_trait;
@@ -20,6 +20,13 @@ use std::path::{Path, PathBuf};
 pub use common::parse_markdown;
 pub use common::sanitize_filename;
 pub use common::HEADER_MARKER;
+pub use common::generate_copilot_params;
+pub use common::generate_mcpg_config;
+pub use common::generate_mcp_client_config;
+pub use common::MCPG_IMAGE;
+pub use common::MCPG_VERSION;
+pub use common::MCPG_PORT;
+pub use common::MCPG_DOMAIN;
 pub use types::{CompileTarget, FrontMatter, PermissionsConfig};
 
 /// Trait for pipeline compilers.

--- a/src/compile/types.rs
+++ b/src/compile/types.rs
@@ -375,6 +375,23 @@ impl AzureDevOpsToolConfig {
             AzureDevOpsToolConfig::WithOptions(opts) => opts.org.as_deref(),
         }
     }
+
+    /// Set the org override (for local run mode when --org is provided).
+    /// Converts `Enabled(true)` to `WithOptions` with the org set.
+    pub fn set_org(&mut self, org: String) {
+        match self {
+            AzureDevOpsToolConfig::Enabled(true) => {
+                *self = AzureDevOpsToolConfig::WithOptions(AzureDevOpsOptions {
+                    org: Some(org),
+                    ..Default::default()
+                });
+            }
+            AzureDevOpsToolConfig::WithOptions(opts) => {
+                opts.org = Some(org);
+            }
+            AzureDevOpsToolConfig::Enabled(false) => {}
+        }
+    }
 }
 
 impl SanitizeConfigTrait for AzureDevOpsToolConfig {

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,6 +11,7 @@ mod logging;
 mod mcp;
 mod ndjson;
 pub mod runtimes;
+mod run;
 pub mod sanitize;
 mod safeoutputs;
 mod tools;
@@ -122,6 +123,29 @@ enum Commands {
         #[arg(long, value_delimiter = ',')]
         definition_ids: Option<Vec<u64>>,
     },
+    /// Run agent locally (local development mode)
+    Run {
+        /// Path to the agent markdown file
+        path: String,
+        /// Azure DevOps PAT for API access (prefer AZURE_DEVOPS_EXT_PAT env var)
+        #[arg(long, env = "AZURE_DEVOPS_EXT_PAT")]
+        pat: Option<String>,
+        /// Azure DevOps organization URL
+        #[arg(long)]
+        org: Option<String>,
+        /// Azure DevOps project name
+        #[arg(long)]
+        project: Option<String>,
+        /// Dry-run: skip real ADO API calls in execute stage
+        #[arg(long)]
+        dry_run: bool,
+        /// Skip MCPG/Docker (only SafeOutputs MCP available)
+        #[arg(long)]
+        skip_mcpg: bool,
+        /// Output directory for safe outputs and artifacts
+        #[arg(long)]
+        output_dir: Option<PathBuf>,
+    },
 }
 
 #[derive(Parser, Debug)]
@@ -150,6 +174,7 @@ async fn main() -> Result<()> {
         Some(Commands::McpHttp { .. }) => "mcp-http",
         Some(Commands::Init { .. }) => "init",
         Some(Commands::Configure { .. }) => "configure",
+        Some(Commands::Run { .. }) => "run",
         None => "ado-aw",
     };
 
@@ -347,6 +372,26 @@ async fn main() -> Result<()> {
                     dry_run,
                     definition_ids.as_deref(),
                 )
+                .await?;
+            }
+            Commands::Run {
+                path,
+                pat,
+                org,
+                project,
+                dry_run,
+                skip_mcpg,
+                output_dir,
+            } => {
+                run::run(&run::RunArgs {
+                    agent_path: PathBuf::from(path),
+                    pat,
+                    org,
+                    project,
+                    dry_run,
+                    skip_mcpg,
+                    output_dir,
+                })
                 .await?;
             }
         }

--- a/src/run.rs
+++ b/src/run.rs
@@ -29,6 +29,10 @@ pub struct RunArgs {
 struct CleanupGuard {
     safeoutputs_child: Option<Child>,
     mcpg_child: Option<Child>,
+    /// Keeps the env file alive until MCPG exits — Docker reads --env-file
+    /// asynchronously after spawn() returns (spawn is just fork, not exec).
+    #[allow(dead_code)]
+    mcpg_env_file: Option<tempfile::NamedTempFile>,
 }
 
 impl Drop for CleanupGuard {
@@ -151,17 +155,16 @@ fn is_docker_available() -> bool {
 }
 
 /// Start the MCPG Docker container. Returns the `docker run` child process
-/// so the caller can store it in `CleanupGuard` for proper reaping.
-///
-/// Secrets (API keys, PAT) are passed via `--env-file` using a temporary file
-/// to avoid exposing them in `ps` output or `/proc/<pid>/cmdline`. The temp
-/// file is deleted when the returned guard is dropped.
+/// and the env file handle. Both must be stored in `CleanupGuard`:
+/// - The child is reaped after `docker stop`
+/// - The env file must outlive the child because `spawn()` returns after
+///   fork() — the Docker CLI hasn't yet exec'd or read `--env-file`
 fn start_mcpg(
     mcpg_config_json: &str,
     mcpg_api_key: &str,
     pat: Option<&str>,
     needs_ado_token: bool,
-) -> Result<Child> {
+) -> Result<(Child, tempfile::NamedTempFile)> {
     // Remove stale container
     let _ = Command::new("docker")
         .args(["rm", "-f", "ado-aw-mcpg"])
@@ -228,8 +231,8 @@ fn start_mcpg(
         drop(stdin);
     }
 
-    // env_file temp file deleted here on drop — Docker has already read it
-    Ok(child)
+    // Caller must keep env_file alive until MCPG has started and read it
+    Ok((child, env_file))
 }
 
 /// Build a `std::process::Command` for a program that may be a script wrapper.
@@ -356,6 +359,7 @@ pub async fn run(args: &RunArgs) -> Result<()> {
     let mut guard = CleanupGuard {
         safeoutputs_child: None,
         mcpg_child: None,
+        mcpg_env_file: None,
     };
 
     println!("\n=== Starting SafeOutputs HTTP server ===");
@@ -418,13 +422,14 @@ pub async fn run(args: &RunArgs) -> Result<()> {
 
         // Start MCPG
         println!("\n=== Starting MCP Gateway (MCPG) ===");
-        let mcpg_child = start_mcpg(
+        let (mcpg_child, mcpg_env_file) = start_mcpg(
             &mcpg_json,
             &mcpg_api_key,
             args.pat.as_deref(),
             needs_ado_token,
         )?;
         guard.mcpg_child = Some(mcpg_child);
+        guard.mcpg_env_file = Some(mcpg_env_file);
 
         // Health check MCPG
         let client = reqwest::Client::new();
@@ -536,6 +541,7 @@ pub async fn run(args: &RunArgs) -> Result<()> {
     let mut ctx = crate::safeoutputs::ExecutionContext::default();
     ctx.dry_run = args.dry_run;
     ctx.working_directory = output_dir.clone();
+    ctx.source_directory = working_dir.clone();
     ctx.tool_configs = front_matter.safe_outputs.clone();
 
     if let Some(org) = &args.org {

--- a/src/run.rs
+++ b/src/run.rs
@@ -215,16 +215,14 @@ fn start_mcpg(
 /// Build a `std::process::Command` for a program that may be a script wrapper.
 ///
 /// On Windows, npm-installed tools (like `copilot`) are `.cmd` wrappers.
-/// `Command::new("copilot")` won't find them — we need a shell wrapper.
+/// On Windows, npm-installed tools like `copilot` are `.cmd`/`.ps1` wrappers.
+/// `Command::new("copilot")` won't find them — `cmd /C` resolves `.cmd`/`.bat`
+/// from PATH and handles execution natively.
 /// On Unix (Linux/macOS), `Command::new` resolves scripts via the shebang.
-///
-/// On Windows, tries `pwsh` (PowerShell 7+) first for modern resolution,
-/// then falls back to `powershell` (5.1, always available on Windows).
 fn host_command(program: &str) -> Command {
     if cfg!(windows) {
-        let shell = windows_shell();
-        let mut cmd = Command::new(&shell);
-        cmd.args(["-NoProfile", "-Command", program]);
+        let mut cmd = Command::new("cmd");
+        cmd.args(["/C", program]);
         cmd
     } else {
         Command::new(program)
@@ -234,43 +232,12 @@ fn host_command(program: &str) -> Command {
 /// Async variant of [`host_command`] using `tokio::process::Command`.
 fn host_command_async(program: &str) -> tokio::process::Command {
     if cfg!(windows) {
-        let shell = windows_shell();
-        let mut cmd = tokio::process::Command::new(&shell);
-        cmd.args(["-NoProfile", "-Command", program]);
+        let mut cmd = tokio::process::Command::new("cmd");
+        cmd.args(["/C", program]);
         cmd
     } else {
         tokio::process::Command::new(program)
     }
-}
-
-/// Resolve the Windows PowerShell binary: prefer `pwsh` (PS 7+), fall back to `powershell` (5.1).
-#[cfg(windows)]
-fn windows_shell() -> String {
-    use std::sync::OnceLock;
-    static SHELL: OnceLock<String> = OnceLock::new();
-    SHELL
-        .get_or_init(|| {
-            if Command::new("pwsh")
-                .args(["-NoProfile", "-Command", "exit 0"])
-                .stdout(Stdio::null())
-                .stderr(Stdio::null())
-                .status()
-                .map(|s| s.success())
-                .unwrap_or(false)
-            {
-                debug!("Using pwsh (PowerShell 7+) as Windows shell");
-                "pwsh".to_string()
-            } else {
-                debug!("pwsh not found, using powershell (5.1) as Windows shell");
-                "powershell".to_string()
-            }
-        })
-        .clone()
-}
-
-#[cfg(not(windows))]
-fn windows_shell() -> String {
-    unreachable!("windows_shell called on non-Windows platform")
 }
 
 /// Check if an executable is available on PATH.

--- a/src/run.rs
+++ b/src/run.rs
@@ -153,14 +153,14 @@ fn is_docker_available() -> bool {
 /// Start the MCPG Docker container. Returns the `docker run` child process
 /// so the caller can store it in `CleanupGuard` for proper reaping.
 ///
-/// Secrets (API keys, PAT) are passed via `--env-file` to avoid exposing
-/// them in `ps` output or `/proc/<pid>/cmdline`.
+/// Secrets (API keys, PAT) are passed via `--env-file` using a temporary file
+/// to avoid exposing them in `ps` output or `/proc/<pid>/cmdline`. The temp
+/// file is deleted when the returned guard is dropped.
 fn start_mcpg(
     mcpg_config_json: &str,
     mcpg_api_key: &str,
     pat: Option<&str>,
     needs_ado_token: bool,
-    output_dir: &Path,
 ) -> Result<Child> {
     // Remove stale container
     let _ = Command::new("docker")
@@ -169,10 +169,13 @@ fn start_mcpg(
         .stderr(Stdio::null())
         .status();
 
-    // Write secrets to an env file in the output dir (avoids exposing in ps/cmdline).
-    // Docker reads this file synchronously during `docker run` setup before the
-    // container starts, so there is no race with file deletion.
-    let env_file_path = output_dir.join("mcpg.env");
+    // Write secrets to a temp file (avoids exposing in ps/cmdline, and avoids
+    // persisting credentials in the output directory). Docker reads --env-file
+    // synchronously during `docker run` setup — before spawn() returns — so the
+    // file is guaranteed to exist when Docker needs it. NamedTempFile allows
+    // shared reads on Windows, so Docker can open it concurrently.
+    let env_file = tempfile::NamedTempFile::new()
+        .context("Failed to create temp env file for MCPG secrets")?;
     let mut env_contents = format!(
         "MCP_GATEWAY_PORT={}\nMCP_GATEWAY_DOMAIN=127.0.0.1\nMCP_GATEWAY_API_KEY={}\n",
         compile::MCPG_PORT, mcpg_api_key,
@@ -182,8 +185,8 @@ fn start_mcpg(
             env_contents.push_str(&format!("AZURE_DEVOPS_EXT_PAT={}\n", pat));
         }
     }
-    std::fs::write(&env_file_path, &env_contents)
-        .with_context(|| format!("Failed to write MCPG env file: {}", env_file_path.display()))?;
+    std::fs::write(env_file.path(), &env_contents)
+        .with_context(|| format!("Failed to write MCPG env file: {}", env_file.path().display()))?;
 
     let mut args = vec![
         "run".to_string(),
@@ -198,7 +201,7 @@ fn start_mcpg(
         "-v".to_string(),
         "/var/run/docker.sock:/var/run/docker.sock".to_string(),
         "--env-file".to_string(),
-        env_file_path.to_string_lossy().into_owned(),
+        env_file.path().to_string_lossy().into_owned(),
     ];
 
     args.push(format!("{}:v{}", compile::MCPG_IMAGE, compile::MCPG_VERSION));
@@ -225,7 +228,7 @@ fn start_mcpg(
         drop(stdin);
     }
 
-    // env file persists in output_dir for debugging; cleaned up with the dir
+    // env_file temp file deleted here on drop — Docker has already read it
     Ok(child)
 }
 
@@ -419,7 +422,6 @@ pub async fn run(args: &RunArgs) -> Result<()> {
             &mcpg_api_key,
             args.pat.as_deref(),
             needs_ado_token,
-            &output_dir,
         )?;
         guard.mcpg_child = Some(mcpg_child);
 

--- a/src/run.rs
+++ b/src/run.rs
@@ -215,12 +215,16 @@ fn start_mcpg(
 /// Build a `std::process::Command` for a program that may be a script wrapper.
 ///
 /// On Windows, npm-installed tools (like `copilot`) are `.cmd` wrappers.
-/// `Command::new("copilot")` won't find them — we need `cmd /C copilot`.
+/// `Command::new("copilot")` won't find them — we need a shell wrapper.
 /// On Unix (Linux/macOS), `Command::new` resolves scripts via the shebang.
+///
+/// On Windows, tries `pwsh` (PowerShell 7+) first for modern resolution,
+/// then falls back to `powershell` (5.1, always available on Windows).
 fn host_command(program: &str) -> Command {
     if cfg!(windows) {
-        let mut cmd = Command::new("cmd");
-        cmd.args(["/C", program]);
+        let shell = windows_shell();
+        let mut cmd = Command::new(&shell);
+        cmd.args(["-NoProfile", "-Command", program]);
         cmd
     } else {
         Command::new(program)
@@ -230,12 +234,43 @@ fn host_command(program: &str) -> Command {
 /// Async variant of [`host_command`] using `tokio::process::Command`.
 fn host_command_async(program: &str) -> tokio::process::Command {
     if cfg!(windows) {
-        let mut cmd = tokio::process::Command::new("cmd");
-        cmd.args(["/C", program]);
+        let shell = windows_shell();
+        let mut cmd = tokio::process::Command::new(&shell);
+        cmd.args(["-NoProfile", "-Command", program]);
         cmd
     } else {
         tokio::process::Command::new(program)
     }
+}
+
+/// Resolve the Windows PowerShell binary: prefer `pwsh` (PS 7+), fall back to `powershell` (5.1).
+#[cfg(windows)]
+fn windows_shell() -> String {
+    use std::sync::OnceLock;
+    static SHELL: OnceLock<String> = OnceLock::new();
+    SHELL
+        .get_or_init(|| {
+            if Command::new("pwsh")
+                .args(["-NoProfile", "-Command", "exit 0"])
+                .stdout(Stdio::null())
+                .stderr(Stdio::null())
+                .status()
+                .map(|s| s.success())
+                .unwrap_or(false)
+            {
+                debug!("Using pwsh (PowerShell 7+) as Windows shell");
+                "pwsh".to_string()
+            } else {
+                debug!("pwsh not found, using powershell (5.1) as Windows shell");
+                "powershell".to_string()
+            }
+        })
+        .clone()
+}
+
+#[cfg(not(windows))]
+fn windows_shell() -> String {
+    unreachable!("windows_shell called on non-Windows platform")
 }
 
 /// Check if an executable is available on PATH.

--- a/src/run.rs
+++ b/src/run.rs
@@ -28,7 +28,7 @@ pub struct RunArgs {
 /// Guard that kills child processes on drop (normal exit, error, or panic).
 struct CleanupGuard {
     safeoutputs_child: Option<Child>,
-    mcpg_started: bool,
+    mcpg_child: Option<Child>,
 }
 
 impl Drop for CleanupGuard {
@@ -38,13 +38,17 @@ impl Drop for CleanupGuard {
             let _ = child.kill();
             let _ = child.wait();
         }
-        if self.mcpg_started {
+        if self.mcpg_child.is_some() {
             info!("Stopping MCPG container...");
             let _ = Command::new("docker")
                 .args(["stop", "ado-aw-mcpg"])
                 .stdout(Stdio::null())
                 .stderr(Stdio::null())
                 .status();
+            // Reap the docker run process to prevent zombie
+            if let Some(ref mut child) = self.mcpg_child {
+                let _ = child.wait();
+            }
         }
     }
 }
@@ -98,10 +102,12 @@ async fn start_safeoutputs(
     // Redirect output to log files
     let log_dir = output_dir.join("logs");
     std::fs::create_dir_all(&log_dir)?;
-    let stdout_file =
-        std::fs::File::create(log_dir.join("safeoutputs.stdout.log"))?;
-    let stderr_file =
-        std::fs::File::create(log_dir.join("safeoutputs.stderr.log"))?;
+    let stdout_log = log_dir.join("safeoutputs.stdout.log");
+    let stderr_log = log_dir.join("safeoutputs.stderr.log");
+    let stdout_file = std::fs::File::create(&stdout_log)
+        .with_context(|| format!("Failed to create log file: {}", stdout_log.display()))?;
+    let stderr_file = std::fs::File::create(&stderr_log)
+        .with_context(|| format!("Failed to create log file: {}", stderr_log.display()))?;
 
     cmd.stdout(stdout_file).stderr(stderr_file);
 
@@ -140,13 +146,14 @@ fn is_docker_available() -> bool {
         .unwrap_or(false)
 }
 
-/// Start the MCPG Docker container.
+/// Start the MCPG Docker container. Returns the `docker run` child process
+/// so the caller can store it in `CleanupGuard` for proper reaping.
 fn start_mcpg(
     mcpg_config_json: &str,
     mcpg_api_key: &str,
     pat: Option<&str>,
     needs_ado_token: bool,
-) -> Result<()> {
+) -> Result<Child> {
     // Remove stale container
     let _ = Command::new("docker")
         .args(["rm", "-f", "ado-aw-mcpg"])
@@ -185,7 +192,7 @@ fn start_mcpg(
     args.push(format!("{}:v{}", compile::MCPG_IMAGE, compile::MCPG_VERSION));
     args.push("--routed".to_string());
     args.push("--listen".to_string());
-    args.push(format!("0.0.0.0:{}", compile::MCPG_PORT));
+    args.push(format!("127.0.0.1:{}", compile::MCPG_PORT));
     args.push("--config-stdin".to_string());
     args.push("--log-dir".to_string());
     args.push("/tmp/gh-aw/mcp-logs".to_string());
@@ -206,11 +213,7 @@ fn start_mcpg(
         drop(stdin);
     }
 
-    // Don't wait — MCPG runs in the background
-    // The container will be cleaned up by CleanupGuard
-    std::mem::forget(child);
-
-    Ok(())
+    Ok(child)
 }
 
 /// Build a `std::process::Command` for a program that may be a script wrapper.
@@ -242,9 +245,15 @@ fn host_command_async(program: &str) -> tokio::process::Command {
 }
 
 /// Check if an executable is available on PATH.
+/// Uses `where` (Windows) or `which` (Unix) to avoid running the program.
 fn is_on_path(name: &str) -> bool {
-    host_command(name)
-        .arg("--version")
+    let (checker, args) = if cfg!(windows) {
+        ("where", vec![name.to_string()])
+    } else {
+        ("which", vec![name.to_string()])
+    };
+    Command::new(checker)
+        .args(&args)
         .stdout(Stdio::null())
         .stderr(Stdio::null())
         .status()
@@ -305,7 +314,7 @@ pub async fn run(args: &RunArgs) -> Result<()> {
     // ── 4. Start SafeOutputs HTTP server ─────────────────────────────
     let mut guard = CleanupGuard {
         safeoutputs_child: None,
-        mcpg_started: false,
+        mcpg_child: None,
     };
 
     println!("\n=== Starting SafeOutputs HTTP server ===");
@@ -368,13 +377,13 @@ pub async fn run(args: &RunArgs) -> Result<()> {
 
         // Start MCPG
         println!("\n=== Starting MCP Gateway (MCPG) ===");
-        start_mcpg(
+        let mcpg_child = start_mcpg(
             &mcpg_json,
             &mcpg_api_key,
             args.pat.as_deref(),
             needs_ado_token,
         )?;
-        guard.mcpg_started = true;
+        guard.mcpg_child = Some(mcpg_child);
 
         // Health check MCPG
         let client = reqwest::Client::new();

--- a/src/run.rs
+++ b/src/run.rs
@@ -1,0 +1,600 @@
+//! Local development run mode.
+//!
+//! Orchestrates the full agent lifecycle locally: parse markdown →
+//! start SafeOutputs → optionally start MCPG → generate configs →
+//! exec copilot → execute safe outputs → cleanup.
+
+use anyhow::{Context, Result, bail};
+use log::{debug, info, warn};
+use std::collections::HashMap;
+use std::io::Write;
+use std::path::{Path, PathBuf};
+use std::process::{Child, Command, Stdio};
+
+use crate::compile;
+use crate::sanitize::SanitizeConfig;
+
+/// Arguments for the `run` subcommand.
+pub struct RunArgs {
+    pub agent_path: PathBuf,
+    pub pat: Option<String>,
+    pub org: Option<String>,
+    pub project: Option<String>,
+    pub dry_run: bool,
+    pub skip_mcpg: bool,
+    pub output_dir: Option<PathBuf>,
+}
+
+/// Guard that kills child processes on drop (normal exit, error, or panic).
+struct CleanupGuard {
+    safeoutputs_child: Option<Child>,
+    mcpg_started: bool,
+}
+
+impl Drop for CleanupGuard {
+    fn drop(&mut self) {
+        if let Some(ref mut child) = self.safeoutputs_child {
+            info!("Stopping SafeOutputs server...");
+            let _ = child.kill();
+            let _ = child.wait();
+        }
+        if self.mcpg_started {
+            info!("Stopping MCPG container...");
+            let _ = Command::new("docker")
+                .args(["stop", "ado-aw-mcpg"])
+                .stdout(Stdio::null())
+                .stderr(Stdio::null())
+                .status();
+        }
+    }
+}
+
+/// Find a free TCP port by binding to port 0.
+fn find_free_port() -> Result<u16> {
+    let listener = std::net::TcpListener::bind("127.0.0.1:0")
+        .context("Failed to bind to a free port")?;
+    let port = listener.local_addr()?.port();
+    drop(listener);
+    Ok(port)
+}
+
+/// Generate a random API key (alphanumeric, 45 chars).
+fn generate_api_key() -> String {
+    use rand::RngExt;
+    let mut bytes = [0u8; 33];
+    rand::rng().fill(&mut bytes);
+    base64::Engine::encode(&base64::engine::general_purpose::URL_SAFE_NO_PAD, &bytes)
+        .chars()
+        .filter(|c| c.is_ascii_alphanumeric())
+        .take(45)
+        .collect()
+}
+
+/// Start the SafeOutputs MCP HTTP server as a child process.
+async fn start_safeoutputs(
+    output_dir: &Path,
+    bounding_dir: &Path,
+    enabled_tools: &[String],
+) -> Result<(Child, u16, String)> {
+    let port = find_free_port()?;
+    let api_key = generate_api_key();
+
+    let exe = std::env::current_exe().context("Failed to determine current executable path")?;
+
+    let mut cmd = Command::new(&exe);
+    cmd.arg("mcp-http")
+        .arg("--port")
+        .arg(port.to_string())
+        .arg("--api-key")
+        .arg(&api_key);
+
+    for tool in enabled_tools {
+        cmd.arg("--enabled-tools").arg(tool);
+    }
+
+    cmd.arg(output_dir.to_string_lossy().as_ref())
+        .arg(bounding_dir.to_string_lossy().as_ref());
+
+    // Redirect output to log files
+    let log_dir = output_dir.join("logs");
+    std::fs::create_dir_all(&log_dir)?;
+    let stdout_file =
+        std::fs::File::create(log_dir.join("safeoutputs.stdout.log"))?;
+    let stderr_file =
+        std::fs::File::create(log_dir.join("safeoutputs.stderr.log"))?;
+
+    cmd.stdout(stdout_file).stderr(stderr_file);
+
+    let child = cmd.spawn().context("Failed to start SafeOutputs HTTP server")?;
+    info!("SafeOutputs started (PID: {}, port: {})", child.id(), port);
+
+    // Health check
+    let client = reqwest::Client::new();
+    let health_url = format!("http://127.0.0.1:{}/health", port);
+    let mut ready = false;
+    for _ in 0..30 {
+        tokio::time::sleep(std::time::Duration::from_secs(1)).await;
+        match client.get(&health_url).send().await {
+            Ok(resp) if resp.status().is_success() => {
+                ready = true;
+                break;
+            }
+            _ => continue,
+        }
+    }
+    if !ready {
+        bail!("SafeOutputs HTTP server did not become ready within 30s on port {}", port);
+    }
+
+    Ok((child, port, api_key))
+}
+
+/// Check if Docker is available.
+fn is_docker_available() -> bool {
+    Command::new("docker")
+        .arg("info")
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .status()
+        .map(|s| s.success())
+        .unwrap_or(false)
+}
+
+/// Start the MCPG Docker container.
+fn start_mcpg(
+    mcpg_config_json: &str,
+    mcpg_api_key: &str,
+    pat: Option<&str>,
+    needs_ado_token: bool,
+) -> Result<()> {
+    // Remove stale container
+    let _ = Command::new("docker")
+        .args(["rm", "-f", "ado-aw-mcpg"])
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .status();
+
+    let mut args = vec![
+        "run".to_string(),
+        "-i".to_string(),
+        "--rm".to_string(),
+        "--name".to_string(),
+        "ado-aw-mcpg".to_string(),
+        "--network".to_string(),
+        "host".to_string(),
+        "--entrypoint".to_string(),
+        "/app/awmg".to_string(),
+        "-v".to_string(),
+        "/var/run/docker.sock:/var/run/docker.sock".to_string(),
+        "-e".to_string(),
+        format!("MCP_GATEWAY_PORT={}", compile::MCPG_PORT),
+        "-e".to_string(),
+        "MCP_GATEWAY_DOMAIN=127.0.0.1".to_string(),
+        "-e".to_string(),
+        format!("MCP_GATEWAY_API_KEY={}", mcpg_api_key),
+    ];
+
+    // Pass PAT to MCPG for ADO MCP child container passthrough
+    if needs_ado_token {
+        if let Some(pat) = pat {
+            args.push("-e".to_string());
+            args.push(format!("AZURE_DEVOPS_EXT_PAT={}", pat));
+        }
+    }
+
+    args.push(format!("{}:v{}", compile::MCPG_IMAGE, compile::MCPG_VERSION));
+    args.push("--routed".to_string());
+    args.push("--listen".to_string());
+    args.push(format!("0.0.0.0:{}", compile::MCPG_PORT));
+    args.push("--config-stdin".to_string());
+    args.push("--log-dir".to_string());
+    args.push("/tmp/gh-aw/mcp-logs".to_string());
+
+    let mut child = Command::new("docker")
+        .args(&args)
+        .stdin(Stdio::piped())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn()
+        .context("Failed to start MCPG Docker container")?;
+
+    // Pipe config to stdin
+    if let Some(mut stdin) = child.stdin.take() {
+        stdin
+            .write_all(mcpg_config_json.as_bytes())
+            .context("Failed to write MCPG config to stdin")?;
+    }
+
+    // Don't wait — MCPG runs in the background
+    // The container will be cleaned up by CleanupGuard
+    std::mem::forget(child);
+
+    Ok(())
+}
+
+/// Check if an executable is available on PATH.
+fn is_on_path(name: &str) -> bool {
+    Command::new(name)
+        .arg("--version")
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .status()
+        .map(|s| s.success())
+        .unwrap_or(false)
+}
+
+pub async fn run(args: &RunArgs) -> Result<()> {
+    // ── 1. Parse agent markdown ──────────────────────────────────────
+    let content = tokio::fs::read_to_string(&args.agent_path)
+        .await
+        .with_context(|| format!("Failed to read agent file: {}", args.agent_path.display()))?;
+
+    let (mut front_matter, markdown_body) = compile::parse_markdown(&content)?;
+    front_matter.sanitize_config_fields();
+
+    println!("=== ado-aw run: {} ===", front_matter.name);
+    println!("Description: {}", front_matter.description);
+    println!("Engine: {}", front_matter.engine.model());
+    if args.dry_run {
+        println!("Mode: dry-run (ADO API calls will be skipped in execute stage)");
+    }
+
+    // If --org is provided and tools.azure-devops has no explicit org,
+    // inject it so AzureDevOpsExtension picks it up during config generation.
+    if let Some(org) = &args.org {
+        if let Some(ref mut tools) = front_matter.tools {
+            if let Some(ref mut ado) = tools.azure_devops {
+                if ado.org().is_none() {
+                    ado.set_org(org.clone());
+                }
+            }
+        }
+    }
+
+    // ── 2. Collect extensions ────────────────────────────────────────
+    let extensions = compile::extensions::collect_extensions(&front_matter);
+
+    // ── 3. Create output directory ───────────────────────────────────
+    let output_dir = match &args.output_dir {
+        Some(dir) => {
+            tokio::fs::create_dir_all(dir).await?;
+            dir.clone()
+        }
+        None => {
+            let dir = std::env::temp_dir().join(format!("ado-aw-run-{}", std::process::id()));
+            tokio::fs::create_dir_all(&dir).await?;
+            dir
+        }
+    };
+    let working_dir = args
+        .agent_path
+        .parent()
+        .unwrap_or(Path::new("."))
+        .to_path_buf();
+    println!("Output directory: {}", output_dir.display());
+
+    // ── 4. Start SafeOutputs HTTP server ─────────────────────────────
+    let mut guard = CleanupGuard {
+        safeoutputs_child: None,
+        mcpg_started: false,
+    };
+
+    println!("\n=== Starting SafeOutputs HTTP server ===");
+    let (child, so_port, so_api_key) =
+        start_safeoutputs(&output_dir, &working_dir, &[]).await?;
+    guard.safeoutputs_child = Some(child);
+    println!("SafeOutputs ready on port {}", so_port);
+
+    // ── 5. Generate configs + optionally start MCPG ──────────────────
+    let mcpg_api_key = generate_api_key();
+    let mcp_config_path = output_dir.join("mcp-config.json");
+
+    // Check if any MCP or ADO tool needs a token
+    let needs_ado_token = front_matter
+        .tools
+        .as_ref()
+        .and_then(|t| t.azure_devops.as_ref())
+        .is_some_and(|ado| ado.is_enabled())
+        || front_matter.mcp_servers.values().any(|config| {
+            matches!(config, compile::types::McpConfig::WithOptions(opts)
+                if opts.enabled.unwrap_or(true)
+                    && opts.container.is_some()
+                    && opts.env.contains_key("AZURE_DEVOPS_EXT_PAT"))
+        });
+
+    let use_mcpg = !args.skip_mcpg && is_docker_available();
+    if !args.skip_mcpg && !use_mcpg {
+        warn!("Docker is not available — falling back to --skip-mcpg mode");
+        println!("Warning: Docker not available, running without MCPG");
+    }
+
+    if use_mcpg {
+        println!("\n=== Generating MCPG config ===");
+        let compile_dir = args.agent_path.parent().unwrap_or(Path::new("."));
+        let compile_ctx =
+            compile::extensions::CompileContext::new(&front_matter, compile_dir).await;
+
+        let mcpg_config =
+            compile::generate_mcpg_config(&front_matter, &compile_ctx, &extensions)?;
+
+        // Serialize and substitute runtime placeholders
+        let mcpg_json = serde_json::to_string_pretty(&mcpg_config)?;
+        let mcpg_json = mcpg_json
+            .replace("${SAFE_OUTPUTS_PORT}", &so_port.to_string())
+            .replace("${SAFE_OUTPUTS_API_KEY}", &so_api_key)
+            .replace("${MCP_GATEWAY_API_KEY}", &mcpg_api_key);
+
+        tokio::fs::write(output_dir.join("mcpg-config.json"), &mcpg_json).await?;
+        debug!("MCPG config written");
+
+        // Generate MCP client config for copilot
+        let mcp_client_json = compile::generate_mcp_client_config(&mcpg_config)?;
+        // Substitute ADO macro placeholder with actual key
+        let mcp_client_json = mcp_client_json.replace("$(MCP_GATEWAY_API_KEY)", &mcpg_api_key);
+        // Local: copilot runs on host, not inside AWF container
+        let mcp_client_json = mcp_client_json.replace("host.docker.internal", "127.0.0.1");
+
+        tokio::fs::write(&mcp_config_path, &mcp_client_json).await?;
+        debug!("MCP client config written");
+
+        // Start MCPG
+        println!("\n=== Starting MCP Gateway (MCPG) ===");
+        start_mcpg(
+            &mcpg_json,
+            &mcpg_api_key,
+            args.pat.as_deref(),
+            needs_ado_token,
+        )?;
+        guard.mcpg_started = true;
+
+        // Health check MCPG
+        let client = reqwest::Client::new();
+        let health_url = format!("http://127.0.0.1:{}/health", compile::MCPG_PORT);
+        let mut ready = false;
+        for _ in 0..30 {
+            tokio::time::sleep(std::time::Duration::from_secs(1)).await;
+            match client.get(&health_url).send().await {
+                Ok(resp) if resp.status().is_success() => {
+                    ready = true;
+                    break;
+                }
+                _ => continue,
+            }
+        }
+        if !ready {
+            bail!("MCPG did not become ready within 30s");
+        }
+        println!("MCPG ready on port {}", compile::MCPG_PORT);
+    } else {
+        // Skip MCPG — generate direct config pointing to SafeOutputs
+        println!("\n=== Generating direct MCP config (no MCPG) ===");
+        let direct_config = serde_json::json!({
+            "mcpServers": {
+                "safeoutputs": {
+                    "type": "http",
+                    "url": format!("http://127.0.0.1:{}/mcp", so_port),
+                    "headers": {
+                        "Authorization": format!("Bearer {}", so_api_key)
+                    },
+                    "tools": ["*"]
+                }
+            }
+        });
+        let mcp_client_json = serde_json::to_string_pretty(&direct_config)?;
+        tokio::fs::write(&mcp_config_path, &mcp_client_json).await?;
+        println!("MCP config written (direct SafeOutputs, no MCPG)");
+    }
+
+    // ── 6. Write agent prompt ────────────────────────────────────────
+    let prompt_path = output_dir.join("agent-prompt.md");
+    tokio::fs::write(&prompt_path, &markdown_body).await?;
+    debug!("Agent prompt written to {}", prompt_path.display());
+
+    // ── 7. Build and run copilot command ─────────────────────────────
+    let copilot_params = compile::generate_copilot_params(&front_matter, &extensions)?;
+
+    println!("\n=== Copilot CLI ===");
+
+    if is_on_path("copilot") {
+        println!("Running copilot...");
+
+        let prompt_content = tokio::fs::read_to_string(&prompt_path).await?;
+
+        let mut cmd = tokio::process::Command::new("copilot");
+        cmd.arg("--prompt")
+            .arg(&prompt_content)
+            .arg("--additional-mcp-config")
+            .arg(format!("@{}", mcp_config_path.display()));
+
+        // Parse copilot_params and add as args
+        for param in shell_words(&copilot_params) {
+            cmd.arg(param);
+        }
+
+        // Set working directory
+        cmd.current_dir(&working_dir);
+
+        // Set environment
+        if let Some(pat) = &args.pat {
+            cmd.env("AZURE_DEVOPS_EXT_PAT", pat);
+            cmd.env("SYSTEM_ACCESSTOKEN", pat);
+        }
+
+        let status = cmd
+            .status()
+            .await
+            .context("Failed to run copilot")?;
+
+        if !status.success() {
+            warn!("Copilot exited with status: {}", status);
+            println!("Copilot exited with status: {}", status);
+        }
+    } else {
+        println!("Copilot CLI not found on PATH.");
+        println!("To run the agent, execute this command:\n");
+        println!(
+            "  copilot --prompt \"$(cat {})\" --additional-mcp-config @{} {}\n",
+            prompt_path.display(),
+            mcp_config_path.display(),
+            copilot_params,
+        );
+
+        if let Some(pat) = &args.pat {
+            println!("With environment:");
+            println!("  export AZURE_DEVOPS_EXT_PAT=\"{}...\"", &pat[..4.min(pat.len())]);
+        }
+
+        println!("\nPress Enter after the agent completes to continue with execution...");
+        let mut input = String::new();
+        std::io::stdin().read_line(&mut input)?;
+    }
+
+    // ── 8. Execute safe outputs ──────────────────────────────────────
+    println!("\n=== Executing safe outputs ===");
+
+    let mut ctx = crate::safeoutputs::ExecutionContext::default();
+    ctx.dry_run = args.dry_run;
+    ctx.working_directory = output_dir.clone();
+    ctx.tool_configs = front_matter.safe_outputs.clone();
+
+    if let Some(org) = &args.org {
+        ctx.ado_org_url = Some(org.clone());
+    }
+    if let Some(project) = &args.project {
+        ctx.ado_project = Some(project.clone());
+    }
+    if let Some(pat) = &args.pat {
+        ctx.access_token = Some(pat.clone());
+    }
+
+    // Build allowed repositories mapping
+    let mut allowed_repositories = HashMap::new();
+    for checkout_alias in &front_matter.checkout {
+        if let Some(repo) = front_matter
+            .repositories
+            .iter()
+            .find(|r| &r.repository == checkout_alias)
+        {
+            allowed_repositories.insert(checkout_alias.clone(), repo.name.clone());
+        }
+    }
+    ctx.allowed_repositories = allowed_repositories;
+
+    let results = crate::execute::execute_safe_outputs(&output_dir, &ctx).await?;
+
+    // Print summary
+    let success_count = results.iter().filter(|r| r.success && !r.is_warning()).count();
+    let warning_count = results.iter().filter(|r| r.is_warning()).count();
+    let failure_count = results.iter().filter(|r| !r.success).count();
+
+    println!("\n--- Execution Summary ---");
+    println!(
+        "Total: {} | Success: {} | Warnings: {} | Failed: {}",
+        results.len(),
+        success_count,
+        warning_count,
+        failure_count
+    );
+
+    // ── 9. Cleanup (via CleanupGuard drop) ───────────────────────────
+    println!("\n=== Cleanup ===");
+    drop(guard);
+    println!("Done.");
+
+    if failure_count > 0 {
+        std::process::exit(1);
+    }
+
+    Ok(())
+}
+
+/// Simple shell-like word splitting for copilot params.
+/// Handles double-quoted strings (e.g., `--allow-tool "shell(cat)"`)
+/// but does not handle escapes or single quotes.
+fn shell_words(s: &str) -> Vec<String> {
+    let mut words = Vec::new();
+    let mut current = String::new();
+    let mut in_quotes = false;
+
+    for ch in s.chars() {
+        match ch {
+            '"' => in_quotes = !in_quotes,
+            ' ' if !in_quotes => {
+                if !current.is_empty() {
+                    words.push(std::mem::take(&mut current));
+                }
+            }
+            _ => current.push(ch),
+        }
+    }
+    if !current.is_empty() {
+        words.push(current);
+    }
+
+    words
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_generate_api_key_is_alphanumeric() {
+        let key = generate_api_key();
+        assert!(!key.is_empty(), "API key should not be empty");
+        assert!(key.len() >= 30, "API key should be at least 30 chars, got {}", key.len());
+        assert!(
+            key.chars().all(|c| c.is_ascii_alphanumeric()),
+            "API key should be alphanumeric, got: {}",
+            key
+        );
+    }
+
+    #[test]
+    fn test_find_free_port() {
+        let port = find_free_port().unwrap();
+        assert!(port > 0, "Port should be positive");
+    }
+
+    #[test]
+    fn test_shell_words_simple() {
+        let words = shell_words("--model claude-opus-4.5 --no-ask-user");
+        assert_eq!(words, vec!["--model", "claude-opus-4.5", "--no-ask-user"]);
+    }
+
+    #[test]
+    fn test_shell_words_quoted() {
+        let words = shell_words(r#"--allow-tool "shell(cat)" --allow-tool write"#);
+        assert_eq!(words, vec!["--allow-tool", "shell(cat)", "--allow-tool", "write"]);
+    }
+
+    #[test]
+    fn test_shell_words_empty() {
+        let words = shell_words("");
+        assert!(words.is_empty());
+    }
+
+    #[test]
+    fn test_skip_mcpg_direct_config_structure() {
+        // Verify the direct SafeOutputs config has the right structure
+        let port = 8100u16;
+        let api_key = "test-key";
+        let config = serde_json::json!({
+            "mcpServers": {
+                "safeoutputs": {
+                    "type": "http",
+                    "url": format!("http://127.0.0.1:{}/mcp", port),
+                    "headers": {
+                        "Authorization": format!("Bearer {}", api_key)
+                    },
+                    "tools": ["*"]
+                }
+            }
+        });
+
+        let json = serde_json::to_string_pretty(&config).unwrap();
+        assert!(json.contains("127.0.0.1:8100"));
+        assert!(json.contains("Bearer test-key"));
+        assert!(json.contains("\"type\": \"http\""));
+    }
+}

--- a/src/run.rs
+++ b/src/run.rs
@@ -29,8 +29,9 @@ pub struct RunArgs {
 struct CleanupGuard {
     safeoutputs_child: Option<Child>,
     mcpg_child: Option<Child>,
-    /// Keeps the env file alive until MCPG exits — Docker reads --env-file
-    /// asynchronously after spawn() returns (spawn is just fork, not exec).
+    /// Keeps the env file alive until MCPG exits. The file must outlive
+    /// `spawn()` because spawn is just fork — the Docker CLI reads
+    /// `--env-file` after exec, not before spawn returns.
     #[allow(dead_code)]
     mcpg_env_file: Option<tempfile::NamedTempFile>,
 }
@@ -119,14 +120,23 @@ async fn start_safeoutputs(
 
     cmd.stdout(stdout_file).stderr(stderr_file);
 
-    let child = cmd.spawn().context("Failed to start SafeOutputs HTTP server")?;
+    let mut child = cmd.spawn().context("Failed to start SafeOutputs HTTP server")?;
     info!("SafeOutputs started (PID: {}, port: {})", child.id(), port);
 
-    // Health check
+    // Health check — also detect early crash via try_wait()
     let client = reqwest::Client::new();
     let health_url = format!("http://127.0.0.1:{}/health", port);
     let mut ready = false;
     for _ in 0..30 {
+        // Check if process crashed before polling the endpoint
+        if let Some(status) = child.try_wait()? {
+            bail!(
+                "SafeOutputs HTTP server exited during startup with {}. \
+                 Check logs at {}",
+                status,
+                log_dir.display()
+            );
+        }
         tokio::time::sleep(std::time::Duration::from_secs(1)).await;
         match client.get(&health_url).send().await {
             Ok(resp) if resp.status().is_success() => {
@@ -172,11 +182,10 @@ fn start_mcpg(
         .stderr(Stdio::null())
         .status();
 
-    // Write secrets to a temp file (avoids exposing in ps/cmdline, and avoids
-    // persisting credentials in the output directory). Docker reads --env-file
-    // synchronously during `docker run` setup — before spawn() returns — so the
-    // file is guaranteed to exist when Docker needs it. NamedTempFile allows
-    // shared reads on Windows, so Docker can open it concurrently.
+    // Write secrets to a temp file to avoid exposing in ps/cmdline.
+    // The caller must keep the returned NamedTempFile alive — spawn() is
+    // just fork(), so the Docker CLI reads --env-file after exec, which
+    // happens after spawn() returns.
     let env_file = tempfile::NamedTempFile::new()
         .context("Failed to create temp env file for MCPG secrets")?;
     let mut env_contents = format!(
@@ -231,7 +240,7 @@ fn start_mcpg(
         drop(stdin);
     }
 
-    // Caller must keep env_file alive until MCPG has started and read it
+    // Caller must keep env_file alive until Docker has read it
     Ok((child, env_file))
 }
 
@@ -407,7 +416,8 @@ pub async fn run(args: &RunArgs) -> Result<()> {
             .replace("${SAFE_OUTPUTS_API_KEY}", &so_api_key)
             .replace("${MCP_GATEWAY_API_KEY}", &mcpg_api_key);
 
-        tokio::fs::write(output_dir.join("mcpg-config.json"), &mcpg_json).await?;
+        tokio::fs::write(output_dir.join("mcpg-config.json"), &mcpg_json).await
+            .with_context(|| format!("Failed to write MCPG config: {}", output_dir.join("mcpg-config.json").display()))?;
         debug!("MCPG config written");
 
         // Generate MCP client config for copilot
@@ -417,11 +427,17 @@ pub async fn run(args: &RunArgs) -> Result<()> {
         // Local: copilot runs on host, not inside AWF container
         let mcp_client_json = mcp_client_json.replace("host.docker.internal", "127.0.0.1");
 
-        tokio::fs::write(&mcp_config_path, &mcp_client_json).await?;
+        tokio::fs::write(&mcp_config_path, &mcp_client_json).await
+            .with_context(|| format!("Failed to write MCP config: {}", mcp_config_path.display()))?;
         debug!("MCP client config written");
 
         // Start MCPG
         println!("\n=== Starting MCP Gateway (MCPG) ===");
+        if needs_ado_token && args.pat.is_none() {
+            warn!("ADO MCP requires a PAT but none was provided (--pat or AZURE_DEVOPS_EXT_PAT). \
+                   ADO MCP tool calls will likely fail at runtime.");
+            println!("Warning: ADO MCP enabled but no PAT provided — tool calls may fail");
+        }
         let (mcpg_child, mcpg_env_file) = start_mcpg(
             &mcpg_json,
             &mcpg_api_key,
@@ -431,11 +447,16 @@ pub async fn run(args: &RunArgs) -> Result<()> {
         guard.mcpg_child = Some(mcpg_child);
         guard.mcpg_env_file = Some(mcpg_env_file);
 
-        // Health check MCPG
+        // Health check MCPG — also detect early crash
         let client = reqwest::Client::new();
         let health_url = format!("http://127.0.0.1:{}/health", compile::MCPG_PORT);
         let mut ready = false;
         for _ in 0..30 {
+            if let Some(ref mut child) = guard.mcpg_child {
+                if let Some(status) = child.try_wait()? {
+                    bail!("MCPG container exited during startup with {}", status);
+                }
+            }
             tokio::time::sleep(std::time::Duration::from_secs(1)).await;
             match client.get(&health_url).send().await {
                 Ok(resp) if resp.status().is_success() => {
@@ -473,7 +494,8 @@ pub async fn run(args: &RunArgs) -> Result<()> {
 
     // ── 6. Write agent prompt ────────────────────────────────────────
     let prompt_path = output_dir.join("agent-prompt.md");
-    tokio::fs::write(&prompt_path, &markdown_body).await?;
+    tokio::fs::write(&prompt_path, &markdown_body).await
+        .with_context(|| format!("Failed to write agent prompt: {}", prompt_path.display()))?;
     debug!("Agent prompt written to {}", prompt_path.display());
 
     // ── 7. Build and run copilot command ─────────────────────────────
@@ -484,11 +506,9 @@ pub async fn run(args: &RunArgs) -> Result<()> {
     if is_on_path("copilot") {
         println!("Running copilot...");
 
-        let prompt_content = tokio::fs::read_to_string(&prompt_path).await?;
-
         let mut cmd = host_command_async("copilot");
         cmd.arg("--prompt")
-            .arg(&prompt_content)
+            .arg(&markdown_body)
             .arg("--additional-mcp-config")
             .arg(format!("@{}", mcp_config_path.display()));
 

--- a/src/run.rs
+++ b/src/run.rs
@@ -311,11 +311,12 @@ pub async fn run(args: &RunArgs) -> Result<()> {
 
     // If --org is provided and tools.azure-devops has no explicit org,
     // inject it so AzureDevOpsExtension picks it up during config generation.
+    // Sanitize the value since it's injected after sanitize_config_fields().
     if let Some(org) = &args.org {
         if let Some(ref mut tools) = front_matter.tools {
             if let Some(ref mut ado) = tools.azure_devops {
                 if ado.org().is_none() {
-                    ado.set_org(org.clone());
+                    ado.set_org(crate::sanitize::sanitize_config(org));
                 }
             }
         }
@@ -581,6 +582,10 @@ pub async fn run(args: &RunArgs) -> Result<()> {
     drop(guard);
     println!("Done.");
 
+    // process::exit skips async runtime teardown. This is safe because:
+    // - CleanupGuard is explicitly dropped above (child processes reaped)
+    // - No tokio background tasks are spawned after the guard is set
+    // If background tasks are added in the future, they must complete before this point.
     if failure_count > 0 {
         std::process::exit(1);
     }

--- a/src/run.rs
+++ b/src/run.rs
@@ -212,9 +212,35 @@ fn start_mcpg(
     Ok(())
 }
 
+/// Build a `std::process::Command` for a program that may be a script wrapper.
+///
+/// On Windows, npm-installed tools (like `copilot`) are `.cmd` wrappers.
+/// `Command::new("copilot")` won't find them — we need `cmd /C copilot`.
+/// On Unix (Linux/macOS), `Command::new` resolves scripts via the shebang.
+fn host_command(program: &str) -> Command {
+    if cfg!(windows) {
+        let mut cmd = Command::new("cmd");
+        cmd.args(["/C", program]);
+        cmd
+    } else {
+        Command::new(program)
+    }
+}
+
+/// Async variant of [`host_command`] using `tokio::process::Command`.
+fn host_command_async(program: &str) -> tokio::process::Command {
+    if cfg!(windows) {
+        let mut cmd = tokio::process::Command::new("cmd");
+        cmd.args(["/C", program]);
+        cmd
+    } else {
+        tokio::process::Command::new(program)
+    }
+}
+
 /// Check if an executable is available on PATH.
 fn is_on_path(name: &str) -> bool {
-    Command::new(name)
+    host_command(name)
         .arg("--version")
         .stdout(Stdio::null())
         .stderr(Stdio::null())
@@ -400,7 +426,7 @@ pub async fn run(args: &RunArgs) -> Result<()> {
 
         let prompt_content = tokio::fs::read_to_string(&prompt_path).await?;
 
-        let mut cmd = tokio::process::Command::new("copilot");
+        let mut cmd = host_command_async("copilot");
         cmd.arg("--prompt")
             .arg(&prompt_content)
             .arg("--additional-mcp-config")

--- a/src/run.rs
+++ b/src/run.rs
@@ -54,6 +54,11 @@ impl Drop for CleanupGuard {
 }
 
 /// Find a free TCP port by binding to port 0.
+///
+/// Note: There is an inherent TOCTOU race — the port is released before the
+/// child process binds it. Another process could grab it in the gap. This is
+/// acceptable for a local dev tool; fixing it would require refactoring the
+/// mcp-http server to accept a pre-bound listener.
 fn find_free_port() -> Result<u16> {
     let listener = std::net::TcpListener::bind("127.0.0.1:0")
         .context("Failed to bind to a free port")?;
@@ -62,15 +67,14 @@ fn find_free_port() -> Result<u16> {
     Ok(port)
 }
 
-/// Generate a random API key (alphanumeric, 45 chars).
+/// Generate a random alphanumeric API key (at least 40 chars).
 fn generate_api_key() -> String {
     use rand::RngExt;
-    let mut bytes = [0u8; 33];
+    let mut bytes = [0u8; 48];
     rand::rng().fill(&mut bytes);
     base64::Engine::encode(&base64::engine::general_purpose::URL_SAFE_NO_PAD, &bytes)
         .chars()
         .filter(|c| c.is_ascii_alphanumeric())
-        .take(45)
         .collect()
 }
 
@@ -148,11 +152,15 @@ fn is_docker_available() -> bool {
 
 /// Start the MCPG Docker container. Returns the `docker run` child process
 /// so the caller can store it in `CleanupGuard` for proper reaping.
+///
+/// Secrets (API keys, PAT) are passed via `--env-file` to avoid exposing
+/// them in `ps` output or `/proc/<pid>/cmdline`.
 fn start_mcpg(
     mcpg_config_json: &str,
     mcpg_api_key: &str,
     pat: Option<&str>,
     needs_ado_token: bool,
+    output_dir: &Path,
 ) -> Result<Child> {
     // Remove stale container
     let _ = Command::new("docker")
@@ -160,6 +168,22 @@ fn start_mcpg(
         .stdout(Stdio::null())
         .stderr(Stdio::null())
         .status();
+
+    // Write secrets to an env file in the output dir (avoids exposing in ps/cmdline).
+    // Docker reads this file synchronously during `docker run` setup before the
+    // container starts, so there is no race with file deletion.
+    let env_file_path = output_dir.join("mcpg.env");
+    let mut env_contents = format!(
+        "MCP_GATEWAY_PORT={}\nMCP_GATEWAY_DOMAIN=127.0.0.1\nMCP_GATEWAY_API_KEY={}\n",
+        compile::MCPG_PORT, mcpg_api_key,
+    );
+    if needs_ado_token {
+        if let Some(pat) = pat {
+            env_contents.push_str(&format!("AZURE_DEVOPS_EXT_PAT={}\n", pat));
+        }
+    }
+    std::fs::write(&env_file_path, &env_contents)
+        .with_context(|| format!("Failed to write MCPG env file: {}", env_file_path.display()))?;
 
     let mut args = vec![
         "run".to_string(),
@@ -173,21 +197,9 @@ fn start_mcpg(
         "/app/awmg".to_string(),
         "-v".to_string(),
         "/var/run/docker.sock:/var/run/docker.sock".to_string(),
-        "-e".to_string(),
-        format!("MCP_GATEWAY_PORT={}", compile::MCPG_PORT),
-        "-e".to_string(),
-        "MCP_GATEWAY_DOMAIN=127.0.0.1".to_string(),
-        "-e".to_string(),
-        format!("MCP_GATEWAY_API_KEY={}", mcpg_api_key),
+        "--env-file".to_string(),
+        env_file_path.to_string_lossy().into_owned(),
     ];
-
-    // Pass PAT to MCPG for ADO MCP child container passthrough
-    if needs_ado_token {
-        if let Some(pat) = pat {
-            args.push("-e".to_string());
-            args.push(format!("AZURE_DEVOPS_EXT_PAT={}", pat));
-        }
-    }
 
     args.push(format!("{}:v{}", compile::MCPG_IMAGE, compile::MCPG_VERSION));
     args.push("--routed".to_string());
@@ -213,12 +225,12 @@ fn start_mcpg(
         drop(stdin);
     }
 
+    // env file persists in output_dir for debugging; cleaned up with the dir
     Ok(child)
 }
 
 /// Build a `std::process::Command` for a program that may be a script wrapper.
 ///
-/// On Windows, npm-installed tools (like `copilot`) are `.cmd` wrappers.
 /// On Windows, npm-installed tools like `copilot` are `.cmd`/`.ps1` wrappers.
 /// `Command::new("copilot")` won't find them — `cmd /C` resolves `.cmd`/`.bat`
 /// from PATH and handles execution natively.
@@ -261,6 +273,23 @@ fn is_on_path(name: &str) -> bool {
         .unwrap_or(false)
 }
 
+/// Walk up from `start` to find the nearest directory containing `.git`.
+fn find_repo_root(start: &Path) -> Option<PathBuf> {
+    let mut current = if start.is_absolute() {
+        start.to_path_buf()
+    } else {
+        std::env::current_dir().ok()?.join(start)
+    };
+    loop {
+        if current.join(".git").exists() {
+            return Some(current);
+        }
+        if !current.pop() {
+            return None;
+        }
+    }
+}
+
 pub async fn run(args: &RunArgs) -> Result<()> {
     // ── 1. Parse agent markdown ──────────────────────────────────────
     let content = tokio::fs::read_to_string(&args.agent_path)
@@ -295,21 +324,29 @@ pub async fn run(args: &RunArgs) -> Result<()> {
     // ── 3. Create output directory ───────────────────────────────────
     let output_dir = match &args.output_dir {
         Some(dir) => {
-            tokio::fs::create_dir_all(dir).await?;
+            tokio::fs::create_dir_all(dir).await
+                .with_context(|| format!("Failed to create output directory: {}", dir.display()))?;
             dir.clone()
         }
         None => {
             let dir = std::env::temp_dir().join(format!("ado-aw-run-{}", std::process::id()));
-            tokio::fs::create_dir_all(&dir).await?;
+            tokio::fs::create_dir_all(&dir).await
+                .with_context(|| format!("Failed to create output directory: {}", dir.display()))?;
             dir
         }
     };
-    let working_dir = args
+
+    // Working directory: use the repository root (where .git lives) so that
+    // safe-output tools like create-pull-request operate on the full repo,
+    // not just the subdirectory containing the agent file.
+    let agent_dir = args
         .agent_path
         .parent()
-        .unwrap_or(Path::new("."))
-        .to_path_buf();
+        .unwrap_or(Path::new("."));
+    let working_dir = find_repo_root(agent_dir)
+        .unwrap_or_else(|| agent_dir.to_path_buf());
     println!("Output directory: {}", output_dir.display());
+    println!("Working directory: {}", working_dir.display());
 
     // ── 4. Start SafeOutputs HTTP server ─────────────────────────────
     let mut guard = CleanupGuard {
@@ -348,15 +385,15 @@ pub async fn run(args: &RunArgs) -> Result<()> {
 
     if use_mcpg {
         println!("\n=== Generating MCPG config ===");
-        let compile_dir = args.agent_path.parent().unwrap_or(Path::new("."));
         let compile_ctx =
-            compile::extensions::CompileContext::new(&front_matter, compile_dir).await;
+            compile::extensions::CompileContext::new(&front_matter, &working_dir).await;
 
         let mcpg_config =
             compile::generate_mcpg_config(&front_matter, &compile_ctx, &extensions)?;
 
         // Serialize and substitute runtime placeholders
-        let mcpg_json = serde_json::to_string_pretty(&mcpg_config)?;
+        let mcpg_json = serde_json::to_string_pretty(&mcpg_config)
+            .context("Failed to serialize MCPG config")?;
         let mcpg_json = mcpg_json
             .replace("${SAFE_OUTPUTS_PORT}", &so_port.to_string())
             .replace("${SAFE_OUTPUTS_API_KEY}", &so_api_key)
@@ -382,6 +419,7 @@ pub async fn run(args: &RunArgs) -> Result<()> {
             &mcpg_api_key,
             args.pat.as_deref(),
             needs_ado_token,
+            &output_dir,
         )?;
         guard.mcpg_child = Some(mcpg_child);
 
@@ -418,8 +456,10 @@ pub async fn run(args: &RunArgs) -> Result<()> {
                 }
             }
         });
-        let mcp_client_json = serde_json::to_string_pretty(&direct_config)?;
-        tokio::fs::write(&mcp_config_path, &mcp_client_json).await?;
+        let mcp_client_json = serde_json::to_string_pretty(&direct_config)
+            .context("Failed to serialize direct MCP config")?;
+        tokio::fs::write(&mcp_config_path, &mcp_client_json).await
+            .with_context(|| format!("Failed to write MCP config: {}", mcp_config_path.display()))?;
         println!("MCP config written (direct SafeOutputs, no MCPG)");
     }
 
@@ -547,8 +587,14 @@ pub async fn run(args: &RunArgs) -> Result<()> {
 }
 
 /// Simple shell-like word splitting for copilot params.
-/// Handles double-quoted strings (e.g., `--allow-tool "shell(cat)"`)
-/// but does not handle escapes or single quotes.
+///
+/// Handles double-quoted strings (e.g., `--allow-tool "shell(cat)"`).
+/// Does NOT handle backslash escapes, single quotes, or nested quotes.
+///
+/// This is safe because the input is compiler-controlled output from
+/// `generate_copilot_params()`, which only produces double-quoted values
+/// with no escapes. If params ever gain more complex quoting, consider
+/// using the `shell-words` crate.
 fn shell_words(s: &str) -> Vec<String> {
     let mut words = Vec::new();
     let mut current = String::new();
@@ -580,7 +626,7 @@ mod tests {
     fn test_generate_api_key_is_alphanumeric() {
         let key = generate_api_key();
         assert!(!key.is_empty(), "API key should not be empty");
-        assert!(key.len() >= 30, "API key should be at least 30 chars, got {}", key.len());
+        assert!(key.len() >= 40, "API key should be at least 40 chars, got {}", key.len());
         assert!(
             key.chars().all(|c| c.is_ascii_alphanumeric()),
             "API key should be alphanumeric, got: {}",

--- a/src/run.rs
+++ b/src/run.rs
@@ -198,11 +198,12 @@ fn start_mcpg(
         .spawn()
         .context("Failed to start MCPG Docker container")?;
 
-    // Pipe config to stdin
+    // Pipe config to stdin, then close so container sees EOF
     if let Some(mut stdin) = child.stdin.take() {
         stdin
             .write_all(mcpg_config_json.as_bytes())
             .context("Failed to write MCPG config to stdin")?;
+        drop(stdin);
     }
 
     // Don't wait — MCPG runs in the background


### PR DESCRIPTION
## Summary

Adds two features to improve the inner dev loop (#263):

### Phase 1: `--dry-run` for `execute`
Adds dry-run mode to the `execute` subcommand. When enabled, all inputs are validated and sanitized but no ADO API calls are made. Each tool reports what it *would* do with a `[DRY-RUN]` prefix.

**Design**: Dry-run check is in `Executor::execute_sanitized()` — one change covers all 17 executors.

### Phase 2: `ado-aw run` subcommand
New local development orchestrator that runs the full agent lifecycle:

```bash
# Minimal local run (no Docker, no ADO API calls)
ado-aw run ./agents/my-agent.md --skip-mcpg --dry-run

# Full run with ADO MCP and real execution
ado-aw run ./agents/my-agent.md --pat $AZURE_DEVOPS_EXT_PAT --org https://dev.azure.com/myorg --project MyProject
```

**Features:**
- Reuses existing compile functions (`generate_copilot_params`, `generate_mcpg_config`, `generate_mcp_client_config`) — no duplication
- ADO MCP injection is fully native: `generate_mcpg_config()` already produces the MCPG config including the ADO MCP stdio entry. PAT flows through MCPG to child container via env passthrough
- Graceful degradation: `--skip-mcpg` when Docker unavailable, prints copilot command when CLI not on PATH
- `CleanupGuard` ensures child processes are killed on exit/error/panic

### Changes

**Phase 1 (`--dry-run`):**
- `src/safeoutputs/result.rs`: `dry_run` field + trait-level intercept
- `src/main.rs`: `--dry-run` CLI flag
- 17 executor files: `dry_run_summary()` overrides
- `src/execute.rs`: 6 unit tests

**Phase 2 (`run`):**
- `src/run.rs`: New 600-line orchestrator module
- `src/compile/mod.rs`: Re-export compile functions for `run`
- `src/compile/types.rs`: `set_org()` for local org override
- `src/main.rs`: `Commands::Run` variant
- `AGENTS.md`: Documentation for both features

### Testing

All 901 tests pass (835 unit + 55 compiler + 3 init + 8 mcp-http).
