### PR TITLE
chore: migrate MCP config from .vscode/mcp.json to .mcp.json

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -1,5 +1,5 @@
 {
-  "servers": {
+  "mcpServers": {
     "github-agentic-workflows": {
       "command": "gh",
       "args": [


### PR DESCRIPTION
Per https://gh.io/copilotcli-mcpmigrate, Copilot CLI loads workspace MCP servers from .mcp.json at the repo root (not .vscode/mcp.json).

## Changes
- Rename `.vscode/mcp.json` → `.mcp.json`
- Switch the top-level key from `servers` to `mcpServers` (the format Copilot CLI expects)

## Verification
Before:
```
> copilot mcp list --json
{ "mcpServers": {} }
```

After:
```
> copilot mcp list
Workspace servers:
  github-agentic-workflows (local)

> copilot mcp get github-agentic-workflows
github-agentic-workflows
  Type: local
  Command: gh aw mcp-server
  Tools: * (all)
  Source: Workspace (.mcp.json)
```