### PR TITLE
docs: improve hero contrast, simplify example, adjust labels

### DIFF
--- a/site/src/components/CompilePreview.astro
+++ b/site/src/components/CompilePreview.astro
@@ -35,7 +35,7 @@
     flex: 1;
     min-width: 0;
     position: relative;
-    overflow: hidden;
+    overflow: visible;
     border-radius: 0.75rem;
   }
 
@@ -45,13 +45,14 @@
     border-radius: 0.75rem;
     height: 100%;
     font-size: 0.82rem;
+    padding-bottom: 2rem;
   }
 
   .compile-label {
     position: absolute;
-    top: 0.65rem;
-    right: 1rem;
-    z-index: 1;
+    top: 1.1rem;
+    left: 1rem;
+    z-index: 10;
     font-size: 0.7rem;
     font-weight: 600;
     text-transform: uppercase;
@@ -59,6 +60,7 @@
     color: var(--sl-color-accent);
     opacity: 0.7;
     font-family: var(--sl-font-mono, monospace);
+    pointer-events: none;
   }
 
   .compile-arrow {

--- a/site/src/content/docs/index.mdx
+++ b/site/src/content/docs/index.mdx
@@ -29,22 +29,18 @@ No pipeline YAML to hand-write. No complex scripting. Just describe the agent's 
 ---
 on:
   schedule: weekly on monday around 10:00
-engine:
-  model: gpt-4.1
-tools:
-  bash: [grep, find, wc, jq]
+permissions:
+  write: my-write-arm-connection
 safe-outputs:
   create-pull-request:
     title-prefix: "[docs] "
     max: 1
-  comment-on-work-item:
 ---
 
 ## Documentation Sync
 
 Review all public API surfaces and ensure the corresponding
-docs are up to date. Open a PR with any corrections and
-comment on related work items with a summary.
+docs are up to date. Open a PR with any corrections.
 ```
   </Fragment>
   <Fragment slot="output">

--- a/site/src/styles/custom.css
+++ b/site/src/styles/custom.css
@@ -177,6 +177,18 @@
   color: #424a53;
 }
 
+/* Hero action buttons — light mode contrast fix */
+[data-theme='light'] .hero .sl-link-button.primary {
+  background: #4c2889;
+  border-color: #4c2889;
+  color: #ffffff;
+}
+
+[data-theme='light'] .hero .sl-link-button.primary:hover {
+  background: #3c1f6e;
+  border-color: #3c1f6e;
+}
+
 /* Hero gradient for light mode */
 [data-theme='light'] .hero h1 {
   background: linear-gradient(135deg, #6b46c1, #7c3aed);


### PR DESCRIPTION
- Fix Get Started button contrast in light mode (correct Starlight selector: \.sl-link-button.primary\)
- Simplify hero code example to minimum viable config (just \permissions\ + \safe-outputs\)
- Move compile preview labels to top-left position and adjust spacing