### PR TITLE
fix: revert pipeline prompt to $(cat) inline expansion

### DIFF
--- a/src/data/1es-base.yml
+++ b/src/data/1es-base.yml
@@ -370,7 +370,7 @@ extends:
                       --container-workdir "{{ working_directory }}" \
                       --log-level info \
                       --proxy-logs-dir "$(Agent.TempDirectory)/staging/logs/firewall" \
-                      -- '/tmp/awf-tools/copilot --prompt @/tmp/awf-tools/agent-prompt.md --additional-mcp-config @/tmp/awf-tools/mcp-config.json {{ copilot_params }}' \
+                      -- '/tmp/awf-tools/copilot --prompt "$(cat /tmp/awf-tools/agent-prompt.md)" --additional-mcp-config @/tmp/awf-tools/mcp-config.json {{ copilot_params }}' \
                       2>&1 \
                       | sed -u 's/##vso\[/[VSO-FILTERED] vso[/g; s/##\[/[VSO-FILTERED] [/g' \
                       | tee "$AGENT_OUTPUT_FILE" \
@@ -563,7 +563,7 @@ extends:
                       --container-workdir "{{ working_directory }}" \
                       --log-level info \
                       --proxy-logs-dir "$(Agent.TempDirectory)/threat-analysis-logs/firewall" \
-                      -- '/tmp/awf-tools/copilot --prompt @/tmp/awf-tools/threat-analysis-prompt.md {{ copilot_params }}' \
+                      -- '/tmp/awf-tools/copilot --prompt "$(cat /tmp/awf-tools/threat-analysis-prompt.md)" {{ copilot_params }}' \
                       2>&1 \
                       | sed -u 's/##vso\[/[VSO-FILTERED] vso[/g; s/##\[/[VSO-FILTERED] [/g' \
                       | tee "$THREAT_OUTPUT_FILE" \

--- a/src/data/base.yml
+++ b/src/data/base.yml
@@ -341,7 +341,7 @@ jobs:
             --container-workdir "{{ working_directory }}" \
             --log-level info \
             --proxy-logs-dir "$(Agent.TempDirectory)/staging/logs/firewall" \
-            -- '/tmp/awf-tools/copilot --prompt @/tmp/awf-tools/agent-prompt.md --additional-mcp-config @/tmp/awf-tools/mcp-config.json {{ copilot_params }}' \
+            -- '/tmp/awf-tools/copilot --prompt "$(cat /tmp/awf-tools/agent-prompt.md)" --additional-mcp-config @/tmp/awf-tools/mcp-config.json {{ copilot_params }}' \
             2>&1 \
             | sed -u 's/##vso\[/[VSO-FILTERED] vso[/g; s/##\[/[VSO-FILTERED] [/g' \
             | tee "$AGENT_OUTPUT_FILE" \
@@ -532,7 +532,7 @@ jobs:
             --container-workdir "{{ working_directory }}" \
             --log-level info \
             --proxy-logs-dir "$(Agent.TempDirectory)/threat-analysis-logs/firewall" \
-            -- '/tmp/awf-tools/copilot --prompt @/tmp/awf-tools/threat-analysis-prompt.md {{ copilot_params }}' \
+            -- '/tmp/awf-tools/copilot --prompt "$(cat /tmp/awf-tools/threat-analysis-prompt.md)" {{ copilot_params }}' \
             2>&1 \
             | sed -u 's/##vso\[/[VSO-FILTERED] vso[/g; s/##\[/[VSO-FILTERED] [/g' \
             | tee "$THREAT_OUTPUT_FILE" \


### PR DESCRIPTION
Reverts pipeline templates to use `--prompt "$(cat file)"` instead of `--prompt @file`. The `@file` syntax is not supported by copilot in pipeline contexts.

Local dev (`run.rs`) retains `@file` since it avoids the Windows cmd.exe 8191-char argument length limit.