### PR TITLE
docs: fix documentation drift — create_issue.rs missing from AGENTS.md, noop/missing-tool work-item filing undocumented in promp[Content truncated due to length]

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -89,6 +89,7 @@ Every compiled pipeline runs as three sequential jobs:
 │   │   ├── comment_on_work_item.rs
 │   │   ├── create_branch.rs
 │   │   ├── create_git_tag.rs
+│   │   ├── create_issue.rs
 │   │   ├── create_pr.rs
 │   │   ├── create_wiki_page.rs
 │   │   ├── create_work_item.rs

--- a/prompts/create-ado-agentic-workflow.md
+++ b/prompts/create-ado-agentic-workflow.md
@@ -318,9 +318,9 @@ tools:
 | `create-wiki-page` | Create a new ADO wiki page (requires `wiki-name`) | ✅ |
 | `update-wiki-page` | Update an existing ADO wiki page (requires `wiki-name`) | ✅ |
 | **Diagnostics** | | |
-| `noop` | Report no action needed | — |
+| `noop` | Report no action needed; also files an ADO work item (configurable, gracefully skipped without write perms) | — |
 | `missing-data` | Report missing data/information | — |
-| `missing-tool` | Report a missing tool or capability | — |
+| `missing-tool` | Report a missing tool or capability; also files an ADO work item (configurable, gracefully skipped without write perms) | — |
 | `report-incomplete` | Report that a task could not be completed | — |
 
 Example configuration for additional tools:
@@ -339,11 +339,24 @@ safe-outputs:
   queue-build:
     allowed-pipelines: [42, 99]       # Required — pipeline definition IDs that can be triggered
     max: 1
+  # noop and missing-tool auto-file ADO work items (enabled by default, optional customisation):
+  noop:
+    work-item:
+      enabled: true                   # Set to false to disable work-item filing
+      title: "[ado-aw] Agent reported no operation"
+      work-item-type: Task
+      area-path: "MyProject\\MyTeam"  # Optional
+  missing-tool:
+    work-item:
+      enabled: true                   # Set to false to disable work-item filing
+      title: "[ado-aw] Agent encountered missing tool"
+      work-item-type: Task
+      area-path: "MyProject\\MyTeam"  # Optional
 ```
 
 > See `docs/safe-outputs.md` → "Available Safe Output Tools" for full configuration reference of every tool.
 
-Diagnostic tools (`noop`, `missing-data`, `missing-tool`, `report-incomplete`) are always available and require no configuration.
+Diagnostic tools (`noop`, `missing-data`, `missing-tool`, `report-incomplete`) are always available and require no required configuration. `noop` and `missing-tool` automatically file ADO work items by default — this requires `permissions.write` to actually create work items, but gracefully skips (with a warning) if credentials are unavailable.
 
 > **Validation**: The compiler enforces that if write-requiring safe outputs are configured, `permissions.write` must be set.
 


### PR DESCRIPTION
…d, noop/missing-tool work-item filing undocumented in prompt

- Add src/safeoutputs/create_issue.rs to the AGENTS.md architecture tree (added in v0.29.0 via feat(safeoutputs): add ado-aw-debug.create-issue)
- Update prompts/create-ado-agentic-workflow.md to document that noop and missing-tool now auto-file ADO work items (added in v0.29.0 via feat(safeoutputs): add work-item filing to noop and missing-tool) and add example configuration for the work-item: block

<!--
  ⚠️  PR TITLE = CHANGELOG ENTRY
  This repo uses squash-merge, so your PR title becomes the commit on main.
  release-please uses it for the changelog and version bump.

  Format:  type(scope): description
  Example: feat(compile): add S360 Breeze MCP as first-party tool

  Types that appear in the changelog:
    feat  → Features     (bumps minor version)
    fix   → Bug Fixes    (bumps patch version)

  Types that do NOT appear in the changelog (no version bump):
    chore, docs, refactor, test, ci, perf, build

  Bad:  "Allow workspace to target a repo alias"
  Good: "feat(compile): allow workspace to target a repo alias"
-->

## Summary

<!-- Brief description of what this PR does and why. -->

## Test plan

<!-- How was this tested? (cargo test, manual verification, etc.) -->
