### PR TITLE
docs: fix documentation drift — add prompts/ directory to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -136,6 +136,10 @@ Every compiled pipeline runs as three sequential jobs:
 │           └── execute.rs   # Stage 3 runtime (validate/copy)
 ├── ado-aw-derive/        # Proc-macro crate: #[derive(SanitizeConfig)], #[derive(SanitizeContent)]
 ├── examples/             # Example agent definitions
+├── prompts/              # AI agent prompt files for workflow authoring tasks
+│   ├── create-ado-agentic-workflow.md # Step-by-step guide for creating a new agentic pipeline
+│   ├── update-ado-agentic-workflow.md # Guide for modifying an existing agentic pipeline
+│   └── debug-ado-agentic-workflow.md  # Guide for troubleshooting a failing agentic pipeline
 ├── scripts/              # Supporting scripts shipped as release artifacts
 │   ├── gate-eval.py      # Python gate evaluator (data-driven filter evaluation)
 │   └── gate-spec.schema.json # JSON Schema for gate spec (generated from Rust types)
@@ -159,6 +163,15 @@ Every compiled pipeline runs as three sequential jobs:
 
 The detailed reference for each concept lives in [`docs/`](docs/). Use this
 index to jump to the right page.
+
+### Prompt files for workflow authoring
+
+- [`prompts/create-ado-agentic-workflow.md`](prompts/create-ado-agentic-workflow.md) — step-by-step
+  guide for creating a new agentic pipeline from scratch (interactive and non-interactive modes).
+- [`prompts/update-ado-agentic-workflow.md`](prompts/update-ado-agentic-workflow.md) — guide for
+  modifying an existing agentic pipeline (read-then-update workflow with validation).
+- [`prompts/debug-ado-agentic-workflow.md`](prompts/debug-ado-agentic-workflow.md) — guide for
+  troubleshooting a failing agentic pipeline and filing a diagnostic report.
 
 ### Authoring agent files
 


### PR DESCRIPTION
…ion index

The prompts/ directory contains three agent-facing prompt files that guide AI agents through common workflow authoring tasks, but it was missing from the AGENTS.md architecture tree and documentation index entirely:

- prompts/create-ado-agentic-workflow.md
- prompts/update-ado-agentic-workflow.md
- prompts/debug-ado-agentic-workflow.md

The README.md already documented these files in its Prompts & Skill Files section. AGENTS.md is now consistent with both the actual filesystem and README.md.

<!--
  ⚠️  PR TITLE = CHANGELOG ENTRY
  This repo uses squash-merge, so your PR title becomes the commit on main.
  release-please uses it for the changelog and version bump.

  Format:  type(scope): description
  Example: feat(compile): add S360 Breeze MCP as first-party tool

  Types that appear in the changelog:
    feat  → Features     (bumps minor version)
    fix   → Bug Fixes    (bumps patch version)

  Types that do NOT appear in the changelog (no version bump):
    chore, docs, refactor, test, ci, perf, build

  Bad:  "Allow workspace to target a repo alias"
  Good: "feat(compile): allow workspace to target a repo alias"
-->

## Summary

<!-- Brief description of what this PR does and why. -->

## Test plan

<!-- How was this tested? (cargo test, manual verification, etc.) -->
