### PR TITLE
docs: fix documentation drift — pool defaults and codemod registry

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -66,6 +66,7 @@ Every compiled pipeline runs as three sequential jobs:
 │   │   ├── codemods/     # Front-matter codemods (one file per transformation)
 │   │   │   ├── mod.rs    # Codemod struct, CODEMODS registry, runner
 │   │   │   ├── 0001_repos_unified.rs # Legacy repositories/checkout → repos codemod
+│   │   │   ├── 0002_pool_object_form.rs # Legacy scalar pool → object form codemod
 │   │   │   └── helpers.rs # take_key, insert_no_overwrite, rename_key, ConflictPolicy
 │   │   ├── codemod_integration_test.rs # White-box rewrite-path tests (stub registry injection)
 │   │   └── types.rs      # Front matter grammar and types

--- a/README.md
+++ b/README.md
@@ -238,7 +238,7 @@ the service connections. Approve the permissions and the pipeline is ready.
 | `target` | `standalone` \| `1es` | `standalone` | Pipeline output format |
 | `engine` | string or object | `copilot` | Engine identifier or object with `id`, `model`, `timeout-minutes`, etc. |
 | `on` | object | — | Unified trigger configuration (`schedule`, `pipeline` completion, `pr` triggers). See [schedule syntax](#schedule-syntax). |
-| `pool` | string or object | `AZS-1ES-L-MMS-ubuntu-22.04` | Agent pool |
+| `pool` | string or object | `vmImage: ubuntu-latest` (standalone) / `AZS-1ES-L-MMS-ubuntu-22.04` (1ES) | Agent pool |
 | `workspace` | `root` \| `repo` \| `self` \| *alias* | auto | Working directory mode. `self` is an alias for `repo`; any checked-out repo alias is also accepted. |
 | `repos` | list | — | Compact repository declarations (replaces legacy `repositories:` + `checkout:`) |
 | `mcp-servers` | map | — | MCP server configuration |

--- a/docs/codemods.md
+++ b/docs/codemods.md
@@ -108,7 +108,8 @@ Codemods live in `src/compile/codemods/`:
 src/compile/codemods/
 ├── mod.rs                  # Framework + CODEMODS registry
 ├── helpers.rs              # take_key, insert_no_overwrite, rename_key, ConflictPolicy
-└── 0001_repos_unified.rs   # Legacy repositories: + checkout: → repos: codemod
+├── 0001_repos_unified.rs   # Legacy repositories: + checkout: → repos: codemod
+└── 0002_pool_object_form.rs # Legacy scalar pool → explicit object form codemod
 ```
 
 (New codemods are appended as `<NNNN>_<id>.rs` files.)

--- a/prompts/create-ado-agentic-workflow.md
+++ b/prompts/create-ado-agentic-workflow.md
@@ -153,15 +153,19 @@ repos:
 
 ### Step 6 — Pool
 
-Defaults to `AZS-1ES-L-MMS-ubuntu-22.04`. Only include if overriding.
+Default depends on target: standalone uses `vmImage: ubuntu-latest` (Microsoft-hosted); 1ES uses `name: AZS-1ES-L-MMS-ubuntu-22.04`. Only include if overriding the default.
 
-String form:
+String form (self-hosted pool by name):
 ```yaml
 pool: MyCustomPool
 ```
 
-Object form (needed for 1ES target with explicit OS):
+Object form (Microsoft-hosted or explicit OS):
 ```yaml
+pool:
+  vmImage: ubuntu-latest   # Microsoft-hosted (standalone default)
+
+# 1ES pool with explicit OS:
 pool:
   name: AZS-1ES-L-MMS-ubuntu-22.04
   os: linux   # "linux" or "windows"


### PR DESCRIPTION
- README.md: Fix pool field default (was AZS-1ES-L-MMS-ubuntu-22.04 for all targets; correct defaults are vmImage:ubuntu-latest for standalone and AZS-1ES-L-MMS-ubuntu-22.04 for 1ES)
- prompts/create-ado-agentic-workflow.md: Fix Step 6 pool guidance to document the correct target-dependent defaults (standalone vs 1ES)
- AGENTS.md: Add missing 0002_pool_object_form.rs to architecture tree
- docs/codemods.md: Add missing 0002_pool_object_form.rs to file layout listing

<!--
  ⚠️  PR TITLE = CHANGELOG ENTRY
  This repo uses squash-merge, so your PR title becomes the commit on main.
  release-please uses it for the changelog and version bump.

  Format:  type(scope): description
  Example: feat(compile): add S360 Breeze MCP as first-party tool

  Types that appear in the changelog:
    feat  → Features     (bumps minor version)
    fix   → Bug Fixes    (bumps patch version)

  Types that do NOT appear in the changelog (no version bump):
    chore, docs, refactor, test, ci, perf, build

  Bad:  "Allow workspace to target a repo alias"
  Good: "feat(compile): allow workspace to target a repo alias"
-->

## Summary

<!-- Brief description of what this PR does and why. -->

## Test plan

<!-- How was this tested? (cargo test, manual verification, etc.) -->
