### PR TITLE
fix: resolve compiler warnings and remove dead code

### DIFF
--- a/src/compile/common.rs
+++ b/src/compile/common.rs
@@ -659,6 +659,7 @@ pub fn generate_job_timeout(front_matter: &FrontMatter) -> String {
 }
 
 /// Format a single step's YAML string with proper indentation
+#[allow(dead_code)]
 pub fn format_step_yaml(step_yaml: &str) -> String {
     let trimmed = step_yaml.trim();
     trimmed
@@ -695,6 +696,7 @@ pub fn format_step_yaml_indented(step_yaml: &str, base_indent: usize) -> String 
 }
 
 /// Format multiple steps to YAML with proper indentation for jobs
+#[allow(dead_code)]
 pub fn format_steps_yaml(steps: &[serde_yaml::Value]) -> String {
     steps
         .iter()
@@ -2204,7 +2206,7 @@ pub async fn compile_shared(
         ("{{ executor_ado_env }}", &executor_ado_env),
     ];
 
-    let mut pipeline_yaml = replacements
+    let pipeline_yaml = replacements
         .into_iter()
         .fold(template, |yaml, (placeholder, replacement)| {
             replace_with_indent(&yaml, placeholder, replacement)

--- a/src/compile/mod.rs
+++ b/src/compile/mod.rs
@@ -18,7 +18,6 @@ use log::{debug, info};
 use std::path::{Path, PathBuf};
 
 pub use common::parse_markdown;
-pub use common::sanitize_filename;
 pub use common::HEADER_MARKER;
 pub use common::generate_copilot_params;
 pub use common::generate_mcpg_config;
@@ -26,8 +25,7 @@ pub use common::generate_mcp_client_config;
 pub use common::MCPG_IMAGE;
 pub use common::MCPG_VERSION;
 pub use common::MCPG_PORT;
-pub use common::MCPG_DOMAIN;
-pub use types::{CompileTarget, FrontMatter, PermissionsConfig};
+pub use types::{CompileTarget, FrontMatter};
 
 /// Trait for pipeline compilers.
 ///

--- a/src/compile/types.rs
+++ b/src/compile/types.rs
@@ -56,6 +56,7 @@ impl PoolConfig {
     }
 
     /// Get the OS (defaults to "linux" if not specified)
+    #[allow(dead_code)]
     pub fn os(&self) -> &str {
         match self {
             PoolConfig::Name(_) => "linux",

--- a/src/run.rs
+++ b/src/run.rs
@@ -250,6 +250,7 @@ fn start_mcpg(
 /// `Command::new("copilot")` won't find them — `cmd /C` resolves `.cmd`/`.bat`
 /// from PATH and handles execution natively.
 /// On Unix (Linux/macOS), `Command::new` resolves scripts via the shebang.
+#[allow(dead_code)]
 fn host_command(program: &str) -> Command {
     if cfg!(windows) {
         let mut cmd = Command::new("cmd");

--- a/src/safeoutputs/result.rs
+++ b/src/safeoutputs/result.rs
@@ -19,6 +19,7 @@ pub trait ToolResult: Serialize {
     /// Whether this tool requires write access to ADO.
     /// Write-requiring tools need a `permissions.write` service connection.
     /// Diagnostic/read-only tools default to `false`.
+    #[allow(dead_code)]
     const REQUIRES_WRITE: bool = false;
 }
 

--- a/src/safeoutputs/submit_pr_review.rs
+++ b/src/safeoutputs/submit_pr_review.rs
@@ -31,10 +31,6 @@ fn event_to_vote(event: &str) -> Option<i32> {
     }
 }
 
-fn default_repository() -> String {
-    "self".to_string()
-}
-
 /// Parameters for submitting a pull request review
 #[derive(Deserialize, JsonSchema)]
 pub struct SubmitPrReviewParams {


### PR DESCRIPTION
Fixes all compiler warnings (0 warnings after this change):

- **Unused re-exports** in `compile/mod.rs`: removed `sanitize_filename`, `MCPG_DOMAIN`, `PermissionsConfig`
- **Unnecessary `mut`**: removed from `pipeline_yaml` in `common.rs`
- **Dead code removed**: `default_repository()` in `submit_pr_review.rs` (not referenced by any `#[serde(default)]`)
- **Dead code suppressed**: `#[allow(dead_code)]` on tested but currently-uncalled API surface (`format_step_yaml`, `format_steps_yaml`, `PoolConfig::os`, `host_command`, `REQUIRES_WRITE`)