### PR TITLE
feat(compile): add target: job and target: stage for ADO template output

### DIFF
--- a/src/compile/common.rs
+++ b/src/compile/common.rs
@@ -2861,11 +2861,11 @@ pub async fn compile_shared(
 ///
 /// Handles the full setup — collecting extensions, building the compile context,
 /// generating the stage prefix and template parameters, computing AWF/MCPG
-/// values — and delegates to [`compile_shared`].  The caller supplies:
+/// values — and delegates to [`compile_shared`]. The caller supplies:
 ///
 /// - `cfg`: target-specific settings (template string, integrity / debug flags).
 /// - `header_fn`: a function that generates the leading comment block prepended
-///   to the compiled YAML.  The two template compilers use different header
+///   to the compiled YAML. The two template compilers use different header
 ///   layouts, so this lets each compiler keep its own generator while sharing
 ///   all of the boilerplate setup.
 ///
@@ -2927,9 +2927,15 @@ pub async fn compile_template_target(
     };
 
     let yaml = compile_shared(
-        input_path, output_path, front_matter, markdown_body,
-        &extensions, &ctx, config,
-    ).await?;
+        input_path,
+        output_path,
+        front_matter,
+        markdown_body,
+        &extensions,
+        &ctx,
+        config,
+    )
+    .await?;
 
     let header = header_fn(input_path, output_path, front_matter);
     Ok(format!("{}{}", header, yaml))

--- a/src/compile/job.rs
+++ b/src/compile/job.rs
@@ -9,13 +9,12 @@
 
 use anyhow::Result;
 use async_trait::async_trait;
-use log::warn;
+use log::{info, warn};
 use std::path::Path;
 
 use super::Compiler;
 use super::common::{
-    compile_template_target, TemplateTargetConfig,
-    generate_header_comment,
+    compile_template_target, generate_header_comment, TemplateTargetConfig,
 };
 use super::types::FrontMatter;
 
@@ -37,6 +36,8 @@ impl Compiler for JobCompiler {
         skip_integrity: bool,
         debug_pipeline: bool,
     ) -> Result<String> {
+        info!("Compiling for job template target");
+
         if front_matter.on_config.is_some() {
             warn!("on: trigger configuration is ignored for target: job (triggers are the parent pipeline's concern)");
         }
@@ -52,16 +53,15 @@ impl Compiler for JobCompiler {
                 debug_pipeline,
             },
             generate_job_header,
-        ).await
+        )
+        .await
     }
 }
 
 /// Generate the header comment block for job-level templates.
 fn generate_job_header(input_path: &Path, output_path: &Path, front_matter: &FrontMatter) -> String {
     let base_header = generate_header_comment(input_path);
-    let mut lock_path = output_path
-        .to_string_lossy()
-        .replace('\\', "/");
+    let mut lock_path = output_path.to_string_lossy().replace('\\', "/");
     // Strip redundant leading "./" (same normalization as generate_header_comment)
     while lock_path.starts_with("./") {
         lock_path = lock_path[2..].to_string();
@@ -102,7 +102,6 @@ fn generate_job_header(input_path: &Path, output_path: &Path, front_matter: &Fro
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use crate::compile::common::generate_stage_prefix;
 
     #[test]

--- a/src/compile/job.rs
+++ b/src/compile/job.rs
@@ -9,7 +9,7 @@
 
 use anyhow::Result;
 use async_trait::async_trait;
-use log::{info, warn};
+use log::warn;
 use std::path::Path;
 
 use super::Compiler;
@@ -36,8 +36,6 @@ impl Compiler for JobCompiler {
         skip_integrity: bool,
         debug_pipeline: bool,
     ) -> Result<String> {
-        info!("Compiling for job template target");
-
         if front_matter.on_config.is_some() {
             warn!("on: trigger configuration is ignored for target: job (triggers are the parent pipeline's concern)");
         }

--- a/src/compile/stage.rs
+++ b/src/compile/stage.rs
@@ -17,13 +17,12 @@
 
 use anyhow::Result;
 use async_trait::async_trait;
-use log::warn;
+use log::{info, warn};
 use std::path::Path;
 
 use super::Compiler;
 use super::common::{
-    compile_template_target, TemplateTargetConfig,
-    generate_header_comment,
+    compile_template_target, generate_header_comment, TemplateTargetConfig,
 };
 use super::types::FrontMatter;
 
@@ -45,6 +44,8 @@ impl Compiler for StageCompiler {
         skip_integrity: bool,
         debug_pipeline: bool,
     ) -> Result<String> {
+        info!("Compiling for stage template target");
+
         if front_matter.on_config.is_some() {
             warn!("on: trigger configuration is ignored for target: stage (triggers are the parent pipeline's concern)");
         }
@@ -60,16 +61,15 @@ impl Compiler for StageCompiler {
                 debug_pipeline,
             },
             generate_stage_header,
-        ).await
+        )
+        .await
     }
 }
 
 /// Generate the header comment block for stage-level templates.
 fn generate_stage_header(input_path: &Path, output_path: &Path, front_matter: &FrontMatter) -> String {
     let base_header = generate_header_comment(input_path);
-    let mut lock_path = output_path
-        .to_string_lossy()
-        .replace('\\', "/");
+    let mut lock_path = output_path.to_string_lossy().replace('\\', "/");
     while lock_path.starts_with("./") {
         lock_path = lock_path[2..].to_string();
     }

--- a/src/compile/stage.rs
+++ b/src/compile/stage.rs
@@ -17,7 +17,7 @@
 
 use anyhow::Result;
 use async_trait::async_trait;
-use log::{info, warn};
+use log::warn;
 use std::path::Path;
 
 use super::Compiler;
@@ -44,8 +44,6 @@ impl Compiler for StageCompiler {
         skip_integrity: bool,
         debug_pipeline: bool,
     ) -> Result<String> {
-        info!("Compiling for stage template target");
-
         if front_matter.on_config.is_some() {
             warn!("on: trigger configuration is ignored for target: stage (triggers are the parent pipeline's concern)");
         }

--- a/tests/bash_lint_tests.rs
+++ b/tests/bash_lint_tests.rs
@@ -180,6 +180,7 @@ fn compile_fixture_with_flags(workspace: &Path, fixture: &str, extra_flags: &[&s
     } else if stdout.contains("Generated job template:") {
         "job"
     } else if stdout.contains("Generated stage template:") {
+
         "stage"
     } else {
         panic!(

--- a/tests/bash_lint_tests.rs
+++ b/tests/bash_lint_tests.rs
@@ -180,7 +180,6 @@ fn compile_fixture_with_flags(workspace: &Path, fixture: &str, extra_flags: &[&s
     } else if stdout.contains("Generated job template:") {
         "job"
     } else if stdout.contains("Generated stage template:") {
-
         "stage"
     } else {
         panic!(


### PR DESCRIPTION
## Summary

Add two new compile targets (`target: job` and `target: stage`) that produce reusable ADO YAML templates for embedding agentic stages into existing pipelines.

**`target: job`** — generates a job-level template (`jobs:` at root) for inclusion in a flat pipeline or inside a user-defined stage:

```yaml
# Flat pipeline
jobs:
  - template: agents/review.lock.yml

# Or inside a stage
stages:
  - stage: AgenticReview
    dependsOn: Build
    jobs:
      - template: agents/review.lock.yml
```

**`target: stage`** — generates a stage-level template (`stages:` wrapping jobs) for direct inclusion in multi-stage pipelines, with native ADO `dependsOn` and `condition` at the call site:

```yaml
stages:
  - template: agents/review.lock.yml
    dependsOn: Build
    condition: succeeded()
```

### Design decisions

- **Pool** is baked from front matter (not a template parameter)
- **`dependsOn`/`condition`** are set natively at the ADO call site (not template params)
- **Job names** are prefixed with PascalCase agent name for uniqueness (e.g., `DailyReview_Agent`, `DailyReview_Detection`, `DailyReview_Execution`)
- **Triggers** (`on:`) are ignored with a warning in template targets
- **Template parameters** only include `clearMemory` and user-defined params (if any)

### New files

- `src/compile/job.rs` — `JobCompiler` implementing the `Compiler` trait
- `src/compile/stage.rs` — `StageCompiler` implementing the `Compiler` trait
- `src/data/job-base.yml` — job-level template derived from `base.yml`
- `src/data/stage-base.yml` — stage-level template wrapping jobs in a stage block
- `tests/fixtures/job-agent.md` and `stage-agent.md` — test fixtures

## Test plan

- `cargo build` — clean compilation
- `cargo test --bin ado-aw` — 1350 tests pass, 0 failures
- `cargo clippy --all-targets --all-features` — no new warnings
- Both fixtures compile correctly (`cargo run -- compile tests/fixtures/job-agent.md` and `stage-agent.md`)
- Verified output YAML has correctly prefixed job names and dependency chains
- Added both targets to `REQUIRED_TARGETS` in `tests/bash_lint_tests.rs`
