### PR TITLE
docs: fix documentation drift — wrong safeoutputs filename, incomplete template-markers description

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -90,7 +90,7 @@ Every compiled pipeline runs as three sequential jobs:
 │   │   ├── create_branch.rs
 │   │   ├── create_git_tag.rs
 │   │   ├── create_issue.rs
-│   │   ├── create_pr.rs
+│   │   ├── create_pull_request.rs
 │   │   ├── create_wiki_page.rs
 │   │   ├── create_work_item.rs
 │   │   ├── link_work_items.rs
@@ -206,7 +206,7 @@ index to jump to the right page.
 ### Compiler internals & operations
 
 - [`docs/template-markers.md`](docs/template-markers.md) — every `{{ marker }}`
-  in `src/data/base.yml` and `src/data/1es-base.yml` and how it is replaced.
+  in `src/data/base.yml`, `src/data/1es-base.yml`, `src/data/job-base.yml`, and `src/data/stage-base.yml` and how it is replaced.
 - [`docs/cli.md`](docs/cli.md) — `ado-aw` CLI commands (`init`, `compile`,
   `check`, `mcp`, `mcp-http`, `execute`, `configure`).
 - [`docs/mcp.md`](docs/mcp.md) — MCP server configuration (stdio containers,


### PR DESCRIPTION
- Correct safeoutputs architecture entry: create_pr.rs → create_pull_request.rs
- Expand template-markers.md description to include job-base.yml and stage-base.yml

<!--
  ⚠️  PR TITLE = CHANGELOG ENTRY
  This repo uses squash-merge, so your PR title becomes the commit on main.
  release-please uses it for the changelog and version bump.

  Format:  type(scope): description
  Example: feat(compile): add S360 Breeze MCP as first-party tool

  Types that appear in the changelog:
    feat  → Features     (bumps minor version)
    fix   → Bug Fixes    (bumps patch version)

  Types that do NOT appear in the changelog (no version bump):
    chore, docs, refactor, test, ci, perf, build

  Bad:  "Allow workspace to target a repo alias"
  Good: "feat(compile): allow workspace to target a repo alias"
-->

## Summary

<!-- Brief description of what this PR does and why. -->

## Test plan

<!-- How was this tested? (cargo test, manual verification, etc.) -->
