### PR TITLE
docs: fix stale engine template docs, add TODO for test engine hardcode

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -873,11 +873,15 @@ The step:
 
 If `permissions.read` is not configured, this marker is replaced with an empty string.
 
-## {{ copilot_ado_env }}
+## {{ engine_env }}
 
-Generates environment variable entries for the copilot AWF step when `permissions.read` is configured. Sets both `AZURE_DEVOPS_EXT_PAT` and `SYSTEM_ACCESSTOKEN` to the read service connection token (`SC_READ_TOKEN`).
+Generates engine-specific environment variable entries for the AWF sandbox step via `Engine::env()`. For the Copilot engine, this produces:
 
-If `permissions.read` is not configured, this marker is replaced with an empty string, and ADO access tokens are omitted from the copilot invocation.
+- `GITHUB_TOKEN: $(GITHUB_TOKEN)` — GitHub authentication
+- `GITHUB_READ_ONLY: 1` — Restricts GitHub API to read-only access
+- `COPILOT_OTEL_ENABLED`, `COPILOT_OTEL_EXPORTER_TYPE`, `COPILOT_OTEL_FILE_EXPORTER_PATH` — OpenTelemetry file-based tracing for agent statistics
+
+ADO access tokens (`AZURE_DEVOPS_EXT_PAT`, `SYSTEM_ACCESSTOKEN`) are not part of this marker — they are injected separately by `{{ acquire_ado_token }}` and extension pipeline variable mappings when `permissions.read` is configured.
 
 ## {{ acquire_write_token }}
 

--- a/src/compile/extensions/mod.rs
+++ b/src/compile/extensions/mod.rs
@@ -156,6 +156,9 @@ impl<'a> CompileContext<'a> {
     }
 
     /// Create a context for tests (no async, no git remote inference).
+    // TODO: resolve engine from front_matter.engine when multiple engines are supported,
+    // instead of hardcoding Engine::Copilot. Currently safe because "copilot" is the only
+    // engine variant, but this will need to call get_engine() once more are added.
     #[cfg(test)]
     pub fn for_test(front_matter: &'a FrontMatter) -> Self {
         Self {


### PR DESCRIPTION
## Summary

Follow-up to #286 — fixes two items missed in the merge:

### Changes

1. **AGENTS.md**: Replace stale `{{ copilot_ado_env }}` section with correct `{{ engine_env }}` docs. The template marker was renamed but the docs still described the old semantics (ADO token passthrough). The actual `{{ engine_env }}` generates engine-specific env vars (GITHUB_TOKEN, OTEL config) via `Engine::env()`.

2. **CompileContext::for_test()**: Add TODO comment flagging that `Engine::Copilot` is hardcoded. Currently correct (only engine), but will need to resolve from `front_matter.engine` when additional engines are added.

### Testing

All 930 tests pass.