### PR TITLE
docs: fix documentation drift — add `job` and `stage` targets to README, AGENTS.md, and create prompt

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -193,8 +193,8 @@ index to jump to the right page.
   `edit`, `cache-memory`, `azure-devops` MCP).
 - [`docs/runtimes.md`](docs/runtimes.md) — `runtimes:` configuration (Lean 4,
   Python, Node.js, .NET).
-- [`docs/targets.md`](docs/targets.md) — target platforms: `standalone` and
-  `1es`.
+- [`docs/targets.md`](docs/targets.md) — target platforms: `standalone`,
+  `1es`, `job`, and `stage`.
 - [`docs/safe-outputs.md`](docs/safe-outputs.md) — full reference for every
   safe-output tool agents can use to propose actions (PRs, work items, wiki
   pages, comments, etc.) plus their per-agent configuration.

--- a/README.md
+++ b/README.md
@@ -235,7 +235,7 @@ the service connections. Approve the permissions and the pipeline is ready.
 |-------|------|---------|-------------|
 | `name` | string | **required** | Human-readable name for the agent |
 | `description` | string | **required** | One-line summary of the agent's purpose |
-| `target` | `standalone` \| `1es` | `standalone` | Pipeline output format |
+| `target` | `standalone` \| `1es` \| `job` \| `stage` | `standalone` | Pipeline output format. `job` and `stage` generate reusable ADO YAML templates rather than complete pipelines. |
 | `engine` | string or object | `copilot` | Engine identifier or object with `id`, `model`, `timeout-minutes`, etc. |
 | `on` | object | — | Unified trigger configuration (`schedule`, `pipeline` completion, `pr` triggers). See [schedule syntax](#schedule-syntax). |
 | `pool` | string or object | `vmImage: ubuntu-latest` (standalone) / `AZS-1ES-L-MMS-ubuntu-22.04` (1ES) | Agent pool |

--- a/prompts/create-ado-agentic-workflow.md
+++ b/prompts/create-ado-agentic-workflow.md
@@ -173,7 +173,7 @@ pool:
 
 ### Step 7 — Target
 
-Defaults to `standalone`. Only include if using 1ES Pipeline Templates.
+Defaults to `standalone`. Only include if using a different target.
 
 ```yaml
 target: 1es
@@ -183,6 +183,10 @@ target: 1es
 |---|---|
 | `standalone` | Full 3-job pipeline with AWF network sandbox and Squid proxy |
 | `1es` | Pipeline extending `1ES.Unofficial.PipelineTemplate.yml`; no custom proxy; MCPs via MCPG |
+| `job` | Reusable ADO YAML template with `jobs:` at root — include in an existing pipeline (no triggers or pipeline name) |
+| `stage` | Reusable ADO YAML template with `stages:` at root — include as a stage in a multi-stage pipeline |
+
+> **Note**: For `target: job` and `target: stage`, triggers configured via `on:` are ignored with a warning — the parent pipeline controls triggers. Job names are prefixed with the agent name for uniqueness (e.g., `DailyReview_Agent`). See `docs/targets.md` for usage examples.
 
 ### Step 8 — MCP Servers
 


### PR DESCRIPTION
…AGENTS.md, and create prompt

All three files (README.md, AGENTS.md, prompts/create-ado-agentic-workflow.md) only documented 'standalone' and '1es' as valid target values, but the compiler has supported 'job' and 'stage' targets (via target: job / target: stage in front matter) since they were added (src/compile/job.rs, src/compile/stage.rs, src/data/job-base.yml, src/data/stage-base.yml). docs/targets.md and docs/front-matter.md correctly documented all four values but the three files above were never updated.

- README.md: expand target field type column to include 'job' and 'stage'
- AGENTS.md: update docs/targets.md link description to mention all four targets
- prompts/create-ado-agentic-workflow.md Step 7: add 'job' and 'stage' rows to the target table and a brief note about trigger-ignore behaviour and job-name prefixing

<!--
  ⚠️  PR TITLE = CHANGELOG ENTRY
  This repo uses squash-merge, so your PR title becomes the commit on main.
  release-please uses it for the changelog and version bump.

  Format:  type(scope): description
  Example: feat(compile): add S360 Breeze MCP as first-party tool

  Types that appear in the changelog:
    feat  → Features     (bumps minor version)
    fix   → Bug Fixes    (bumps patch version)

  Types that do NOT appear in the changelog (no version bump):
    chore, docs, refactor, test, ci, perf, build

  Bad:  "Allow workspace to target a repo alias"
  Good: "feat(compile): allow workspace to target a repo alias"
-->

## Summary

<!-- Brief description of what this PR does and why. -->

## Test plan

<!-- How was this tested? (cargo test, manual verification, etc.) -->
