### PR TITLE
fix(workflows): simplify change-risk to use add-comment instead of PR review

### DIFF
--- a/.github/workflows/change-risk.lock.yml
+++ b/.github/workflows/change-risk.lock.yml
@@ -22,7 +22,7 @@
 #
 # Assesses PRs for breaking change risk and approves or requests changes
 #
-# gh-aw-metadata: {"schema_version":"v2","frontmatter_hash":"edb23594cb29ef789f03751b3a77ee97d9a8d55696455fc2d194cce74f76a560","compiler_version":"v0.62.0","strict":true}
+# gh-aw-metadata: {"schema_version":"v2","frontmatter_hash":"896da8e67f522edb4b3a0e996ece5b7e0ac43377b098bcb12cb93f103d283d5b","compiler_version":"v0.62.0","strict":true}
 
 name: "Change Risk Assessor"
 "on":
@@ -182,7 +182,7 @@ jobs:
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_prompt.md"
           cat << 'GH_AW_PROMPT_EOF'
           <safe-output-tools>
-          Tools: add_comment, submit_pull_request_review, missing_tool, missing_data, noop
+          Tools: add_comment, missing_tool, missing_data, noop
           </safe-output-tools>
           <github-context>
           The following GitHub context information is available for this workflow:
@@ -387,15 +387,14 @@ jobs:
           mkdir -p /tmp/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/mcp-logs/safeoutputs
           cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/config.json << 'GH_AW_SAFE_OUTPUTS_CONFIG_EOF'
-          {"add_comment":{"max":1},"missing_data":{},"missing_tool":{},"noop":{"max":1},"submit_pull_request_review":{"max":1}}
+          {"add_comment":{"max":1},"missing_data":{},"missing_tool":{},"noop":{"max":1}}
           GH_AW_SAFE_OUTPUTS_CONFIG_EOF
       - name: Write Safe Outputs Tools
         run: |
           cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/tools_meta.json << 'GH_AW_SAFE_OUTPUTS_TOOLS_META_EOF'
           {
             "description_suffixes": {
-              "add_comment": " CONSTRAINTS: Maximum 1 comment(s) can be added.",
-              "submit_pull_request_review": " CONSTRAINTS: Maximum 1 review(s) can be submitted."
+              "add_comment": " CONSTRAINTS: Maximum 1 comment(s) can be added."
             },
             "repo_params": {},
             "dynamic_tools": []
@@ -475,24 +474,6 @@ jobs:
                   "type": "string",
                   "sanitize": true,
                   "maxLength": 65000
-                }
-              }
-            },
-            "submit_pull_request_review": {
-              "defaultMax": 1,
-              "fields": {
-                "body": {
-                  "type": "string",
-                  "sanitize": true,
-                  "maxLength": 65000
-                },
-                "event": {
-                  "type": "string",
-                  "enum": [
-                    "APPROVE",
-                    "REQUEST_CHANGES",
-                    "COMMENT"
-                  ]
                 }
               }
             }
@@ -1126,7 +1107,7 @@ jobs:
           GH_AW_ALLOWED_DOMAINS: "api.business.githubcopilot.com,api.enterprise.githubcopilot.com,api.github.com,api.githubcopilot.com,api.individual.githubcopilot.com,api.snapcraft.io,archive.ubuntu.com,azure.archive.ubuntu.com,crates.io,crl.geotrust.com,crl.globalsign.com,crl.identrust.com,crl.sectigo.com,crl.thawte.com,crl.usertrust.com,crl.verisign.com,crl3.digicert.com,crl4.digicert.com,crls.ssl.com,github.com,host.docker.internal,index.crates.io,json-schema.org,json.schemastore.org,keyserver.ubuntu.com,ocsp.digicert.com,ocsp.geotrust.com,ocsp.globalsign.com,ocsp.identrust.com,ocsp.sectigo.com,ocsp.ssl.com,ocsp.thawte.com,ocsp.usertrust.com,ocsp.verisign.com,packagecloud.io,packages.cloud.google.com,packages.microsoft.com,ppa.launchpad.net,raw.githubusercontent.com,registry.npmjs.org,s.symcb.com,s.symcd.com,security.ubuntu.com,sh.rustup.rs,static.crates.io,static.rust-lang.org,telemetry.enterprise.githubcopilot.com,ts-crl.ws.symantec.com,ts-ocsp.ws.symantec.com,www.googleapis.com"
           GITHUB_SERVER_URL: ${{ github.server_url }}
           GITHUB_API_URL: ${{ github.api_url }}
-          GH_AW_SAFE_OUTPUTS_HANDLER_CONFIG: "{\"add_comment\":{\"max\":1},\"missing_data\":{},\"missing_tool\":{},\"noop\":{\"max\":1,\"report-as-issue\":\"true\"},\"submit_pull_request_review\":{\"footer\":\"if-body\",\"max\":1}}"
+          GH_AW_SAFE_OUTPUTS_HANDLER_CONFIG: "{\"add_comment\":{\"hide_older_comments\":true,\"max\":1},\"missing_data\":{},\"missing_tool\":{},\"noop\":{\"max\":1,\"report-as-issue\":\"true\"}}"
         with:
           github-token: ${{ secrets.GH_AW_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}
           script: |

--- a/.github/workflows/change-risk.md
+++ b/.github/workflows/change-risk.md
@@ -14,11 +14,9 @@ tools:
 network:
   allowed: [defaults, rust]
 safe-outputs:
-  submit-pull-request-review:
-    max: 1
-    footer: "if-body"
   add-comment:
     max: 1
+    hide-older-comments: true
 ---
 
 # Change Risk Assessor
@@ -92,7 +90,7 @@ Analyze the PR diff against these risk categories:
 
 ## Output
 
-Submit a PR review with your verdict. Structure the review body as:
+Post a comment on the PR with your verdict using `add-comment`. Structure the comment as:
 
 ```
 ## ⚡ Change Risk Assessment
@@ -111,6 +109,4 @@ Submit a PR review with your verdict. Structure the review body as:
 [List any breaking changes, or "None identified"]
 ```
 
-Keep the review body **concise** — focus on what matters. If approving a clean PR, a short summary is sufficient. Only expand into detailed findings when risks are found.
-
-**Important**: Use `submit-pull-request-review` with event `APPROVE` or `REQUEST_CHANGES` — do not just post a comment. Your review should directly gate the PR.
+Keep the comment **concise** — focus on what matters. If approving a clean PR, a short summary is sufficient. Only expand into detailed findings when risks are found.


### PR DESCRIPTION
## Summary

The `change-risk` agentic workflow was using `submit-pull-request-review` which wasn't working correctly in practice. This simplifies it to use `add-comment` instead, which reliably posts the risk assessment as a PR comment.

Changes:
- Removed `submit-pull-request-review` safe output from frontmatter
- Kept `add-comment` with `hide-older-comments: true` to minimize stale assessments
- Updated agent instructions to post a comment rather than submit a formal PR review
- Recompiled lock file with `gh aw compile` (v0.62.0)

## Test plan

- `gh aw compile change-risk` compiles cleanly with 0 errors, 0 warnings
- Verified compiled lock file only exposes `add_comment, missing_tool, missing_data, noop` tools (no `submit_pull_request_review`)
