### PR TITLE
ci(test): lint compiled bash bodies with shellcheck

### DIFF
--- a/.github/workflows/rust-tests.yml
+++ b/.github/workflows/rust-tests.yml
@@ -22,8 +22,16 @@ jobs:
 
       - uses: Swatinem/rust-cache@v2
 
+      - name: Install shellcheck
+        # ubuntu-latest already ships shellcheck, but install explicitly to
+        # guarantee it on every refresh of the runner image and to surface
+        # a clear failure when the bash-lint integration test is enforced.
+        run: sudo apt-get update && sudo apt-get install -y shellcheck
+
       - name: Build
         run: cargo build --verbose
 
       - name: Run tests
+        env:
+          ENFORCE_BASH_LINT: "1"
         run: cargo test --verbose

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -273,6 +273,25 @@ cargo test
 cargo clippy
 ```
 
+### Bash step lint
+
+The `tests/bash_lint_tests.rs` integration test compiles a representative set
+of fixtures and runs `shellcheck` against every literal `bash:` body in the
+generated YAML. It catches silent-failure patterns that ADO's "fail on last
+command" default would let through (e.g. `cd "$X"` without `|| exit`, tilde
+inside double quotes, masked-return assignments).
+
+The test is skipped if `shellcheck` is not on PATH. Install locally with
+`brew install shellcheck` (macOS) or `apt-get install -y shellcheck` (Debian
+/ Ubuntu); CI installs it in `.github/workflows/rust-tests.yml` and sets
+`ENFORCE_BASH_LINT=1` so a missing shellcheck becomes a hard failure rather
+than a silent skip.
+
+When adding a new bash step, run `cargo test --test bash_lint_tests` and fix
+anything it flags. If a finding is genuinely intentional, add a
+`# shellcheck disable=SCxxxx` comment immediately above the offending line in
+the bash body — shellcheck honours the directive and it's inert at runtime.
+
 ## Common Tasks
 
 ### Compile a markdown pipeline

--- a/docs/extending.md
+++ b/docs/extending.md
@@ -90,3 +90,45 @@ To add a new filter type:
    `validate_pr_filters()` or `validate_pipeline_filters()`
 5. **Write tests** — lowering test, validation test, and codegen test in
    `filter_ir.rs`
+
+## Bash steps in pipeline templates
+
+Pipeline templates and Rust step generators emit dozens of multi-line `bash:`
+steps. ADO bash steps fail only on the *last* command's exit status by
+default, so a chain like `mkdir … && curl … && cd … && cmd` can silently
+swallow earlier failures.
+
+Rather than spread `set -eo pipefail` boilerplate across every step, the
+project enforces hygiene via `tests/bash_lint_tests.rs`, which compiles a set
+of fixtures and runs `shellcheck` against every literal `bash:` body in the
+generated YAML. The lint catches:
+
+- **SC2164** — `cd $X` without `|| exit` (the canonical silent-failure)
+- **SC2155** — `local var=$(cmd)` masking the inner exit code
+- **SC2086 / SC2046** — unquoted variables / command substitutions
+- **SC2154** — variables referenced but never assigned
+- **SC2088** — tilde inside double quotes (does not expand at all)
+
+When you add or modify a bash step:
+
+1. Run `cargo test --test bash_lint_tests` (locally requires `shellcheck` on
+   PATH; install with `brew install shellcheck` or
+   `apt-get install -y shellcheck`). CI sets `ENFORCE_BASH_LINT=1` so a
+   missing shellcheck becomes a hard failure rather than a silent skip.
+2. Fix any finding by adjusting the bash. Common fixes: `cd "$X" || exit 1`,
+   `exit "$CODE"`, `"$HOME/.foo"` instead of `"~/.foo"`, quoting variable
+   expansions.
+3. If a finding is genuinely intentional, add a
+   `# shellcheck disable=SCxxxx` comment immediately above the line in the
+   bash body. Such directives are bash comments and have no runtime effect.
+
+Do **not** sprinkle `set -eo pipefail` into every step to silence the lint —
+that approach was tried (PR #492) and was rejected because it adds noise,
+drifts as new steps are added, and doesn't address the actual silent-failure
+patterns that the lint surfaces. Use targeted `set -eo pipefail` only when a
+step has a real fail-fast requirement that the lint cannot express (the
+current uses are on AWF/MCPG download and the `tee`-piped agent run).
+
+The exclude list (`SC1090`, `SC1091`, `SC2034`, `SC2016`) is documented in
+`tests/bash_lint_tests.rs`. Each entry has a justification — do not extend
+without one.

--- a/src/compile/extensions/trigger_filters.rs
+++ b/src/compile/extensions/trigger_filters.rs
@@ -101,6 +101,7 @@ impl CompilerExtension for TriggerFiltersExtension {
         let mut steps = Vec::new();
         steps.push(format!(
             r#"- bash: |
+    set -eo pipefail
     mkdir -p /tmp/ado-aw-scripts
     curl -fsSL "{RELEASE_BASE_URL}/v{version}/checksums.txt" -o /tmp/ado-aw-scripts/checksums.txt
     curl -fsSL "{RELEASE_BASE_URL}/v{version}/scripts.zip" -o /tmp/ado-aw-scripts/scripts.zip

--- a/src/data/1es-base.yml
+++ b/src/data/1es-base.yml
@@ -59,6 +59,7 @@ extends:
                 {{ engine_install_steps }}
 
                 - bash: |
+                    set -eo pipefail
                     COMPILER_VERSION="{{ compiler_version }}"
                     DOWNLOAD_DIR="$(Pipeline.Workspace)/agentic-pipeline-compiler"
                     DOWNLOAD_URL="https://github.com/githubnext/ado-aw/releases/download/v${COMPILER_VERSION}/ado-aw-linux-x64"
@@ -70,7 +71,7 @@ extends:
                     curl -fsSL -o "$DOWNLOAD_DIR/checksums.txt" "$CHECKSUM_URL"
 
                     echo "Verifying checksum..."
-                    cd "$DOWNLOAD_DIR"
+                    cd "$DOWNLOAD_DIR" || exit 1
                     grep "ado-aw-linux-x64" checksums.txt | sha256sum -c -
                     mv ado-aw-linux-x64 ado-aw
                     chmod +x ado-aw
@@ -156,7 +157,7 @@ extends:
                     curl -fsSL -o "$DOWNLOAD_DIR/checksums.txt" "$CHECKSUM_URL"
 
                     echo "Verifying checksum..."
-                    cd "$DOWNLOAD_DIR"
+                    cd "$DOWNLOAD_DIR" || exit 1
                     grep "awf-linux-x64" checksums.txt | sha256sum -c -
                     mv awf-linux-x64 awf
                     chmod +x awf
@@ -204,6 +205,7 @@ extends:
 
                     # Wait for server to be ready
                     READY=false
+                    # shellcheck disable=SC2034 # i is intentionally unused; wait-N-times loop
                     for i in $(seq 1 30); do
                       if curl -sf "http://localhost:$SAFE_OUTPUTS_PORT/health" > /dev/null 2>&1; then
                         echo "SafeOutputs HTTP server is ready"
@@ -267,6 +269,7 @@ extends:
 
                     # Wait for MCPG to be ready
                     READY=false
+                    # shellcheck disable=SC2034 # i is intentionally unused; wait-N-times loop
                     for i in $(seq 1 30); do
                       if curl -sf "http://localhost:{{ mcpg_port }}/health" > /dev/null 2>&1; then
                         echo "MCPG is ready"
@@ -284,6 +287,7 @@ extends:
                     # Health check passing doesn't guarantee stdout is flushed, so poll.
                     echo "Waiting for gateway output file..."
                     GATEWAY_READY=false
+                    # shellcheck disable=SC2034 # i is intentionally unused; wait-N-times loop
                     for i in $(seq 1 15); do
                       if [ -s "$GATEWAY_OUTPUT" ] && jq -e '.mcpServers' "$GATEWAY_OUTPUT" > /dev/null 2>&1; then
                         echo "Gateway output is ready"
@@ -361,7 +365,7 @@ extends:
                       "$(Pipeline.Workspace)/awf/awf" logs summary --source "$(Agent.TempDirectory)/staging/logs/firewall" 2>/dev/null || true
                     fi
 
-                    exit $AGENT_EXIT_CODE
+                    exit "$AGENT_EXIT_CODE"
                   displayName: "Run copilot (AWF network isolated)"
                   workingDirectory: {{ working_directory }}
                   env:
@@ -433,6 +437,7 @@ extends:
                 {{ engine_install_steps }}
 
                 - bash: |
+                    set -eo pipefail
                     COMPILER_VERSION="{{ compiler_version }}"
                     DOWNLOAD_DIR="$(Pipeline.Workspace)/agentic-pipeline-compiler"
                     DOWNLOAD_URL="https://github.com/githubnext/ado-aw/releases/download/v${COMPILER_VERSION}/ado-aw-linux-x64"
@@ -444,7 +449,7 @@ extends:
                     curl -fsSL -o "$DOWNLOAD_DIR/checksums.txt" "$CHECKSUM_URL"
 
                     echo "Verifying checksum..."
-                    cd "$DOWNLOAD_DIR"
+                    cd "$DOWNLOAD_DIR" || exit 1
                     grep "ado-aw-linux-x64" checksums.txt | sha256sum -c -
                     mv ado-aw-linux-x64 ado-aw
                     chmod +x ado-aw
@@ -469,7 +474,7 @@ extends:
                     curl -fsSL -o "$DOWNLOAD_DIR/checksums.txt" "$CHECKSUM_URL"
 
                     echo "Verifying checksum..."
-                    cd "$DOWNLOAD_DIR"
+                    cd "$DOWNLOAD_DIR" || exit 1
                     grep "awf-linux-x64" checksums.txt | sha256sum -c -
                     mv awf-linux-x64 awf
                     chmod +x awf
@@ -487,8 +492,8 @@ extends:
                   displayName: "Pre-pull AWF container images (v{{ firewall_version }})"
 
                 - bash: |
-                    mkdir -p {{ working_directory }}/safe_outputs
-                    cp -a "$(Pipeline.Workspace)/agent_outputs_$(Build.BuildId)/."  {{ working_directory }}/safe_outputs
+                    mkdir -p "{{ working_directory }}/safe_outputs"
+                    cp -a "$(Pipeline.Workspace)/agent_outputs_$(Build.BuildId)/."  "{{ working_directory }}/safe_outputs"
                   displayName: "Prepare safe outputs for analysis"
 
                 - bash: |
@@ -526,7 +531,7 @@ extends:
                       | tee "$THREAT_OUTPUT_FILE" \
                       && AGENT_EXIT_CODE=0 || AGENT_EXIT_CODE=$?
 
-                    exit $AGENT_EXIT_CODE
+                    exit "$AGENT_EXIT_CODE"
                   displayName: "Run threat analysis (AWF network isolated)"
                   workingDirectory: {{ working_directory }}
                   env:
@@ -550,7 +555,7 @@ extends:
                       RESULT_LINE=$(grep "THREAT_DETECTION_RESULT:" "$(Agent.TempDirectory)/threat-analysis-output.txt" | tail -1)
                       if [ -n "$RESULT_LINE" ]; then
                         # Extract JSON after the prefix
-                        JSON_CONTENT=$(echo "$RESULT_LINE" | sed 's/.*THREAT_DETECTION_RESULT://')
+                        JSON_CONTENT="${RESULT_LINE##*THREAT_DETECTION_RESULT:}"
                         echo "$JSON_CONTENT" > "$(Agent.TempDirectory)/analyzed_outputs/threat-analysis.json"
                         echo "Extracted threat analysis JSON:"
                         cat "$(Agent.TempDirectory)/analyzed_outputs/threat-analysis.json"
@@ -635,6 +640,7 @@ extends:
                   artifact: analyzed_outputs_$(Build.BuildId)
 
                 - bash: |
+                    set -eo pipefail
                     COMPILER_VERSION="{{ compiler_version }}"
                     DOWNLOAD_DIR="$(Pipeline.Workspace)/agentic-pipeline-compiler"
                     DOWNLOAD_URL="https://github.com/githubnext/ado-aw/releases/download/v${COMPILER_VERSION}/ado-aw-linux-x64"
@@ -646,7 +652,7 @@ extends:
                     curl -fsSL -o "$DOWNLOAD_DIR/checksums.txt" "$CHECKSUM_URL"
 
                     echo "Verifying checksum..."
-                    cd "$DOWNLOAD_DIR"
+                    cd "$DOWNLOAD_DIR" || exit 1
                     grep "ado-aw-linux-x64" checksums.txt | sha256sum -c -
                     mv ado-aw-linux-x64 ado-aw
                     chmod +x ado-aw

--- a/src/data/1es-base.yml
+++ b/src/data/1es-base.yml
@@ -223,14 +223,15 @@ extends:
                 # Start MCP Gateway (MCPG) on host
                 - bash: |
                     # Substitute runtime values into MCPG config
-                    MCPG_CONFIG=$(cat /tmp/awf-tools/staging/mcpg-config.json \
-                      | sed "s|\${SAFE_OUTPUTS_PORT}|$(SAFE_OUTPUTS_PORT)|g" \
-                      | sed "s|\${SAFE_OUTPUTS_API_KEY}|$(SAFE_OUTPUTS_API_KEY)|g" \
-                      | sed "s|\${MCP_GATEWAY_API_KEY}|$(MCP_GATEWAY_API_KEY)|g")
+                    MCPG_CONFIG=$(sed \
+                      -e "s|\${SAFE_OUTPUTS_PORT}|$(SAFE_OUTPUTS_PORT)|g" \
+                      -e "s|\${SAFE_OUTPUTS_API_KEY}|$(SAFE_OUTPUTS_API_KEY)|g" \
+                      -e "s|\${MCP_GATEWAY_API_KEY}|$(MCP_GATEWAY_API_KEY)|g" \
+                      /tmp/awf-tools/staging/mcpg-config.json)
 
                     # Log the template config (before API key substitution) for debugging.
                     echo "Starting MCPG with config template:"
-                    cat /tmp/awf-tools/staging/mcpg-config.json | python3 -m json.tool
+                    python3 -m json.tool < /tmp/awf-tools/staging/mcpg-config.json
 
                     # Remove any leftover container or stale output from a previous interrupted run
                     # (--rm only cleans up on clean exit; OOM/SIGKILL may leave it behind)

--- a/src/data/base.yml
+++ b/src/data/base.yml
@@ -30,6 +30,7 @@ jobs:
       {{ engine_install_steps }}
 
       - bash: |
+          set -eo pipefail
           COMPILER_VERSION="{{ compiler_version }}"
           DOWNLOAD_DIR="$(Pipeline.Workspace)/agentic-pipeline-compiler"
           DOWNLOAD_URL="https://github.com/githubnext/ado-aw/releases/download/v${COMPILER_VERSION}/ado-aw-linux-x64"
@@ -41,7 +42,7 @@ jobs:
           curl -fsSL -o "$DOWNLOAD_DIR/checksums.txt" "$CHECKSUM_URL"
 
           echo "Verifying checksum..."
-          cd "$DOWNLOAD_DIR"
+          cd "$DOWNLOAD_DIR" || exit 1
           grep "ado-aw-linux-x64" checksums.txt | sha256sum -c -
           mv ado-aw-linux-x64 ado-aw
           chmod +x ado-aw
@@ -127,7 +128,7 @@ jobs:
           curl -fsSL -o "$DOWNLOAD_DIR/checksums.txt" "$CHECKSUM_URL"
 
           echo "Verifying checksum..."
-          cd "$DOWNLOAD_DIR"
+          cd "$DOWNLOAD_DIR" || exit 1
           grep "awf-linux-x64" checksums.txt | sha256sum -c -
           mv awf-linux-x64 awf
           chmod +x awf
@@ -175,6 +176,7 @@ jobs:
 
           # Wait for server to be ready
           READY=false
+          # shellcheck disable=SC2034 # i is intentionally unused; wait-N-times loop
           for i in $(seq 1 30); do
             if curl -sf "http://localhost:$SAFE_OUTPUTS_PORT/health" > /dev/null 2>&1; then
               echo "SafeOutputs HTTP server is ready"
@@ -238,6 +240,7 @@ jobs:
 
           # Wait for MCPG to be ready
           READY=false
+          # shellcheck disable=SC2034 # i is intentionally unused; wait-N-times loop
           for i in $(seq 1 30); do
             if curl -sf "http://localhost:{{ mcpg_port }}/health" > /dev/null 2>&1; then
               echo "MCPG is ready"
@@ -255,6 +258,7 @@ jobs:
           # Health check passing doesn't guarantee stdout is flushed, so poll.
           echo "Waiting for gateway output file..."
           GATEWAY_READY=false
+          # shellcheck disable=SC2034 # i is intentionally unused; wait-N-times loop
           for i in $(seq 1 15); do
             if [ -s "$GATEWAY_OUTPUT" ] && jq -e '.mcpServers' "$GATEWAY_OUTPUT" > /dev/null 2>&1; then
               echo "Gateway output is ready"
@@ -332,7 +336,7 @@ jobs:
             "$(Pipeline.Workspace)/awf/awf" logs summary --source "$(Agent.TempDirectory)/staging/logs/firewall" 2>/dev/null || true
           fi
 
-          exit $AGENT_EXIT_CODE
+          exit "$AGENT_EXIT_CODE"
         displayName: "Run copilot (AWF network isolated)"
         workingDirectory: {{ working_directory }}
         env:
@@ -402,6 +406,7 @@ jobs:
       {{ engine_install_steps }}
 
       - bash: |
+          set -eo pipefail
           COMPILER_VERSION="{{ compiler_version }}"
           DOWNLOAD_DIR="$(Pipeline.Workspace)/agentic-pipeline-compiler"
           DOWNLOAD_URL="https://github.com/githubnext/ado-aw/releases/download/v${COMPILER_VERSION}/ado-aw-linux-x64"
@@ -413,7 +418,7 @@ jobs:
           curl -fsSL -o "$DOWNLOAD_DIR/checksums.txt" "$CHECKSUM_URL"
 
           echo "Verifying checksum..."
-          cd "$DOWNLOAD_DIR"
+          cd "$DOWNLOAD_DIR" || exit 1
           grep "ado-aw-linux-x64" checksums.txt | sha256sum -c -
           mv ado-aw-linux-x64 ado-aw
           chmod +x ado-aw
@@ -438,7 +443,7 @@ jobs:
           curl -fsSL -o "$DOWNLOAD_DIR/checksums.txt" "$CHECKSUM_URL"
 
           echo "Verifying checksum..."
-          cd "$DOWNLOAD_DIR"
+          cd "$DOWNLOAD_DIR" || exit 1
           grep "awf-linux-x64" checksums.txt | sha256sum -c -
           mv awf-linux-x64 awf
           chmod +x awf
@@ -456,8 +461,8 @@ jobs:
         displayName: "Pre-pull AWF container images (v{{ firewall_version }})"
 
       - bash: |
-          mkdir -p {{ working_directory }}/safe_outputs
-          cp -a "$(Pipeline.Workspace)/agent_outputs_$(Build.BuildId)/."  {{ working_directory }}/safe_outputs
+          mkdir -p "{{ working_directory }}/safe_outputs"
+          cp -a "$(Pipeline.Workspace)/agent_outputs_$(Build.BuildId)/."  "{{ working_directory }}/safe_outputs"
         displayName: "Prepare safe outputs for analysis"
 
       - bash: |
@@ -495,7 +500,7 @@ jobs:
             | tee "$THREAT_OUTPUT_FILE" \
             && AGENT_EXIT_CODE=0 || AGENT_EXIT_CODE=$?
 
-          exit $AGENT_EXIT_CODE
+          exit "$AGENT_EXIT_CODE"
         displayName: "Run threat analysis (AWF network isolated)"
         workingDirectory: {{ working_directory }}
         env:
@@ -519,7 +524,7 @@ jobs:
             RESULT_LINE=$(grep "THREAT_DETECTION_RESULT:" "$(Agent.TempDirectory)/threat-analysis-output.txt" | tail -1)
             if [ -n "$RESULT_LINE" ]; then
               # Extract JSON after the prefix
-              JSON_CONTENT=$(echo "$RESULT_LINE" | sed 's/.*THREAT_DETECTION_RESULT://')
+              JSON_CONTENT="${RESULT_LINE##*THREAT_DETECTION_RESULT:}"
               echo "$JSON_CONTENT" > "$(Agent.TempDirectory)/analyzed_outputs/threat-analysis.json"
               echo "Extracted threat analysis JSON:"
               cat "$(Agent.TempDirectory)/analyzed_outputs/threat-analysis.json"
@@ -603,6 +608,7 @@ jobs:
         artifact: analyzed_outputs_$(Build.BuildId)
 
       - bash: |
+          set -eo pipefail
           COMPILER_VERSION="{{ compiler_version }}"
           DOWNLOAD_DIR="$(Pipeline.Workspace)/agentic-pipeline-compiler"
           DOWNLOAD_URL="https://github.com/githubnext/ado-aw/releases/download/v${COMPILER_VERSION}/ado-aw-linux-x64"
@@ -614,7 +620,7 @@ jobs:
           curl -fsSL -o "$DOWNLOAD_DIR/checksums.txt" "$CHECKSUM_URL"
 
           echo "Verifying checksum..."
-          cd "$DOWNLOAD_DIR"
+          cd "$DOWNLOAD_DIR" || exit 1
           grep "ado-aw-linux-x64" checksums.txt | sha256sum -c -
           mv ado-aw-linux-x64 ado-aw
           chmod +x ado-aw

--- a/src/data/base.yml
+++ b/src/data/base.yml
@@ -194,14 +194,15 @@ jobs:
       # Start MCP Gateway (MCPG) on host
       - bash: |
           # Substitute runtime values into MCPG config
-          MCPG_CONFIG=$(cat /tmp/awf-tools/staging/mcpg-config.json \
-            | sed "s|\${SAFE_OUTPUTS_PORT}|$(SAFE_OUTPUTS_PORT)|g" \
-            | sed "s|\${SAFE_OUTPUTS_API_KEY}|$(SAFE_OUTPUTS_API_KEY)|g" \
-            | sed "s|\${MCP_GATEWAY_API_KEY}|$(MCP_GATEWAY_API_KEY)|g")
+          MCPG_CONFIG=$(sed \
+            -e "s|\${SAFE_OUTPUTS_PORT}|$(SAFE_OUTPUTS_PORT)|g" \
+            -e "s|\${SAFE_OUTPUTS_API_KEY}|$(SAFE_OUTPUTS_API_KEY)|g" \
+            -e "s|\${MCP_GATEWAY_API_KEY}|$(MCP_GATEWAY_API_KEY)|g" \
+            /tmp/awf-tools/staging/mcpg-config.json)
 
           # Log the template config (before API key substitution) for debugging.
           echo "Starting MCPG with config template:"
-          cat /tmp/awf-tools/staging/mcpg-config.json | python3 -m json.tool
+          python3 -m json.tool < /tmp/awf-tools/staging/mcpg-config.json
 
           # Remove any leftover container or stale output from a previous interrupted run
           # (--rm only cleans up on clean exit; OOM/SIGKILL may leave it behind)

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -105,7 +105,11 @@ impl Engine {
     /// Used by log collection steps to copy engine logs to pipeline artifacts.
     pub fn log_dir(&self) -> &str {
         match self {
-            Engine::Copilot => "~/.copilot/logs",
+            // `$HOME` (not `~`) so that the bash `[ -d "..." ]` test below
+            // actually expands. Tilde does not expand inside double quotes,
+            // so the previous value caused the directory check to always
+            // fail and Copilot logs were silently never collected.
+            Engine::Copilot => "$HOME/.copilot/logs",
         }
     }
 

--- a/src/runtimes/dotnet/mod.rs
+++ b/src/runtimes/dotnet/mod.rs
@@ -207,23 +207,23 @@ pub fn generate_ensure_nuget_config(config: &DotnetRuntimeConfig) -> String {
     let feed_url = config.feed_url().unwrap_or("https://api.nuget.org/v3/index.json");
 
     format!(
-        "\
-- bash: |\n\
-    if [ ! -f nuget.config ] && [ ! -f NuGet.config ] && [ ! -f NuGet.Config ]; then\n\
-      cat > nuget.config <<'EOF'\n\
-    <?xml version=\"1.0\" encoding=\"utf-8\"?>\n\
-    <configuration>\n\
-      <packageSources>\n\
-        <clear />\n\
-        <add key=\"internal\" value=\"{feed_url}\" />\n\
-      </packageSources>\n\
-    </configuration>\n\
-    EOF\n\
-      echo 'Created nuget.config with source={feed_url}'\n\
-    else\n\
-      echo 'nuget.config already exists, skipping creation'\n\
-    fi\n\
-  displayName: 'Ensure nuget.config exists'"
+        r#"- bash: |
+    set -eo pipefail
+    if [ ! -f nuget.config ] && [ ! -f NuGet.config ] && [ ! -f NuGet.Config ]; then
+      cat > nuget.config <<'EOF'
+    <?xml version="1.0" encoding="utf-8"?>
+    <configuration>
+      <packageSources>
+        <clear />
+        <add key="internal" value="{feed_url}" />
+      </packageSources>
+    </configuration>
+    EOF
+      echo 'Created nuget.config with source={feed_url}'
+    else
+      echo 'nuget.config already exists, skipping creation'
+    fi
+  displayName: 'Ensure nuget.config exists'"#
     )
 }
 

--- a/src/runtimes/lean/mod.rs
+++ b/src/runtimes/lean/mod.rs
@@ -91,6 +91,7 @@ pub fn generate_lean_install(config: &LeanRuntimeConfig) -> String {
     let toolchain = config.toolchain().unwrap_or("stable");
     let script = format!(
         "\
+set -eo pipefail
 curl https://elan.lean-lang.org/elan-init.sh -sSf | sh -s -- -y --default-toolchain {toolchain}
 echo \"##vso[task.prependpath]$HOME/.elan/bin\"
 export PATH=\"$HOME/.elan/bin:$PATH\"

--- a/src/runtimes/node/mod.rs
+++ b/src/runtimes/node/mod.rs
@@ -155,15 +155,15 @@ pub fn generate_ensure_npmrc(config: &NodeRuntimeConfig) -> String {
         .unwrap_or("https://registry.npmjs.org/");
 
     format!(
-        "\
-- bash: |\n\
-    if [ ! -f .npmrc ]; then\n\
-      echo 'registry={registry}' > .npmrc\n\
-      echo 'Created .npmrc with registry={registry}'\n\
-    else\n\
-      echo '.npmrc already exists, skipping creation'\n\
-    fi\n\
-  displayName: 'Ensure .npmrc exists'"
+        r#"- bash: |
+    set -eo pipefail
+    if [ ! -f .npmrc ]; then
+      echo 'registry={registry}' > .npmrc
+      echo 'Created .npmrc with registry={registry}'
+    else
+      echo '.npmrc already exists, skipping creation'
+    fi
+  displayName: 'Ensure .npmrc exists'"#
     )
 }
 

--- a/tests/bash_lint_tests.rs
+++ b/tests/bash_lint_tests.rs
@@ -63,6 +63,12 @@ const SHELLCHECK_EXCLUDE: &str = "SC1090,SC1091";
 /// first-class tool that emits bash (cache-memory). Add a fixture here only
 /// when a new generator is introduced that none of the existing fixtures
 /// exercises.
+///
+/// Note: `runtime-coverage-agent.md` and `runtime-coverage-1es-agent.md` are
+/// the same agent compiled to different targets so we exercise code-generated
+/// runtime/tool bash on both `standalone` and `1es`. Today their bash bodies
+/// are byte-identical, but a future target-specific divergence in a generator
+/// would only be caught with both fixtures in the harness.
 const FIXTURES: &[&str] = &[
     "minimal-agent.md",
     "complete-agent.md",
@@ -71,6 +77,7 @@ const FIXTURES: &[&str] = &[
     "pipeline-trigger-agent.md",
     "pipeline-filter-agent.md",
     "runtime-coverage-agent.md",
+    "runtime-coverage-1es-agent.md",
 ];
 
 /// Step display names that the lint expects to find at least once across all
@@ -129,8 +136,9 @@ fn fresh_workspace() -> TempDir {
 }
 
 /// Compile a fixture by copying it into `workspace` and invoking
-/// `ado-aw compile`. Returns the path to the generated `.lock.yml`.
-fn compile_fixture(workspace: &Path, fixture: &str) -> PathBuf {
+/// `ado-aw compile`. Returns the path to the generated `.lock.yml` and the
+/// target (`"standalone"` or `"1es"`) reported in compiler stdout.
+fn compile_fixture(workspace: &Path, fixture: &str) -> (PathBuf, String) {
     let src = fixtures_dir().join(fixture);
     let dest = workspace.join(fixture);
     std::fs::copy(&src, &dest)
@@ -149,9 +157,22 @@ fn compile_fixture(workspace: &Path, fixture: &str) -> PathBuf {
         String::from_utf8_lossy(&output.stderr),
     );
 
+    // `ado-aw compile` prints `Generated <target> pipeline: <file>` to stdout;
+    // parse the target so the test can assert coverage of every known target.
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let target = if stdout.contains("Generated 1ES pipeline:") {
+        "1es"
+    } else if stdout.contains("Generated standalone pipeline:") {
+        "standalone"
+    } else {
+        panic!(
+            "could not determine compile target for {fixture} from stdout:\n{stdout}"
+        )
+    };
+
     let lock = dest.with_extension("lock.yml");
     assert!(lock.exists(), "expected lock file {}", lock.display());
-    lock
+    (lock, target.to_string())
 }
 
 /// A single bash body extracted from a compiled pipeline.
@@ -287,9 +308,12 @@ fn compiled_bash_bodies_pass_shellcheck() {
     let workspace = fresh_workspace();
     let mut report: BTreeMap<String, Vec<String>> = BTreeMap::new();
     let mut all_display_names: Vec<String> = Vec::new();
+    let mut targets_seen: std::collections::BTreeSet<String> =
+        std::collections::BTreeSet::new();
 
     for fixture in FIXTURES {
-        let lock = compile_fixture(workspace.path(), fixture);
+        let (lock, target) = compile_fixture(workspace.path(), fixture);
+        targets_seen.insert(target);
         for body in extract_bash_bodies(&lock) {
             all_display_names.push(body.display_name.clone());
             let findings = run_shellcheck(&body.body);
@@ -303,6 +327,25 @@ fn compiled_bash_bodies_pass_shellcheck() {
             }
         }
     }
+
+    // Target coverage — assert that every known compile target is exercised by
+    // at least one fixture, so we shellcheck the bash output of every template
+    // (`src/data/base.yml` and `src/data/1es-base.yml`) and every code-generated
+    // step on both targets.
+    const REQUIRED_TARGETS: &[&str] = &["standalone", "1es"];
+    let missing_targets: Vec<&str> = REQUIRED_TARGETS
+        .iter()
+        .copied()
+        .filter(|t| !targets_seen.contains(*t))
+        .collect();
+    assert!(
+        missing_targets.is_empty(),
+        "no fixture compiles to the following target(s): {:?}\n\
+         Each compile target has its own template under src/data/ whose bash \
+         bodies need shellchecking. Add a fixture with `target: <missing>` to \
+         tests/fixtures/ and list it in FIXTURES.",
+        missing_targets
+    );
 
     // Coverage check — every required generator must appear in the harvested
     // step list, otherwise a fixture has stopped exercising its generator.

--- a/tests/bash_lint_tests.rs
+++ b/tests/bash_lint_tests.rs
@@ -1,0 +1,354 @@
+//! Integration test that lints the bash bodies of compiled pipeline YAML
+//! using `shellcheck`.
+//!
+//! ## Why this test exists
+//!
+//! Pipeline templates contain dozens of multi-line `bash:` steps. ADO bash
+//! steps fail only on the *last* command's exit code by default, which makes
+//! it easy for an earlier command to fail silently and the step to still
+//! report green. Rather than spread `set -eo pipefail` boilerplate across
+//! every step, we lint each bash body with shellcheck. Real silent-failure
+//! patterns surface here:
+//!
+//! * **SC2164** — `cd $X` without `|| exit` (the canonical silent-failure)
+//! * **SC2155** — `local var=$(cmd)` masking the inner exit code
+//! * **SC2086 / SC2046** — unquoted variables / command substitutions
+//! * **SC2154** — variables referenced but never assigned
+//! * **SC2088** — tilde inside double quotes (does not expand)
+//!
+//! ## How it works
+//!
+//! 1. Compiles a representative set of fixtures with `ado-aw compile`.
+//! 2. For each generated `*.lock.yml`, walks the YAML and collects every
+//!    `bash:` body that is the value of a step entry (i.e., a mapping that
+//!    is itself an element of a sequence). This avoids false positives from
+//!    arbitrary `bash` keys nested inside `env:` blocks or comments.
+//! 3. Pipes each body to `shellcheck --shell=bash --format=json -`.
+//! 4. Aggregates findings; the test fails with a structured report listing
+//!    every finding by fixture / step / line / code / message.
+//!
+//! ## Skip vs. enforce
+//!
+//! By default, if `shellcheck` is not installed locally the test prints a
+//! notice and returns early. CI runners are expected to set the
+//! `ENFORCE_BASH_LINT` environment variable so a missing shellcheck becomes
+//! a hard failure rather than a silent skip. To install shellcheck locally:
+//!
+//! * macOS: `brew install shellcheck`
+//! * Debian / Ubuntu: `apt-get install -y shellcheck`
+
+use std::collections::BTreeMap;
+use std::io::Write;
+use std::path::{Path, PathBuf};
+use std::process::{Command, Stdio};
+
+use serde_yaml::Value;
+use tempfile::TempDir;
+
+/// Shellcheck rule codes that are intentionally suppressed for ADO bash steps.
+///
+/// Each entry has a justification — do not extend this list without one.
+/// The list is deliberately short: project-specific suppressions belong as
+/// per-line `# shellcheck disable=SCxxxx` comments inside the bash body, not
+/// as a global override.
+///
+/// * **SC1090, SC1091** — `source` paths that include ADO macros
+///   (e.g. `$(Pipeline.Workspace)`) are dynamic and cannot be resolved by
+///   shellcheck.
+const SHELLCHECK_EXCLUDE: &str = "SC1090,SC1091";
+
+/// Fixtures exercised by the lint. Chosen to collectively cover every bash-step
+/// generator in the codebase: standalone + 1ES templates, every runtime that
+/// emits bash steps (Lean, Node with feed-url, .NET with feed-url), and every
+/// first-class tool that emits bash (cache-memory). Add a fixture here only
+/// when a new generator is introduced that none of the existing fixtures
+/// exercises.
+const FIXTURES: &[&str] = &[
+    "minimal-agent.md",
+    "complete-agent.md",
+    "1es-test-agent.md",
+    "azure-devops-mcp-agent.md",
+    "pipeline-trigger-agent.md",
+    "pipeline-filter-agent.md",
+    "runtime-coverage-agent.md",
+];
+
+/// Step display names that the lint expects to find at least once across all
+/// fixtures. If any of these is missing it means the corresponding generator
+/// is not being exercised — almost always because a fixture was deleted or
+/// the generator's output changed without updating the coverage list.
+const REQUIRED_STEP_DISPLAY_NAMES: &[&str] = &[
+    // Static templates (standalone + 1ES)
+    "Prepare MCPG config",
+    "Prepare tooling",
+    "Prepare agent prompt",
+    "Run copilot (AWF network isolated)",
+    "Run threat analysis (AWF network isolated)",
+    "Evaluate threat analysis",
+    "Execute safe outputs (Stage 3)",
+    // Rust generators
+    "Install Lean 4 (elan)",                  // src/runtimes/lean/mod.rs
+    "Append Lean 4 prompt",                   // src/runtimes/lean/extension.rs
+    "Ensure .npmrc exists",                   // src/runtimes/node/mod.rs
+    "Ensure nuget.config exists",             // src/runtimes/dotnet/mod.rs
+    "Restore previous agent memory",          // src/tools/cache_memory/extension.rs
+    "Initialize empty agent memory (clearMemory=true)",
+    "Generate GITHUB_PATH file",              // src/compile/common.rs (AWF path step)
+];
+
+fn ado_aw_binary() -> PathBuf {
+    PathBuf::from(env!("CARGO_BIN_EXE_ado-aw"))
+}
+
+fn fixtures_dir() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures")
+}
+
+/// Probe for the shellcheck binary. Returns `None` if it is not on PATH or
+/// fails to report a version.
+fn shellcheck_version() -> Option<String> {
+    let output = Command::new("shellcheck").arg("--version").output().ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    let text = String::from_utf8_lossy(&output.stdout);
+    text.lines()
+        .find(|l| l.starts_with("version:"))
+        .map(|l| l.trim().to_string())
+}
+
+/// A fresh `TempDir` plus a `.git/` marker so `ado-aw compile` can resolve
+/// repo-relative paths. RAII cleans up on drop, even on panic.
+fn fresh_workspace() -> TempDir {
+    let dir = tempfile::Builder::new()
+        .prefix("ado-aw-bash-lint-")
+        .tempdir()
+        .expect("create temp dir");
+    std::fs::create_dir(dir.path().join(".git")).expect("create .git dir");
+    dir
+}
+
+/// Compile a fixture by copying it into `workspace` and invoking
+/// `ado-aw compile`. Returns the path to the generated `.lock.yml`.
+fn compile_fixture(workspace: &Path, fixture: &str) -> PathBuf {
+    let src = fixtures_dir().join(fixture);
+    let dest = workspace.join(fixture);
+    std::fs::copy(&src, &dest)
+        .unwrap_or_else(|e| panic!("copy fixture {fixture}: {e}"));
+
+    let output = Command::new(ado_aw_binary())
+        .args(["compile", dest.to_str().unwrap()])
+        .current_dir(workspace)
+        .output()
+        .unwrap_or_else(|e| panic!("spawn ado-aw compile: {e}"));
+
+    assert!(
+        output.status.success(),
+        "ado-aw compile failed for {fixture}\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+    );
+
+    let lock = dest.with_extension("lock.yml");
+    assert!(lock.exists(), "expected lock file {}", lock.display());
+    lock
+}
+
+/// A single bash body extracted from a compiled pipeline.
+struct BashBody {
+    display_name: String,
+    body: String,
+}
+
+/// Walk a parsed YAML document and collect every step that has a literal
+/// block-scalar `bash:` body. Only mappings reached via a sequence element
+/// are considered candidate steps — this avoids treating an arbitrary
+/// `bash:` key inside, e.g., an `env:` block as a step.
+fn extract_bash_bodies(yml_path: &Path) -> Vec<BashBody> {
+    let content = std::fs::read_to_string(yml_path)
+        .unwrap_or_else(|e| panic!("read {}: {e}", yml_path.display()));
+    let doc: Value = serde_yaml::from_str(&content)
+        .unwrap_or_else(|e| panic!("parse YAML {}: {e}", yml_path.display()));
+
+    let mut out = Vec::new();
+    collect(&doc, /* in_sequence_element = */ false, &mut out);
+    out
+}
+
+fn collect(node: &Value, in_sequence_element: bool, out: &mut Vec<BashBody>) {
+    match node {
+        Value::Mapping(map) => {
+            // Only treat this mapping as a step candidate if we reached it
+            // by descending into a sequence (i.e., it's `[bash: |, …]`).
+            if in_sequence_element
+                && let Some(Value::String(body)) = map.get(Value::String("bash".into()))
+            {
+                let display_name = map
+                    .get(Value::String("displayName".into()))
+                    .and_then(Value::as_str)
+                    .unwrap_or("<unnamed>")
+                    .to_string();
+                out.push(BashBody {
+                    display_name,
+                    body: body.clone(),
+                });
+            }
+            for (_, v) in map {
+                collect(v, /* in_sequence_element = */ false, out);
+            }
+        }
+        Value::Sequence(seq) => {
+            for v in seq {
+                collect(v, /* in_sequence_element = */ true, out);
+            }
+        }
+        _ => {}
+    }
+}
+
+/// Run shellcheck on a bash body. Returns the parsed JSON findings.
+fn run_shellcheck(body: &str) -> serde_json::Value {
+    let mut child = Command::new("shellcheck")
+        .args([
+            "--shell=bash",
+            "--format=json",
+            &format!("--exclude={SHELLCHECK_EXCLUDE}"),
+            "-",
+        ])
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("spawn shellcheck");
+
+    child
+        .stdin
+        .as_mut()
+        .expect("shellcheck stdin")
+        .write_all(body.as_bytes())
+        .expect("write to shellcheck stdin");
+    drop(child.stdin.take());
+
+    let output = child.wait_with_output().expect("wait for shellcheck");
+
+    // shellcheck exits 0 when clean and 1 when findings exist; both produce
+    // valid JSON on stdout. Higher exit codes (e.g. parse error) are real
+    // failures and should surface in the test output.
+    let exit = output.status.code().unwrap_or(-1);
+    if exit > 1 {
+        panic!(
+            "shellcheck failed (exit {exit}):\nstdout:\n{}\nstderr:\n{}",
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr),
+        );
+    }
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let trimmed = stdout.trim();
+    if trimmed.is_empty() {
+        return serde_json::Value::Array(Vec::new());
+    }
+
+    serde_json::from_str(trimmed)
+        .unwrap_or_else(|e| panic!("parse shellcheck JSON: {e}\nraw:\n{stdout}"))
+}
+
+/// Format a single shellcheck finding for the test failure report.
+fn format_finding(fixture: &str, display_name: &str, finding: &serde_json::Value) -> String {
+    let code = finding["code"].as_i64().unwrap_or(0);
+    let level = finding["level"].as_str().unwrap_or("?");
+    let line = finding["line"].as_i64().unwrap_or(0);
+    let message = finding["message"].as_str().unwrap_or("?");
+    format!("  [{level}] SC{code} {fixture} :: {display_name:?} (body L{line}): {message}")
+}
+
+#[test]
+fn compiled_bash_bodies_pass_shellcheck() {
+    let enforce = std::env::var_os("ENFORCE_BASH_LINT").is_some();
+
+    let Some(version) = shellcheck_version() else {
+        if enforce {
+            panic!(
+                "ENFORCE_BASH_LINT is set but `shellcheck` is not on PATH. \
+                 Install it in CI (e.g. `apt-get install -y shellcheck`) \
+                 or unset ENFORCE_BASH_LINT for local development."
+            );
+        }
+        eprintln!(
+            "skipping bash lint test: `shellcheck` not found on PATH. \
+             Install via your OS package manager (e.g. `brew install shellcheck`, \
+             `apt-get install -y shellcheck`). \
+             Set ENFORCE_BASH_LINT=1 to make this a hard failure (CI does)."
+        );
+        return;
+    };
+    eprintln!("using {version}");
+
+    let workspace = fresh_workspace();
+    let mut report: BTreeMap<String, Vec<String>> = BTreeMap::new();
+    let mut all_display_names: Vec<String> = Vec::new();
+
+    for fixture in FIXTURES {
+        let lock = compile_fixture(workspace.path(), fixture);
+        for body in extract_bash_bodies(&lock) {
+            all_display_names.push(body.display_name.clone());
+            let findings = run_shellcheck(&body.body);
+            if let Some(arr) = findings.as_array() {
+                for finding in arr {
+                    report
+                        .entry((*fixture).to_string())
+                        .or_default()
+                        .push(format_finding(fixture, &body.display_name, finding));
+                }
+            }
+        }
+    }
+
+    // Coverage check — every required generator must appear in the harvested
+    // step list, otherwise a fixture has stopped exercising its generator.
+    let missing: Vec<&str> = REQUIRED_STEP_DISPLAY_NAMES
+        .iter()
+        .copied()
+        .filter(|name| !all_display_names.iter().any(|d| d == name))
+        .collect();
+    assert!(
+        missing.is_empty(),
+        "the following step display names were not produced by any fixture, \
+         meaning their generator is not being linted:\n  {}\n\
+         Either add a fixture exercising the generator, or update \
+         REQUIRED_STEP_DISPLAY_NAMES if the generator was removed.",
+        missing.join("\n  ")
+    );
+
+    if !report.is_empty() {
+        let mut msg = String::from(
+            "shellcheck flagged silent-failure patterns in compiled bash bodies. \
+             Each finding represents a real or stylistic concern; fix the \
+             offending bash, or if intentional add `# shellcheck disable=SCxxxx` \
+             inline in the bash body (the directive is a comment and does not \
+             affect runtime behaviour).\n",
+        );
+        for (fixture, lines) in &report {
+            msg.push_str(&format!("\n--- {fixture} ---\n"));
+            for line in lines {
+                msg.push_str(line);
+                msg.push('\n');
+            }
+        }
+        panic!("{msg}");
+    }
+}
+
+/// Sanity check: every listed fixture exists. Catches typos in `FIXTURES`
+/// without paying the cost of compiling.
+#[test]
+fn every_listed_fixture_exists() {
+    for fixture in FIXTURES {
+        let path = fixtures_dir().join(fixture);
+        assert!(
+            path.exists(),
+            "fixture listed in FIXTURES but not on disk: {}",
+            path.display()
+        );
+    }
+}

--- a/tests/fixtures/runtime-coverage-1es-agent.md
+++ b/tests/fixtures/runtime-coverage-1es-agent.md
@@ -1,0 +1,24 @@
+---
+name: Runtime Coverage 1ES Agent
+description: 1ES variant of runtime-coverage-agent.md so the bash-lint test exercises code-generated runtime/tool bash bodies on the 1ES target as well as standalone
+target: 1es
+on:
+  schedule: daily
+runtimes:
+  lean: true
+  node:
+    version: "22.x"
+    feed-url: "https://pkgs.dev.azure.com/example/example/_packaging/example/npm/registry/"
+  dotnet:
+    version: "8.0.x"
+    feed-url: "https://pkgs.dev.azure.com/example/example/_packaging/example/nuget/v3/index.json"
+tools:
+  cache-memory: true
+---
+
+## Runtime Coverage 1ES Agent
+
+1ES variant of `runtime-coverage-agent.md`. Same runtimes and tools, compiled to
+the 1ES target so the bash-lint integration test analyses code-generated bash
+bodies on both targets. Today the runtime/tool extension generators emit
+target-agnostic bash, but this fixture guards against future divergence.

--- a/tests/fixtures/runtime-coverage-agent.md
+++ b/tests/fixtures/runtime-coverage-agent.md
@@ -1,0 +1,22 @@
+---
+name: Runtime Coverage Agent
+description: Lint-only fixture exercising Lean, Node, .NET runtimes and the cache-memory tool
+on:
+  schedule: daily
+runtimes:
+  lean: true
+  node:
+    version: "22.x"
+    feed-url: "https://pkgs.dev.azure.com/example/example/_packaging/example/npm/registry/"
+  dotnet:
+    version: "8.0.x"
+    feed-url: "https://pkgs.dev.azure.com/example/example/_packaging/example/nuget/v3/index.json"
+tools:
+  cache-memory: true
+---
+
+## Runtime Coverage Agent
+
+This agent enables every runtime that produces a code-generated bash step,
+plus the `cache-memory` tool. Its sole job is to compile cleanly so the
+bash-step lint can analyse those generated bodies.


### PR DESCRIPTION
Replaces #492 (the heavy-handed `set -eo pipefail` sweep) with a shellcheck-based integration test plus targeted bash fixes for the silent-failure patterns the lint actually surfaces. Closes the dissatisfaction expressed there: noise without enforcement that drifted on the next bash step.

## Why this is different from #492

| | #492 (sweep) | this PR (lint) |
|---|---|---|
| **Mechanism** | 27 inline `set -eo pipefail` lines spread across templates and Rust generators | one shellcheck integration test, no global prelude |
| **Enforcement** | none — relies on contributors remembering to add the line | `cargo test --test bash_lint_tests` blocks regressions; CI sets `ENFORCE_BASH_LINT=1` |
| **Drift** | inevitable: 4 sites already missed | impossible: the lint walks every compiled fixture |
| **Effect on real silent-failures** | did not touch any `2>/dev/null \|\| true` cleanup; in two spots actually *masked* failures more than the original (`grep ... \| tail -1 \|\| true`) | catches `cd` without `\|\|`, masked-return assignments, tilde-in-quotes, unquoted variables |
| **Template noise** | every step gets boilerplate | none — templates stay clean |

## Real bugs surfaced and fixed

These were latent and would have stayed latent under the #492 approach:

- **Copilot logs were never collected.** `Engine::Copilot::log_dir()` returned `"~/.copilot/logs"`. Tilde does not expand inside the double-quoted `[ -d "..." ]` test, so the directory check always failed and the `2>/dev/null || true` masked it. Fixed to `$HOME/.copilot/logs`.
- **`Ensure .npmrc exists` and `Ensure nuget.config exists` emit invalid YAML.** Both generators used Rust `\<newline>` line continuations in `format!`, which strip leading whitespace. The emitted body was flush-left against `- bash: |`, breaking YAML. Fixed by switching to raw string literals. (The fixture `runtime-coverage-agent.md` would not have parsed before this fix.)
- **ado-aw compiler download had no `set -o pipefail`.** `grep "ado-aw-linux-x64" checksums.txt | sha256sum -c -` silently passes when grep returns no match because `sha256sum -c -` returns 0 on empty input. The unverified binary would install successfully. Same pattern in the trigger-filters script download. AWF download was already protected (PR #439); ado-aw compiler download was missed.
- **Lean install** used `curl ... | sh` without pipefail — silent on curl failure.

Plus minor hygiene: `cd "$DOWNLOAD_DIR" || exit 1`, `exit "$AGENT_EXIT_CODE"`, quoted `{{ working_directory }}` substitutions, `${RESULT_LINE##*THREAT_DETECTION_RESULT:}` instead of `echo | sed`.

## What's NOT changed

- The two pre-existing targeted `set -eo pipefail` instances on AWF download / docker pull (PR #439) and on the `tee`-piped agent + threat-analysis runs are preserved. Those were correct.
- No `BashStep` Rust helper, no template injection mechanism — out of scope.
- No global `set -eo pipefail` sweep; targeted only where masked-pipeline exit codes are real.

## How the lint works

1. Compiles seven fixtures (including a new `runtime-coverage-agent.md` that exercises Lean, Node-with-feed-url, .NET-with-feed-url, and cache-memory).
2. For each `*.lock.yml`, walks the YAML and collects every `bash:` body that is the value of a sequence-element mapping (so an arbitrary `bash` key inside an `env:` block is not treated as a step).
3. Pipes each body to `shellcheck --shell=bash --format=json --exclude=SC1090,SC1091 -`.
4. Asserts every entry in `REQUIRED_STEP_DISPLAY_NAMES` was produced — catches fixture/generator drift.
5. Fails the test with a structured per-fixture/per-step report on any finding.

Excludes are limited to `SC1090` / `SC1091` (dynamic source paths) with a documented justification. Project-specific suppressions go inline as `# shellcheck disable=SCxxxx` comments — used in exactly one place for the wait-N-times `for i in $(seq …)` loop pattern, where `i` is intentionally unused.

## Skip vs. enforce

- **Locally**: the test prints a notice and returns early when `shellcheck` is not on PATH. Devs without it installed are unblocked.
- **CI**: `.github/workflows/rust-tests.yml` installs shellcheck and sets `ENFORCE_BASH_LINT=1` so a missing shellcheck becomes a hard failure rather than a silent skip. This was a blocking concern from the design review — without it, a runner image change could have silently disabled the lint.

## Validation

- All 1434 tests pass (1332 unit + 2 bash_lint + …).
- `cargo clippy --tests` clean for the new test.
- Verified the lint catches regressions: re-introduced the tilde bug, confirmed the test fails with a structured report, restored the fix.
- Verified `ENFORCE_BASH_LINT=1` runs the lint without skip.

## Documentation

- `AGENTS.md` Testing section: brief mention of the lint and the install command.
- `docs/extending.md`: new "Bash steps in pipeline templates" section explaining the lint, the exclude rationale, the inline-disable pattern for intentional cases, and explicit guidance not to sprinkle `set -eo pipefail` to silence the lint.
