### PR TITLE
fix(compile): show full error chain in batch compile output

### DIFF
--- a/src/compile/mod.rs
+++ b/src/compile/mod.rs
@@ -243,7 +243,7 @@ pub async fn compile_all_pipelines(skip_integrity: bool, debug_pipeline: bool) -
             Ok(()) => success_count += 1,
             Err(e) => {
                 eprintln!(
-                    "  Error compiling '{}': {}",
+                    "  Error compiling '{}': {:#}",
                     pipeline.source, e
                 );
                 fail_count += 1;


### PR DESCRIPTION
## Problem

When batch-compiling pipelines (`ado-aw compile` with no path), front matter parse errors only showed the outermost context message:

```
  Error compiling 'agents/failure-summary.md': Failed to parse YAML front matter
```

The underlying serde error — which names the specific unknown field and lists valid alternatives — was swallowed by the `{}` (Display) format.

## Fix

Switch from `{}` to `{:#}` (alternate Display) for `anyhow::Error`, which prints the full error chain. Users now see:

```
  Error compiling 'agents/failure-summary.md': Failed to parse YAML front matter: unknown field `safeoutputs`, expected one of `name`, `description`, `target`, ...
```

The single-file compile path (`ado-aw compile <file>`) was already fine — its error propagates to `main()` where Rust's `Debug` formatting shows the full chain.

## Change

One-character change in `src/compile/mod.rs`: `{}` → `{:#}` in the batch compile error `eprintln!`.
