### PR TITLE
docs: fix documentation drift — AGENTS.md architecture tree for scripts/ section

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -159,10 +159,11 @@ Every compiled pipeline runs as three sequential jobs:
 │   ├── update-ado-agentic-workflow.md # Guide for modifying an existing agentic pipeline
 │   └── debug-ado-agentic-workflow.md  # Guide for troubleshooting a failing agentic pipeline
 ├── scripts/              # Supporting scripts shipped as release artifacts
-│   ├── ado-script/       # TypeScript workspace for bundled gate.js, import.js, and future bundles
-│   │   └── src/
-│   │       └── import/   # Runtime prompt resolver bundle
-│   └── gate.js           # Bundled gate evaluator (built from scripts/ado-script/, see docs/ado-script.md)
+│   └── ado-script/       # TypeScript workspace for bundled gate.js, import.js, and future bundles
+│       └── src/
+│           ├── gate/     # Gate evaluator source (bundled to dist/gate/index.js)
+│           ├── import/   # Runtime prompt resolver source (bundled to dist/import/index.js)
+│           └── shared/   # Shared modules across bundles (auth, ado-client, env-facts, types.gen.ts)
 ├── tests/                # Integration tests and fixtures
 ├── docs/                 # Per-concept reference documentation (see index below)
 ├── Cargo.toml            # Rust dependencies


### PR DESCRIPTION
Two inaccuracies in the architecture tree:

1. scripts/gate.js was listed as a committed file but it is in .gitignore (build artifact - bundled by npm run build into scripts/ado-script/dist/). Removed from the tree.

2. scripts/ado-script/src/ only showed the import/ subdirectory but the actual directory also contains gate/ (gate evaluator source) and shared/ (modules shared across bundles). Updated to reflect the actual structure.

<!--
  ⚠️  PR TITLE = CHANGELOG ENTRY
  This repo uses squash-merge, so your PR title becomes the commit on main.
  release-please uses it for the changelog and version bump.

  Format:  type(scope): description
  Example: feat(compile): add S360 Breeze MCP as first-party tool

  Types that appear in the changelog:
    feat  → Features     (bumps minor version)
    fix   → Bug Fixes    (bumps patch version)

  Types that do NOT appear in the changelog (no version bump):
    chore, docs, refactor, test, ci, perf, build

  Bad:  "Allow workspace to target a repo alias"
  Good: "feat(compile): allow workspace to target a repo alias"
-->

## Summary

<!-- Brief description of what this PR does and why. -->

## Test plan

<!-- How was this tested? (cargo test, manual verification, etc.) -->
