### PR TITLE
fix(tests): isolate fixtures from codemod rewrites and bump Windows debug stack

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,14 @@
+# Windows MSVC: bump the main-thread stack from the default 1 MiB to 8 MiB.
+#
+# Rust debug builds produce very large async state machines (no optimisation
+# collapses them), and `#[tokio::main]` polls the top-level future on the main
+# thread. The compile path nests many async fns whose combined Future state
+# easily exceeds 1 MiB, crashing with `thread 'main' has overflowed its stack`
+# on a stock `cargo build` + `target\debug\ado-aw.exe compile <fixture>` run.
+#
+# 8 MiB matches the Linux default and is what the binary already gets on
+# Linux/macOS, so applying it on Windows just restores parity rather than
+# introducing a platform-specific quirk. Release builds work either way; this
+# only matters in practice for debug/test builds.
+[target.'cfg(all(windows, target_env = "msvc"))']
+rustflags = ["-C", "link-arg=/STACK:8388608"]

--- a/tests/compiler_tests.rs
+++ b/tests/compiler_tests.rs
@@ -851,10 +851,16 @@ fn test_1es_compiled_output_no_unreplaced_markers() {
     ));
     fs::create_dir_all(&temp_dir).expect("Failed to create temp directory");
 
-    let fixture_path = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+    let fixture_src = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
         .join("tests")
         .join("fixtures")
         .join("1es-test-agent.md");
+
+    // Copy the fixture into the temp dir before compiling so codemods
+    // (e.g. pool_object_form) can never rewrite the source tree, and
+    // parallel test runs cannot race on the same input file.
+    let fixture_path = temp_dir.join("1es-test-agent.md");
+    fs::copy(&fixture_src, &fixture_path).expect("Failed to copy 1ES fixture into temp dir");
 
     let output_path = temp_dir.join("1es-test-agent.yml");
 
@@ -3520,10 +3526,19 @@ fn compile_fixture_with_flags(fixture_name: &str, extra_flags: &[&str]) -> Strin
     ));
     fs::create_dir_all(&temp_dir).expect("Failed to create temp directory");
 
-    let fixture_path = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+    let fixture_src = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
         .join("tests")
         .join("fixtures")
         .join(fixture_name);
+
+    // Copy the fixture into the temp dir before compiling. Codemods
+    // (e.g. pool_object_form) may rewrite the source on disk; copying
+    // keeps the canonical fixture under tests/fixtures pristine and
+    // prevents parallel tests that target the same fixture from
+    // racing on the lost-update guard in compile.
+    let fixture_path = temp_dir.join(fixture_name);
+    fs::copy(&fixture_src, &fixture_path)
+        .unwrap_or_else(|e| panic!("Failed to copy fixture {fixture_name} into temp dir: {e}"));
 
     let output_path = temp_dir.join(fixture_name.replace(".md", ".yml"));
 


### PR DESCRIPTION
## Summary

Two surgical fixes for the failing `test_1es_compiled_output_no_unreplaced_markers` CI test, plus a Windows-only build-config fix discovered while reproducing it.

### 1. Fix codemod race in compile-fixture tests (`tests/compiler_tests.rs`)

CI error:
```
Error: source file /home/runner/work/ado-aw/ado-aw/tests/fixtures/1es-test-agent.md
changed during compilation; refusing to apply codemods. Re-run `ado-aw compile`.
```

**Root cause.** The `pool_object_form` codemod (introduced in 0.30.0) fires on `target: 1es` fixtures lacking `pool:`, injecting `pool: { name: AZS-1ES-L-MMS-ubuntu-22.04 }` and rewriting the source on disk. `cargo test` runs in parallel, so multiple tests targeting the same fixture all snapshot the original SHA and race to write back — whichever loses trips the lost-update guard in `src/compile/mod.rs:305-310`.

**Fix.** Copy each fixture into a per-test temp dir before invoking the compiler. Codemods may still fire (harmless on the temp copy) but the canonical fixture under `tests/fixtures/` is never mutated and parallel tests cannot race.

Two edits:
- `test_1es_compiled_output_no_unreplaced_markers` (the failing test): now copies `1es-test-agent.md` into the temp dir.
- `compile_fixture_with_flags` helper (used by ~12 other tests): same pattern.

`tests/bash_lint_tests.rs` was already doing this correctly. Other inline compile invocations in `compiler_tests.rs` don't target the 1ES fixtures that trigger the codemod.

### 2. Fix Windows debug-build stack overflow (`.cargo/config.toml`)

When reproducing the CI failure locally on Windows, the compile crashed with `thread 'main' has overflowed its stack` before the codemod logic ever ran — a separate, pre-existing issue.

**Root cause.** `#[tokio::main]` polls the top-level future on the main thread. Debug builds produce very large async state machines (no optimisation collapses them), and the deeply-nested `async fn`s in `ado-aw compile` exceed Windows' default 1 MiB main-thread stack. Linux/macOS default to 8 MiB and were unaffected. Release builds work everywhere because optimisation shrinks the state machines.

**Fix.** New `.cargo/config.toml` adds `/STACK:8388608` (8 MiB, matching Linux) via a linker flag gated to `cfg(all(windows, target_env = "msvc"))`. Linux and macOS builds are untouched.

## Test plan

- `cargo test` — full suite passes on Windows (1587 unit + 91 compiler + 0 failures across all test binaries). Before the fix, `test_1es_compiled_output_no_unreplaced_markers` failed on Windows (stack overflow) and on Linux CI (codemod race).
- Manually re-ran `ado-aw compile tests/fixtures/1es-test-agent.md` with the freshly-rebuilt debug binary on Windows — no stack overflow, codemod fires on the temp copy as expected.
- Verified the canonical fixture under `tests/fixtures/` is no longer mutated by test runs (`git status` clean after `cargo test`).
