### PR TITLE
docs: fix documentation drift — add missing audit/ module to architecture tree

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -87,6 +87,27 @@ Every compiled pipeline runs as three sequential jobs:
 │   ├── ado/              # Shared Azure DevOps REST helpers (auth, list/match/PATCH/POST)
 │   │   ├── mod.rs        # Shared ADO REST helpers used by all lifecycle commands (`enable`, `disable`, `list`, `status`, `run`, `remove`, `secrets`)
 │   │   └── discovery.rs  # Project-scope pipeline discovery (`--all-repos` / `--source` flags)
+│   ├── audit/            # `ado-aw audit` command — downloads pipeline artifacts and runs analyzers
+│   │   ├── mod.rs        # Shared audit data types; AuditData report model
+│   │   ├── cli.rs        # CLI entry point for the `audit` subcommand
+│   │   ├── model.rs      # AuditData and supporting report structs
+│   │   ├── findings.rs   # Finding severity levels and structured finding types
+│   │   ├── cache.rs      # Artifact download cache (keyed on build-id)
+│   │   ├── url.rs        # Build-reference parsing (bare ID, full ADO URL)
+│   │   ├── analyzers/    # Per-signal analyzers that populate AuditData sections
+│   │   │   ├── mod.rs
+│   │   │   ├── detection.rs    # Detection-stage artifact analysis
+│   │   │   ├── firewall.rs     # AWF network log analysis
+│   │   │   ├── jobs.rs         # Build timeline / job-level analysis
+│   │   │   ├── mcp.rs          # MCP tool-call analysis
+│   │   │   ├── missing.rs      # Missing-tool / missing-data / noop safe-output analysis
+│   │   │   ├── otel.rs         # OTel agent stats (token usage, duration, turns)
+│   │   │   ├── policy.rs       # Policy-level findings (safe-output integrity, prompt injection signals)
+│   │   │   └── safe_outputs.rs # Safe-output NDJSON analysis
+│   │   └── render/       # Report renderers
+│   │       ├── mod.rs
+│   │       ├── console.rs # Human-readable console report
+│   │       └── json.rs    # Machine-readable AuditData JSON
 │   ├── detect.rs         # Agentic pipeline detection — discovers compiled pipelines; used by all lifecycle commands
 │   ├── update_check.rs   # Version update check — queries GitHub Releases and prints advisory when newer version is available
 │   ├── ndjson.rs         # NDJSON parsing utilities


### PR DESCRIPTION
The src/audit/ module (introduced with the ado-aw audit command) was
never added to the architecture section of AGENTS.md. The command is
referenced in the CLI docs and docs index, but agents reading the
architecture tree had no visibility into the module structure.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>

<!--
  ⚠️  PR TITLE = CHANGELOG ENTRY
  This repo uses squash-merge, so your PR title becomes the commit on main.
  release-please uses it for the changelog and version bump.

  Format:  type(scope): description
  Example: feat(compile): add S360 Breeze MCP as first-party tool

  Types that appear in the changelog:
    feat  → Features     (bumps minor version)
    fix   → Bug Fixes    (bumps patch version)

  Types that do NOT appear in the changelog (no version bump):
    chore, docs, refactor, test, ci, perf, build

  Bad:  "Allow workspace to target a repo alias"
  Good: "feat(compile): allow workspace to target a repo alias"
-->

## Summary

<!-- Brief description of what this PR does and why. -->

## Test plan

<!-- How was this tested? (cargo test, manual verification, etc.) -->
