### PR TITLE
fix(compile): fail pipeline step on AWF download errors

### DIFF
--- a/src/data/1es-base.yml
+++ b/src/data/1es-base.yml
@@ -143,6 +143,8 @@ extends:
                     dockerVersion: 26.1.4
 
                 - bash: |
+                    set -eo pipefail
+
                     AWF_VERSION="{{ firewall_version }}"
                     DOWNLOAD_DIR="$(Pipeline.Workspace)/awf"
                     DOWNLOAD_URL="https://github.com/github/gh-aw-firewall/releases/download/v${AWF_VERSION}/awf-linux-x64"
@@ -159,10 +161,12 @@ extends:
                     mv awf-linux-x64 awf
                     chmod +x awf
                     echo "##vso[task.prependpath]$(Pipeline.Workspace)/awf"
-                    ./awf --version || echo "AWF binary ready"
+                    ./awf --version
                   displayName: "Download AWF (Agentic Workflow Firewall) v{{ firewall_version }}"
 
                 - bash: |
+                    set -eo pipefail
+
                     docker pull ghcr.io/github/gh-aw-firewall/squid:{{ firewall_version }}
                     docker pull ghcr.io/github/gh-aw-firewall/agent:{{ firewall_version }}
                     docker tag ghcr.io/github/gh-aw-firewall/squid:{{ firewall_version }} ghcr.io/github/gh-aw-firewall/squid:latest
@@ -451,6 +455,8 @@ extends:
                     dockerVersion: 26.1.4
 
                 - bash: |
+                    set -eo pipefail
+
                     AWF_VERSION="{{ firewall_version }}"
                     DOWNLOAD_DIR="$(Pipeline.Workspace)/awf"
                     DOWNLOAD_URL="https://github.com/github/gh-aw-firewall/releases/download/v${AWF_VERSION}/awf-linux-x64"
@@ -467,10 +473,12 @@ extends:
                     mv awf-linux-x64 awf
                     chmod +x awf
                     echo "##vso[task.prependpath]$(Pipeline.Workspace)/awf"
-                    ./awf --version || echo "AWF binary ready"
+                    ./awf --version
                   displayName: "Download AWF (Agentic Workflow Firewall) v{{ firewall_version }}"
 
                 - bash: |
+                    set -eo pipefail
+
                     docker pull ghcr.io/github/gh-aw-firewall/squid:{{ firewall_version }}
                     docker pull ghcr.io/github/gh-aw-firewall/agent:{{ firewall_version }}
                     docker tag ghcr.io/github/gh-aw-firewall/squid:{{ firewall_version }} ghcr.io/github/gh-aw-firewall/squid:latest

--- a/src/data/base.yml
+++ b/src/data/base.yml
@@ -114,6 +114,8 @@ jobs:
           dockerVersion: 26.1.4
 
       - bash: |
+          set -eo pipefail
+
           AWF_VERSION="{{ firewall_version }}"
           DOWNLOAD_DIR="$(Pipeline.Workspace)/awf"
           DOWNLOAD_URL="https://github.com/github/gh-aw-firewall/releases/download/v${AWF_VERSION}/awf-linux-x64"
@@ -130,10 +132,12 @@ jobs:
           mv awf-linux-x64 awf
           chmod +x awf
           echo "##vso[task.prependpath]$(Pipeline.Workspace)/awf"
-          ./awf --version || echo "AWF binary ready"
+          ./awf --version
         displayName: "Download AWF (Agentic Workflow Firewall) v{{ firewall_version }}"
 
       - bash: |
+          set -eo pipefail
+
           docker pull ghcr.io/github/gh-aw-firewall/squid:{{ firewall_version }}
           docker pull ghcr.io/github/gh-aw-firewall/agent:{{ firewall_version }}
           docker tag ghcr.io/github/gh-aw-firewall/squid:{{ firewall_version }} ghcr.io/github/gh-aw-firewall/squid:latest
@@ -420,6 +424,8 @@ jobs:
           dockerVersion: 26.1.4
 
       - bash: |
+          set -eo pipefail
+
           AWF_VERSION="{{ firewall_version }}"
           DOWNLOAD_DIR="$(Pipeline.Workspace)/awf"
           DOWNLOAD_URL="https://github.com/github/gh-aw-firewall/releases/download/v${AWF_VERSION}/awf-linux-x64"
@@ -436,10 +442,12 @@ jobs:
           mv awf-linux-x64 awf
           chmod +x awf
           echo "##vso[task.prependpath]$(Pipeline.Workspace)/awf"
-          ./awf --version || echo "AWF binary ready"
+          ./awf --version
         displayName: "Download AWF (Agentic Workflow Firewall) v{{ firewall_version }}"
 
       - bash: |
+          set -eo pipefail
+
           docker pull ghcr.io/github/gh-aw-firewall/squid:{{ firewall_version }}
           docker pull ghcr.io/github/gh-aw-firewall/agent:{{ firewall_version }}
           docker tag ghcr.io/github/gh-aw-firewall/squid:{{ firewall_version }} ghcr.io/github/gh-aw-firewall/squid:latest


### PR DESCRIPTION
## Problem

AWF download steps in generated pipelines report **green** even when the download fails (e.g. HTTP 404). The `|| echo "AWF binary ready"` fallback on `./awf --version` swallows the failure exit code, causing all downstream steps to fail with a confusing "No such file or directory" error instead of surfacing the real problem at the download step.

## Fix

- Add `set -eo pipefail` to all AWF download and docker pull bash steps in both `base.yml` and `1es-base.yml` templates (4 blocks total: agent stage + detection stage × 2 templates).
- Remove `|| echo "AWF binary ready"` so `./awf --version` failures propagate correctly.

With this change, any download failure (curl 404, checksum mismatch, missing binary) immediately fails the step with a clear error.
