### PR TITLE
feat(workflows): file release-notes action-item issues from update-awf-version

### DIFF
--- a/.github/workflows/update-awf-version.lock.yml
+++ b/.github/workflows/update-awf-version.lock.yml
@@ -1,4 +1,4 @@
-# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"3646c79f13286c3a047c82a590586e2b78a4f9aa22690e9d47b9ef73b150e1b2","compiler_version":"v0.72.1","strict":true,"agent_id":"copilot"}
+# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"360131674423a05c3915cfaa445e56e586855059eda479010a83aa0aa5211e70","compiler_version":"v0.72.1","strict":true,"agent_id":"copilot"}
 # gh-aw-manifest: {"version":1,"secrets":["COPILOT_GITHUB_TOKEN","GH_AW_CI_TRIGGER_TOKEN","GH_AW_GITHUB_MCP_SERVER_TOKEN","GH_AW_GITHUB_TOKEN","GITHUB_TOKEN"],"actions":[{"repo":"actions/checkout","sha":"de0fac2e4500dabe0009e67214ff5f5447ce83dd","version":"v6.0.2"},{"repo":"actions/download-artifact","sha":"3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c","version":"v8.0.1"},{"repo":"actions/github-script","sha":"373c709c69115d41ff229c7e5df9f8788daa9553","version":"v9"},{"repo":"actions/github-script","sha":"3a2844b7e9c422d3c10d287c895573f7108da1b3","version":"v9.0.0"},{"repo":"actions/github-script","sha":"d746ffe35508b1917358783b479e04febd2b8f71","version":"v9.0.0"},{"repo":"actions/setup-node","sha":"48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e","version":"v6.4.0"},{"repo":"actions/upload-artifact","sha":"043fb46d1a93c77aae656e7c1c64a875d1fc6a0a","version":"v7.0.1"},{"repo":"github/gh-aw-actions/setup","sha":"bc56a0cad2f450c562810785ef38649c04db812a","version":"v0.72.1"}],"containers":[{"image":"ghcr.io/github/gh-aw-firewall/agent:0.25.41"},{"image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.25.41"},{"image":"ghcr.io/github/gh-aw-firewall/squid:0.25.41"},{"image":"ghcr.io/github/gh-aw-mcpg:v0.3.6","digest":"sha256:2bb8eef86006a4c5963c55616a9c51c32f27bfdecb023b8aa6f91f6718d9171c","pinned_image":"ghcr.io/github/gh-aw-mcpg:v0.3.6@sha256:2bb8eef86006a4c5963c55616a9c51c32f27bfdecb023b8aa6f91f6718d9171c"},{"image":"ghcr.io/github/github-mcp-server:v1.0.3","digest":"sha256:2ac27ef03461ef2b877031b838a7d1fd7f12b12d4ace7796d8cad91446d55959","pinned_image":"ghcr.io/github/github-mcp-server:v1.0.3@sha256:2ac27ef03461ef2b877031b838a7d1fd7f12b12d4ace7796d8cad91446d55959"},{"image":"node:lts-alpine","digest":"sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f","pinned_image":"node:lts-alpine@sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f"}]}
 #    ___                   _   _      
 #   / _ \                 | | (_)     
@@ -22,7 +22,7 @@
 #
 # For more information: https://github.github.com/gh-aw/introduction/overview/
 #
-# Checks for new releases of gh-aw-firewall, copilot-cli, and gh-aw-mcpg, and syncs ecosystem_domains.json from gh-aw. Opens PRs for any updates found.
+# Checks for new releases of gh-aw-firewall, copilot-cli, and gh-aw-mcpg, and syncs ecosystem_domains.json from gh-aw. Opens PRs for any updates found, and files action-item issues summarizing the upstream release notes for each dependency bump.
 #
 # Secrets used:
 #   - COPILOT_GITHUB_TOKEN
@@ -185,23 +185,23 @@ jobs:
         run: |
           bash "${RUNNER_TEMP}/gh-aw/actions/create_prompt_first.sh"
           {
-          cat << 'GH_AW_PROMPT_aab39335f447d1cb_EOF'
+          cat << 'GH_AW_PROMPT_d2adfe5cbbadc5b3_EOF'
           <system>
-          GH_AW_PROMPT_aab39335f447d1cb_EOF
+          GH_AW_PROMPT_d2adfe5cbbadc5b3_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/xpia.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/temp_folder_prompt.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/markdown.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_prompt.md"
-          cat << 'GH_AW_PROMPT_aab39335f447d1cb_EOF'
+          cat << 'GH_AW_PROMPT_d2adfe5cbbadc5b3_EOF'
           <safe-output-tools>
-          Tools: create_pull_request(max:4), close_pull_request(max:10), missing_tool, missing_data, noop
-          GH_AW_PROMPT_aab39335f447d1cb_EOF
+          Tools: create_issue(max:3), close_issue(max:10), create_pull_request(max:4), close_pull_request(max:10), missing_tool, missing_data, noop
+          GH_AW_PROMPT_d2adfe5cbbadc5b3_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_create_pull_request.md"
-          cat << 'GH_AW_PROMPT_aab39335f447d1cb_EOF'
+          cat << 'GH_AW_PROMPT_d2adfe5cbbadc5b3_EOF'
           </safe-output-tools>
-          GH_AW_PROMPT_aab39335f447d1cb_EOF
+          GH_AW_PROMPT_d2adfe5cbbadc5b3_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/mcp_cli_tools_prompt.md"
-          cat << 'GH_AW_PROMPT_aab39335f447d1cb_EOF'
+          cat << 'GH_AW_PROMPT_d2adfe5cbbadc5b3_EOF'
           <github-context>
           The following GitHub context information is available for this workflow:
           {{#if __GH_AW_GITHUB_ACTOR__ }}
@@ -230,12 +230,12 @@ jobs:
           {{/if}}
           </github-context>
           
-          GH_AW_PROMPT_aab39335f447d1cb_EOF
+          GH_AW_PROMPT_d2adfe5cbbadc5b3_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/github_mcp_tools_with_safeoutputs_prompt.md"
-          cat << 'GH_AW_PROMPT_aab39335f447d1cb_EOF'
+          cat << 'GH_AW_PROMPT_d2adfe5cbbadc5b3_EOF'
           </system>
           {{#runtime-import .github/workflows/update-awf-version.md}}
-          GH_AW_PROMPT_aab39335f447d1cb_EOF
+          GH_AW_PROMPT_d2adfe5cbbadc5b3_EOF
           } > "$GH_AW_PROMPT"
       - name: Interpolate variables and render templates
         uses: actions/github-script@d746ffe35508b1917358783b479e04febd2b8f71 # v9.0.0
@@ -434,15 +434,17 @@ jobs:
           mkdir -p "${RUNNER_TEMP}/gh-aw/safeoutputs"
           mkdir -p /tmp/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/mcp-logs/safeoutputs
-          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_3231f4c52beb48d5_EOF'
-          {"close_pull_request":{"max":10,"required_title_prefix":"chore(deps): ","target":"*"},"create_pull_request":{"max":4,"max_patch_files":100,"max_patch_size":1024,"protect_top_level_dot_folders":true,"protected_files":["package.json","bun.lockb","bunfig.toml","deno.json","deno.jsonc","deno.lock","global.json","NuGet.Config","Directory.Packages.props","mix.exs","mix.lock","go.mod","go.sum","stack.yaml","stack.yaml.lock","pom.xml","build.gradle","build.gradle.kts","settings.gradle","settings.gradle.kts","gradle.properties","package-lock.json","yarn.lock","pnpm-lock.yaml","npm-shrinkwrap.json","requirements.txt","Pipfile","Pipfile.lock","pyproject.toml","setup.py","setup.cfg","Gemfile","Gemfile.lock","uv.lock","CODEOWNERS","DESIGN.md","README.md","CONTRIBUTING.md","CHANGELOG.md","SECURITY.md","CODE_OF_CONDUCT.md","AGENTS.md","CLAUDE.md","GEMINI.md"],"title_prefix":"chore(deps): "},"create_report_incomplete_issue":{},"missing_data":{},"missing_tool":{},"noop":{"max":1,"report-as-issue":"true"},"report_incomplete":{}}
-          GH_AW_SAFE_OUTPUTS_CONFIG_3231f4c52beb48d5_EOF
+          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_8c9d390b4e7e4522_EOF'
+          {"close_issue":{"max":10,"required_title_prefix":"[deps-release-notes] ","state_reason":"not_planned","target":"*"},"close_pull_request":{"max":10,"required_title_prefix":"chore(deps): ","target":"*"},"create_issue":{"labels":["automation","dependencies"],"max":3,"title_prefix":"[deps-release-notes] "},"create_pull_request":{"max":4,"max_patch_files":100,"max_patch_size":1024,"protect_top_level_dot_folders":true,"protected_files":["package.json","bun.lockb","bunfig.toml","deno.json","deno.jsonc","deno.lock","global.json","NuGet.Config","Directory.Packages.props","mix.exs","mix.lock","go.mod","go.sum","stack.yaml","stack.yaml.lock","pom.xml","build.gradle","build.gradle.kts","settings.gradle","settings.gradle.kts","gradle.properties","package-lock.json","yarn.lock","pnpm-lock.yaml","npm-shrinkwrap.json","requirements.txt","Pipfile","Pipfile.lock","pyproject.toml","setup.py","setup.cfg","Gemfile","Gemfile.lock","uv.lock","CODEOWNERS","DESIGN.md","README.md","CONTRIBUTING.md","CHANGELOG.md","SECURITY.md","CODE_OF_CONDUCT.md","AGENTS.md","CLAUDE.md","GEMINI.md"],"title_prefix":"chore(deps): "},"create_report_incomplete_issue":{},"missing_data":{},"missing_tool":{},"noop":{"max":1,"report-as-issue":"true"},"report_incomplete":{}}
+          GH_AW_SAFE_OUTPUTS_CONFIG_8c9d390b4e7e4522_EOF
       - name: Generate Safe Outputs Tools
         env:
           GH_AW_TOOLS_META_JSON: |
             {
               "description_suffixes": {
+                "close_issue": " CONSTRAINTS: Maximum 10 issue(s) can be closed. Target: *. Only issues with title prefix \"[deps-release-notes] \" can be closed.",
                 "close_pull_request": " CONSTRAINTS: Maximum 10 pull request(s) can be closed. Target: *. Only PRs with title prefix \"chore(deps): \" can be closed.",
+                "create_issue": " CONSTRAINTS: Maximum 3 issue(s) can be created. Title will be prefixed with \"[deps-release-notes] \". Labels [\"automation\" \"dependencies\"] will be automatically added.",
                 "create_pull_request": " CONSTRAINTS: Maximum 4 pull request(s) can be created. Title will be prefixed with \"chore(deps): \"."
               },
               "repo_params": {},
@@ -450,6 +452,24 @@ jobs:
             }
           GH_AW_VALIDATION_JSON: |
             {
+              "close_issue": {
+                "defaultMax": 1,
+                "fields": {
+                  "body": {
+                    "required": true,
+                    "type": "string",
+                    "sanitize": true,
+                    "maxLength": 65000
+                  },
+                  "issue_number": {
+                    "optionalPositiveInteger": true
+                  },
+                  "repo": {
+                    "type": "string",
+                    "maxLength": 256
+                  }
+                }
+              },
               "close_pull_request": {
                 "defaultMax": 1,
                 "fields": {
@@ -465,6 +485,39 @@ jobs:
                   "repo": {
                     "type": "string",
                     "maxLength": 256
+                  }
+                }
+              },
+              "create_issue": {
+                "defaultMax": 1,
+                "fields": {
+                  "body": {
+                    "required": true,
+                    "type": "string",
+                    "sanitize": true,
+                    "maxLength": 65000
+                  },
+                  "labels": {
+                    "type": "array",
+                    "itemType": "string",
+                    "itemSanitize": true,
+                    "itemMaxLength": 128
+                  },
+                  "parent": {
+                    "issueOrPRNumber": true
+                  },
+                  "repo": {
+                    "type": "string",
+                    "maxLength": 256
+                  },
+                  "temporary_id": {
+                    "type": "string"
+                  },
+                  "title": {
+                    "required": true,
+                    "type": "string",
+                    "sanitize": true,
+                    "maxLength": 128
                   }
                 }
               },
@@ -663,7 +716,7 @@ jobs:
           
           mkdir -p /home/runner/.copilot
           GH_AW_NODE=$(which node 2>/dev/null || command -v node 2>/dev/null || echo node)
-          cat << GH_AW_MCP_CONFIG_898cb9d5142c2b5c_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
+          cat << GH_AW_MCP_CONFIG_b469026799a4e9c6_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
           {
             "mcpServers": {
               "github": {
@@ -704,7 +757,7 @@ jobs:
               "payloadDir": "${MCP_GATEWAY_PAYLOAD_DIR}"
             }
           }
-          GH_AW_MCP_CONFIG_898cb9d5142c2b5c_EOF
+          GH_AW_MCP_CONFIG_b469026799a4e9c6_EOF
       - name: Mount MCP servers as CLIs
         id: mount-mcp-clis
         continue-on-error: true
@@ -1159,7 +1212,7 @@ jobs:
         uses: actions/github-script@d746ffe35508b1917358783b479e04febd2b8f71 # v9.0.0
         env:
           WORKFLOW_NAME: "Dependency Version Updater"
-          WORKFLOW_DESCRIPTION: "Checks for new releases of gh-aw-firewall, copilot-cli, and gh-aw-mcpg, and syncs ecosystem_domains.json from gh-aw. Opens PRs for any updates found."
+          WORKFLOW_DESCRIPTION: "Checks for new releases of gh-aw-firewall, copilot-cli, and gh-aw-mcpg, and syncs ecosystem_domains.json from gh-aw. Opens PRs for any updates found, and files action-item issues summarizing the upstream release notes for each dependency bump."
           HAS_PATCH: ${{ needs.agent.outputs.has_patch }}
         with:
           script: |
@@ -1286,6 +1339,8 @@ jobs:
       code_push_failure_errors: ${{ steps.process_safe_outputs.outputs.code_push_failure_errors }}
       create_discussion_error_count: ${{ steps.process_safe_outputs.outputs.create_discussion_error_count }}
       create_discussion_errors: ${{ steps.process_safe_outputs.outputs.create_discussion_errors }}
+      created_issue_number: ${{ steps.process_safe_outputs.outputs.created_issue_number }}
+      created_issue_url: ${{ steps.process_safe_outputs.outputs.created_issue_url }}
       created_pr_number: ${{ steps.process_safe_outputs.outputs.created_pr_number }}
       created_pr_url: ${{ steps.process_safe_outputs.outputs.created_pr_url }}
       process_safe_outputs_processed_count: ${{ steps.process_safe_outputs.outputs.processed_count }}
@@ -1384,7 +1439,7 @@ jobs:
           GH_AW_ALLOWED_DOMAINS: "api.business.githubcopilot.com,api.enterprise.githubcopilot.com,api.github.com,api.githubcopilot.com,api.individual.githubcopilot.com,api.snapcraft.io,archive.ubuntu.com,azure.archive.ubuntu.com,crl.geotrust.com,crl.globalsign.com,crl.identrust.com,crl.sectigo.com,crl.thawte.com,crl.usertrust.com,crl.verisign.com,crl3.digicert.com,crl4.digicert.com,crls.ssl.com,github.com,host.docker.internal,json-schema.org,json.schemastore.org,keyserver.ubuntu.com,ocsp.digicert.com,ocsp.geotrust.com,ocsp.globalsign.com,ocsp.identrust.com,ocsp.sectigo.com,ocsp.ssl.com,ocsp.thawte.com,ocsp.usertrust.com,ocsp.verisign.com,packagecloud.io,packages.cloud.google.com,packages.microsoft.com,ppa.launchpad.net,raw.githubusercontent.com,registry.npmjs.org,s.symcb.com,s.symcd.com,security.ubuntu.com,telemetry.enterprise.githubcopilot.com,ts-crl.ws.symantec.com,ts-ocsp.ws.symantec.com,www.googleapis.com"
           GITHUB_SERVER_URL: ${{ github.server_url }}
           GITHUB_API_URL: ${{ github.api_url }}
-          GH_AW_SAFE_OUTPUTS_HANDLER_CONFIG: "{\"close_pull_request\":{\"max\":10,\"required_title_prefix\":\"chore(deps): \",\"target\":\"*\"},\"create_pull_request\":{\"max\":4,\"max_patch_files\":100,\"max_patch_size\":1024,\"protect_top_level_dot_folders\":true,\"protected_files\":[\"package.json\",\"bun.lockb\",\"bunfig.toml\",\"deno.json\",\"deno.jsonc\",\"deno.lock\",\"global.json\",\"NuGet.Config\",\"Directory.Packages.props\",\"mix.exs\",\"mix.lock\",\"go.mod\",\"go.sum\",\"stack.yaml\",\"stack.yaml.lock\",\"pom.xml\",\"build.gradle\",\"build.gradle.kts\",\"settings.gradle\",\"settings.gradle.kts\",\"gradle.properties\",\"package-lock.json\",\"yarn.lock\",\"pnpm-lock.yaml\",\"npm-shrinkwrap.json\",\"requirements.txt\",\"Pipfile\",\"Pipfile.lock\",\"pyproject.toml\",\"setup.py\",\"setup.cfg\",\"Gemfile\",\"Gemfile.lock\",\"uv.lock\",\"CODEOWNERS\",\"DESIGN.md\",\"README.md\",\"CONTRIBUTING.md\",\"CHANGELOG.md\",\"SECURITY.md\",\"CODE_OF_CONDUCT.md\",\"AGENTS.md\",\"CLAUDE.md\",\"GEMINI.md\"],\"title_prefix\":\"chore(deps): \"},\"create_report_incomplete_issue\":{},\"missing_data\":{},\"missing_tool\":{},\"noop\":{\"max\":1,\"report-as-issue\":\"true\"},\"report_incomplete\":{}}"
+          GH_AW_SAFE_OUTPUTS_HANDLER_CONFIG: "{\"close_issue\":{\"max\":10,\"required_title_prefix\":\"[deps-release-notes] \",\"state_reason\":\"not_planned\",\"target\":\"*\"},\"close_pull_request\":{\"max\":10,\"required_title_prefix\":\"chore(deps): \",\"target\":\"*\"},\"create_issue\":{\"labels\":[\"automation\",\"dependencies\"],\"max\":3,\"title_prefix\":\"[deps-release-notes] \"},\"create_pull_request\":{\"max\":4,\"max_patch_files\":100,\"max_patch_size\":1024,\"protect_top_level_dot_folders\":true,\"protected_files\":[\"package.json\",\"bun.lockb\",\"bunfig.toml\",\"deno.json\",\"deno.jsonc\",\"deno.lock\",\"global.json\",\"NuGet.Config\",\"Directory.Packages.props\",\"mix.exs\",\"mix.lock\",\"go.mod\",\"go.sum\",\"stack.yaml\",\"stack.yaml.lock\",\"pom.xml\",\"build.gradle\",\"build.gradle.kts\",\"settings.gradle\",\"settings.gradle.kts\",\"gradle.properties\",\"package-lock.json\",\"yarn.lock\",\"pnpm-lock.yaml\",\"npm-shrinkwrap.json\",\"requirements.txt\",\"Pipfile\",\"Pipfile.lock\",\"pyproject.toml\",\"setup.py\",\"setup.cfg\",\"Gemfile\",\"Gemfile.lock\",\"uv.lock\",\"CODEOWNERS\",\"DESIGN.md\",\"README.md\",\"CONTRIBUTING.md\",\"CHANGELOG.md\",\"SECURITY.md\",\"CODE_OF_CONDUCT.md\",\"AGENTS.md\",\"CLAUDE.md\",\"GEMINI.md\"],\"title_prefix\":\"chore(deps): \"},\"create_report_incomplete_issue\":{},\"missing_data\":{},\"missing_tool\":{},\"noop\":{\"max\":1,\"report-as-issue\":\"true\"},\"report_incomplete\":{}}"
           GH_AW_CI_TRIGGER_TOKEN: ${{ secrets.GH_AW_CI_TRIGGER_TOKEN }}
         with:
           github-token: ${{ secrets.GH_AW_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}

--- a/.github/workflows/update-awf-version.md
+++ b/.github/workflows/update-awf-version.md
@@ -1,7 +1,7 @@
 ---
 on:
   schedule: daily
-description: Checks for new releases of gh-aw-firewall, copilot-cli, and gh-aw-mcpg, and syncs ecosystem_domains.json from gh-aw. Opens PRs for any updates found.
+description: Checks for new releases of gh-aw-firewall, copilot-cli, and gh-aw-mcpg, and syncs ecosystem_domains.json from gh-aw. Opens PRs for any updates found, and files action-item issues summarizing the upstream release notes for each dependency bump.
 permissions:
   contents: read
   issues: read
@@ -19,6 +19,15 @@ safe-outputs:
     required-title-prefix: "chore(deps): "
     target: "*"
     max: 10
+  create-issue:
+    title-prefix: "[deps-release-notes] "
+    labels: [automation, dependencies]
+    max: 3
+  close-issue:
+    target: "*"
+    required-title-prefix: "[deps-release-notes] "
+    max: 10
+    state-reason: "not_planned"
 ---
 
 # Dependency Version Updater
@@ -27,7 +36,7 @@ You are a dependency maintenance bot for the **ado-aw** project — a Rust CLI c
 
 ## Your Task
 
-Check whether pinned version constants in `src/compile/common.rs` are up to date with the latest releases of their upstream dependencies, and whether `src/data/ecosystem_domains.json` matches the upstream source. For each outdated item, open a PR to update it.
+Check whether pinned version constants in `src/compile/common.rs` are up to date with the latest releases of their upstream dependencies, and whether `src/data/ecosystem_domains.json` matches the upstream source. For each outdated item, open a PR to update it. In addition, for each of the three pinned **version constants** (not the JSON sync), analyze the upstream release notes between the previously pinned version and the new latest version, and — when the notes contain breaking changes, security fixes, notable adoptable features, or deprecations — file a companion GitHub issue summarizing the action items for ado-aw maintainers.
 
 There are four items to check:
 
@@ -97,6 +106,10 @@ The `safe-outputs.create-pull-request.title-prefix` field is configured to `chor
 
   See the [gh-aw-firewall release notes](https://github.com/github/gh-aw-firewall/releases/tag/v<latest-version>) for details.
 
+  ### Action Items
+
+  If the upstream release notes describe changes that need follow-up in ado-aw, the workflow has also filed a companion issue titled `[deps-release-notes] awf v<latest-version> action items` summarizing them. If no such issue exists, the release was deemed routine (patch-level fixes, internal refactors, dependency bumps with no consumer-visible effect).
+
   ---
   *This PR was opened automatically by the dependency version updater workflow.*
   ```
@@ -112,6 +125,10 @@ The `safe-outputs.create-pull-request.title-prefix` field is configured to `chor
   ### Release
 
   See the [copilot-cli release notes](https://github.com/github/copilot-cli/releases/tag/v<latest-version>) for details.
+
+  ### Action Items
+
+  If the upstream release notes describe changes that need follow-up in ado-aw, the workflow has also filed a companion issue titled `[deps-release-notes] copilot-cli v<latest-version> action items` summarizing them. If no such issue exists, the release was deemed routine (patch-level fixes, internal refactors, dependency bumps with no consumer-visible effect).
 
   ---
   *This PR was opened automatically by the dependency version updater workflow.*
@@ -129,11 +146,121 @@ The `safe-outputs.create-pull-request.title-prefix` field is configured to `chor
 
   See the [gh-aw-mcpg release notes](https://github.com/github/gh-aw-mcpg/releases/tag/v<latest-version>) for details.
 
+  ### Action Items
+
+  If the upstream release notes describe changes that need follow-up in ado-aw, the workflow has also filed a companion issue titled `[deps-release-notes] mcpg v<latest-version> action items` summarizing them. If no such issue exists, the release was deemed routine (patch-level fixes, internal refactors, dependency bumps with no consumer-visible effect).
+
   ---
   *This PR was opened automatically by the dependency version updater workflow.*
   ```
 
 - **Base branch**: `main`
+
+### Step 5: File a Release-Notes Action-Items Issue (if applicable)
+
+After emitting the version-bump PR, analyze the upstream release notes between the **current** (about-to-be-replaced) version and the **latest** version, and decide whether to file a companion GitHub issue capturing items that need follow-up in ado-aw.
+
+This step **only** applies when Step 3 determined the version is being bumped. If the version is already up to date, skip Step 5 as well.
+
+#### Per-dependency identifiers
+
+Each of the three version constants uses a short dependency token in issue titles and a fixed upstream repository for release-note lookups:
+
+| Constant | Dep token | Upstream repo for releases |
+|----------|-----------|----------------------------|
+| `AWF_VERSION` | `awf` | `github/gh-aw-firewall` |
+| `COPILOT_CLI_VERSION` | `copilot-cli` | `github/copilot-cli` |
+| `MCPG_VERSION` | `mcpg` | `github/gh-aw-mcpg` |
+
+#### Step 5a: Fetch release notes for the version range
+
+List the releases of the upstream repo and select every release whose tag (with leading `v` stripped) satisfies:
+
+- strictly greater than the **current** pinned version (the value that was in the constant before this run), **and**
+- less than or equal to the **latest** version selected in Step 1.
+
+Use semantic-version comparison (compare major, then minor, then patch as integers). Pre-release tags (containing `-alpha`, `-beta`, `-rc`, etc.) are excluded.
+
+For each selected release, capture:
+
+- the version string (without the leading `v`)
+- the release notes body
+- the release URL
+
+If the agent cannot fetch a release body for some reason, record the URL and proceed with the rest; do not abort the whole step.
+
+#### Step 5b: Classify the changes
+
+For each release, classify each notable bullet/section into one of these categories, using the upstream release notes' own wording. Be conservative — when in doubt, classify as "Notable" rather than "Breaking".
+
+- **Breaking changes** — config schema changes, removed/renamed CLI flags, removed network egress, removed safe outputs, behaviour changes that an existing pinned ado-aw consumer would notice on upgrade.
+- **Security fixes** — CVEs, sandbox-escape fixes, credential-handling fixes, advisory references.
+- **Notable features for ado-aw to adopt** — new MCPG routing modes, new AWF egress controls, new tool surfaces, new safe outputs, observability or diagnostics features that ado-aw could plausibly surface to its users.
+- **Deprecations** — fields, flags, or behaviours announced as deprecated but not yet removed.
+
+Ignore items that are purely:
+
+- Patch-level internal refactors with no consumer-visible effect
+- Documentation-only changes upstream
+- Upstream dependency bumps that do not change consumer behaviour
+- CI / repo-hygiene changes upstream
+
+#### Step 5c: Decide whether to file an issue
+
+If after classification there are **no** items across all selected releases in any of the four categories above, **skip** — do not file an issue for this dependency. The PR body's "Action Items" section will then accurately read as "no issue exists" to reviewers.
+
+If there is **at least one** item in any category, continue to Step 5d.
+
+#### Step 5d: Close older action-items issues for the same dependency
+
+Search open issues whose titles start with the prefix `[deps-release-notes] <dep-token> v` (where `<dep-token>` is `awf`, `mcpg`, or `copilot-cli`). For each match:
+
+- If the title exactly matches the **expected** title for this run — `[deps-release-notes] <dep-token> v<latest-version> action items` — **skip** the issue-creation step; an up-to-date action-items issue is already open.
+- Otherwise the issue is an older action-items issue for the same dependency. Emit a `close-issue` safe output for its issue number with a short comment explaining that it is superseded by the issue being filed for `<latest-version>`. Then continue to Step 5e.
+
+Only close issues whose titles start with the per-dependency prefix above — never close issues that merely share the broader `[deps-release-notes] ` prefix but belong to a different dependency token.
+
+#### Step 5e: Create the action-items issue
+
+The `safe-outputs.create-issue.title-prefix` field is configured to `[deps-release-notes] `, so gh-aw will automatically prepend that prefix to every issue title. Provide the title below **without** the `[deps-release-notes] ` prefix — the compiled workflow will add it.
+
+- **Title**: `<dep-token> v<latest-version> action items` (will be published as `[deps-release-notes] <dep-token> v<latest-version> action items`)
+- **Body**:
+  ```markdown
+  ## Release Notes Action Items for `<dep-token>` `<old-version>` → `<latest-version>`
+
+  This issue summarizes upstream release notes for the `<dep-token>` dependency between the previously pinned version (`<old-version>`) and the new pinned version (`<latest-version>`), highlighting items that may need follow-up in ado-aw.
+
+  The companion version-bump PR is titled `chore(deps): update <CONSTANT_NAME> to <latest-version>`.
+
+  ### Releases analyzed
+
+  - [v<version-1>](<release-url-1>)
+  - [v<version-2>](<release-url-2>)
+  - …
+  - [v<latest-version>](<release-url-latest>)
+
+  ### Breaking changes
+
+  - <one bullet per breaking change, with a brief description and a link to the release that introduced it. Omit the section entirely if there are none.>
+
+  ### Security fixes
+
+  - <one bullet per security fix, with a brief description and a link to the release. Omit the section entirely if there are none.>
+
+  ### Notable features for ado-aw to adopt
+
+  - <one bullet per notable feature, with a brief description of how ado-aw could surface or integrate it, and a link to the release. Omit the section entirely if there are none.>
+
+  ### Deprecations
+
+  - <one bullet per deprecation, with a brief description and a link to the release. Omit the section entirely if there are none.>
+
+  ---
+  *This issue was opened automatically by the dependency version updater workflow.*
+  ```
+
+Keep the body grounded in the actual upstream release notes — do not invent items, and do not paraphrase so heavily that the upstream wording is lost. Each bullet should be checkable against the linked release.
 
 ---
 


### PR DESCRIPTION
## Summary

Expands the scope of the `update-awf-version` workflow so that, in addition to opening version-bump PRs for `AWF_VERSION`, `MCPG_VERSION`, and `COPILOT_CLI_VERSION`, it also analyzes the upstream release notes between the previously-pinned version and the new latest version and files a companion GitHub issue summarizing items that need follow-up in ado-aw.

For each of the three pinned version constants, the workflow now:

- Fetches every release between the currently-pinned version (exclusive) and the latest version (inclusive), using semver comparison and skipping pre-releases.
- Classifies each notable item into one of four buckets: **Breaking changes**, **Security fixes**, **Notable features for ado-aw to adopt**, **Deprecations**.
- Skips issue creation entirely when the release notes contain only routine items (patch fixes, internal refactors, upstream dep bumps, docs/CI).
- Otherwise files a single `[deps-release-notes] <dep-token> v<latest> action items` issue covering the full range, with one bullet per item linked back to the originating release.
- Dedups per dependency: searches existing open issues with the same per-dep prefix, skips when an up-to-date issue already exists, and closes older superseded issues via the new `close-issue` safe output. Only matches its own dep token, never crosses dependencies.
- Cross-links: the version-bump PR body's new *Action Items* section names the expected companion issue title so reviewers know whether to look for it.

New safe outputs in the workflow:

- `create-issue` with `title-prefix: "[deps-release-notes] "`, `max: 3`, labels `automation, dependencies`.
- `close-issue` with matching `required-title-prefix`, `target: "*"`, `max: 10`, `state-reason: not_planned`.

Out of scope: the `ecosystem_domains.json` sync still works exactly as before — release-notes analysis only applies to the three pinned version constants.

## Test plan

- `gh aw compile update-awf-version` → 0 errors, 0 warnings; regenerated `.lock.yml` confirms both new safe-output handlers are wired in with the expected limits, prefixes, and labels.
- Verified no Rust source or tests reference the workflow file (it's a gh-aw artifact, treated as `linguist-generated`).
