### PR TITLE
fix(configure): accept bare org name for --org

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -37,7 +37,7 @@ Global flags (apply to all subcommands): `--verbose, -v` (enable info-level logg
 
 - `configure` - Detect agentic pipelines in a local repository and update the `GITHUB_TOKEN` pipeline variable on their Azure DevOps build definitions
   - `--token <token>` / `GITHUB_TOKEN` env var - The new GITHUB_TOKEN value (prompted if omitted)
-  - `--org <url>` - Override: Azure DevOps organization URL (inferred from git remote by default)
+  - `--org <url>` - Override: Azure DevOps organization URL (e.g. `https://dev.azure.com/myorg`) or just the org name (e.g. `myorg`, auto-prefixed to the canonical URL). Inferred from git remote by default.
   - `--project <name>` - Override: Azure DevOps project name (inferred from git remote by default)
   - `--pat <pat>` / `AZURE_DEVOPS_EXT_PAT` env var - PAT for ADO API authentication (prompted if omitted)
   - `--path <path>` - Path to the repository root (defaults to current directory)

--- a/src/configure.rs
+++ b/src/configure.rs
@@ -652,6 +652,33 @@ async fn resolve_auth(pat: Option<&str>) -> Result<AdoAuth> {
     }
 }
 
+/// Normalize a `--org` value to a full ADO organization URL.
+///
+/// Users commonly pass just the org name (e.g. `myorg`) instead of the full
+/// URL (`https://dev.azure.com/myorg`). Accept both forms by prefixing the
+/// canonical `https://dev.azure.com/` host when the input has no scheme.
+///
+/// Also accepts the legacy `{org}.visualstudio.com` form and rewrites it to
+/// the modern `dev.azure.com/{org}` form for consistency with `parse_ado_remote`.
+pub fn normalize_org_url(org: &str) -> String {
+    let trimmed = org.trim().trim_end_matches('/');
+
+    // Bare org name: no scheme, no dots — assume it's just the org.
+    if !trimmed.contains("://") && !trimmed.contains('/') && !trimmed.contains('.') {
+        return format!("https://dev.azure.com/{}", trimmed);
+    }
+
+    // Legacy `https://{org}.visualstudio.com` → `https://dev.azure.com/{org}`.
+    if let Ok(url) = url::Url::parse(trimmed)
+        && let Some(host) = url.host_str()
+        && let Some(org) = host.strip_suffix(".visualstudio.com")
+    {
+        return format!("https://dev.azure.com/{}", org);
+    }
+
+    trimmed.to_string()
+}
+
 /// Resolves the ADO context from the git remote (best-effort) with CLI overrides.
 /// Falls back to explicit `--org`/`--project` when the remote is absent or non-ADO.
 async fn resolve_ado_context(
@@ -677,7 +704,7 @@ async fn resolve_ado_context(
         // Git remote parsed — apply overrides
         (Some(mut ctx), org, project) => {
             if let Some(org) = org {
-                ctx.org_url = org.to_string();
+                ctx.org_url = normalize_org_url(org);
             }
             if let Some(project) = project {
                 ctx.project = project.to_string();
@@ -688,7 +715,7 @@ async fn resolve_ado_context(
         (None, Some(org), Some(project)) => {
             info!("No ADO git remote; using --org and --project");
             Ok(AdoContext {
-                org_url: org.to_string(),
+                org_url: normalize_org_url(org),
                 project: project.to_string(),
                 repo_name: String::new(),
             })
@@ -920,6 +947,52 @@ mod tests {
     fn test_parse_ado_remote_invalid() {
         assert!(parse_ado_remote("https://github.com/user/repo").is_err());
         assert!(parse_ado_remote("not-a-url").is_err());
+    }
+
+    // ==================== Org URL normalization ====================
+
+    #[test]
+    fn normalize_org_url_accepts_bare_name() {
+        assert_eq!(
+            normalize_org_url("myorg"),
+            "https://dev.azure.com/myorg"
+        );
+    }
+
+    #[test]
+    fn normalize_org_url_preserves_full_url() {
+        assert_eq!(
+            normalize_org_url("https://dev.azure.com/myorg"),
+            "https://dev.azure.com/myorg"
+        );
+    }
+
+    #[test]
+    fn normalize_org_url_strips_trailing_slash() {
+        assert_eq!(
+            normalize_org_url("https://dev.azure.com/myorg/"),
+            "https://dev.azure.com/myorg"
+        );
+    }
+
+    #[test]
+    fn normalize_org_url_rewrites_legacy_visualstudio() {
+        assert_eq!(
+            normalize_org_url("https://myorg.visualstudio.com"),
+            "https://dev.azure.com/myorg"
+        );
+        assert_eq!(
+            normalize_org_url("https://myorg.visualstudio.com/"),
+            "https://dev.azure.com/myorg"
+        );
+    }
+
+    #[test]
+    fn normalize_org_url_trims_whitespace() {
+        assert_eq!(
+            normalize_org_url("  myorg  "),
+            "https://dev.azure.com/myorg"
+        );
     }
 
     // ==================== Fuzzy name matching ====================

--- a/src/main.rs
+++ b/src/main.rs
@@ -118,7 +118,8 @@ enum Commands {
         /// The new GITHUB_TOKEN value (defaults to GITHUB_TOKEN env var; prompted if omitted)
         #[arg(long, env = "GITHUB_TOKEN")]
         token: Option<String>,
-        /// Override: Azure DevOps organization URL (inferred from git remote by default)
+        /// Override: Azure DevOps organization (URL like `https://dev.azure.com/myorg`,
+        /// or just the org name `myorg`). Inferred from git remote by default.
         #[arg(long)]
         org: Option<String>,
         /// Override: Azure DevOps project name (inferred from git remote by default)


### PR DESCRIPTION
## Problem

`ado-aw configure --org myorg --project Foo --definition-ids 2506` fails because the bare org name is used verbatim as the ADO organization URL. Every API call ends up at `myorg/Foo/_apis/build/definitions/...`, which is malformed.

This bites users whose pipeline *source* lives in GitHub but whose pipeline *runs* in Azure DevOps. In that case `parse_ado_remote` correctly rejects the GitHub remote and falls through to the `(None, Some(org), Some(project))` branch in `resolve_ado_context`, which stored `--org`'s value unchanged.

It was also a footgun even with an ADO remote: the `--org` override branch did the same thing.

## Fix

Add `normalize_org_url(&str) -> String` and apply it in both branches of `resolve_ado_context`. It:

- prefixes the canonical `https://dev.azure.com/` host when a bare org name is passed (no scheme, no slash, no dot)
- rewrites the legacy `{org}.visualstudio.com` form to `dev.azure.com/{org}` for consistency with `parse_ado_remote`
- trims whitespace and trailing slashes
- leaves already-correct `https://dev.azure.com/{org}` URLs untouched

The CLI `--org` help text and `docs/cli.md` are updated to advertise that both forms are accepted.

## Verification

After this change, the user's command works as expected:

```
ado-aw configure --org msazuresphere --project AgentPlayground --definition-ids 2506
```

is equivalent to

```
ado-aw configure --org https://dev.azure.com/msazuresphere --project AgentPlayground --definition-ids 2506
```

## Tests

Five new unit tests in `src/configure.rs` cover:

- bare org name → canonical URL
- full URL passthrough
- trailing slash stripped
- legacy `*.visualstudio.com` rewrite
- whitespace trimming

All 23 tests in `cargo test --bin ado-aw configure::` pass. `cargo build` is clean and no new clippy warnings are introduced in `src/configure.rs`.
