### PR TITLE
docs: fix architecture tree drift — add missing source files

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -59,6 +59,7 @@ Every compiled pipeline runs as three sequential jobs:
 │   │   ├── pr_filters.rs # PR trigger filter generation (native ADO + gate steps)
 │   │   ├── extensions/   # CompilerExtension trait and infrastructure extensions
 │   │   │   ├── mod.rs    # Trait, Extension enum, collect_extensions(), re-exports
+│   │   │   ├── ado_aw_marker.rs # Always-on metadata marker extension (emits # ado-aw-metadata JSON)
 │   │   │   ├── github.rs # Always-on GitHub MCP extension
 │   │   │   ├── safe_outputs.rs # Always-on SafeOutputs MCP extension
 │   │   │   ├── trigger_filters.rs # Trigger filter extension (gate evaluator delivery)
@@ -84,8 +85,10 @@ Every compiled pipeline runs as three sequential jobs:
 │   ├── status.rs         # `status` CLI command — denser per-pipeline status block (thin renderer over `list`'s data path)
 │   ├── run.rs            # `run` CLI command — queues builds for matched definitions, optional polling to completion (module entry is `dispatch`)
 │   ├── ado/              # Shared Azure DevOps REST helpers (auth, list/match/PATCH/POST)
-│   │   └── mod.rs        # Shared ADO REST helpers used by all lifecycle commands (`enable`, `disable`, `list`, `status`, `run`, `remove`, `secrets`)
+│   │   ├── mod.rs        # Shared ADO REST helpers used by all lifecycle commands (`enable`, `disable`, `list`, `status`, `run`, `remove`, `secrets`)
+│   │   └── discovery.rs  # Project-scope pipeline discovery (`--all-repos` / `--source` flags)
 │   ├── detect.rs         # Agentic pipeline detection — discovers compiled pipelines; used by all lifecycle commands
+│   ├── update_check.rs   # Version update check — queries GitHub Releases and prints advisory when newer version is available
 │   ├── ndjson.rs         # NDJSON parsing utilities
 │   ├── sanitize.rs       # Input sanitization for safe outputs
 │   ├── validate.rs       # Structural input validators (char allowlists, format checks, injection detectors)


### PR DESCRIPTION
Add three source files to the AGENTS.md architecture tree that exist in the codebase but were not listed:

- src/compile/extensions/ado_aw_marker.rs — always-on metadata marker extension that emits the # ado-aw-metadata JSON blob into every compiled pipeline (used by project-scope discovery)
- src/ado/discovery.rs — project-scope pipeline discovery backing the --all-repos / --source flags on secrets/enable/disable/remove/list
- src/update_check.rs — version update checker that queries GitHub Releases on each invocation and prints an advisory to stderr when a newer release is available

<!--
  ⚠️  PR TITLE = CHANGELOG ENTRY
  This repo uses squash-merge, so your PR title becomes the commit on main.
  release-please uses it for the changelog and version bump.

  Format:  type(scope): description
  Example: feat(compile): add S360 Breeze MCP as first-party tool

  Types that appear in the changelog:
    feat  → Features     (bumps minor version)
    fix   → Bug Fixes    (bumps patch version)

  Types that do NOT appear in the changelog (no version bump):
    chore, docs, refactor, test, ci, perf, build

  Bad:  "Allow workspace to target a repo alias"
  Good: "feat(compile): allow workspace to target a repo alias"
-->

## Summary

<!-- Brief description of what this PR does and why. -->

## Test plan

<!-- How was this tested? (cargo test, manual verification, etc.) -->
