### PR TITLE
fix(workflows): switch recompile-safe-output-fixtures trigger to release:published and drop broken Step 0

### DIFF
--- a/.github/workflows/recompile-safe-output-fixtures.lock.yml
+++ b/.github/workflows/recompile-safe-output-fixtures.lock.yml
@@ -1,4 +1,4 @@
-# gh-aw-metadata: {"schema_version":"v4","frontmatter_hash":"f6fb6dbafb292393fd525f16e28dfadda7411799718cbe16f55dc7fd4fbd5cc5","body_hash":"70fdfc32ceeb43d45f37a43c4e64e15d3cc2491c1146cd33497907a5139204f4","compiler_version":"v0.77.5","strict":true,"agent_id":"copilot"}
+# gh-aw-metadata: {"schema_version":"v4","frontmatter_hash":"33554ea7b4a25ad990f90f0a9729aebcd785c4a6372889e2412df914bd2c94bd","body_hash":"09ab817be62be5e8bf9912909ac1fedcbaf36e8c048cdc21c1a8ef7cddee3b7c","compiler_version":"v0.77.5","strict":true,"agent_id":"copilot"}
 # gh-aw-manifest: {"version":1,"secrets":["COPILOT_GITHUB_TOKEN","GH_AW_CI_TRIGGER_TOKEN","GH_AW_GITHUB_MCP_SERVER_TOKEN","GH_AW_GITHUB_TOKEN","GITHUB_TOKEN"],"actions":[{"repo":"actions/checkout","sha":"de0fac2e4500dabe0009e67214ff5f5447ce83dd","version":"v6.0.2"},{"repo":"actions/download-artifact","sha":"3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c","version":"v8.0.1"},{"repo":"actions/github-script","sha":"373c709c69115d41ff229c7e5df9f8788daa9553","version":"v9"},{"repo":"actions/github-script","sha":"3a2844b7e9c422d3c10d287c895573f7108da1b3","version":"v9.0.0"},{"repo":"actions/github-script","sha":"d746ffe35508b1917358783b479e04febd2b8f71","version":"v9.0.0"},{"repo":"actions/setup-node","sha":"48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e","version":"v6.4.0"},{"repo":"actions/upload-artifact","sha":"043fb46d1a93c77aae656e7c1c64a875d1fc6a0a","version":"v7.0.1"},{"repo":"github/gh-aw-actions/setup","sha":"3ea13c02d765410340d533515cb31a7eef2baaf0","version":"v0.77.5"}],"containers":[{"image":"ghcr.io/github/gh-aw-firewall/agent:0.25.58"},{"image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.25.58"},{"image":"ghcr.io/github/gh-aw-firewall/squid:0.25.58"},{"image":"ghcr.io/github/gh-aw-mcpg:v0.3.22"},{"image":"ghcr.io/github/github-mcp-server:v1.1.0"},{"image":"node:lts-alpine","digest":"sha256:2bdb65ed1dab192432bc31c95f94155ca5ad7fc1392fb7eb7526ab682fa5bf14","pinned_image":"node:lts-alpine@sha256:2bdb65ed1dab192432bc31c95f94155ca5ad7fc1392fb7eb7526ab682fa5bf14"}]}
 #    ___                   _   _      
 #   / _ \                 | | (_)     
@@ -51,6 +51,9 @@
 
 name: "Recompile safe-output fixtures"
 on:
+  release:
+    types:
+    - published
   workflow_dispatch:
     inputs:
       aw_context:
@@ -62,14 +65,6 @@ on:
         description: ado-aw release tag to recompile against (e.g. v0.16.0). Leave blank to use the latest published release.
         required: false
         type: string
-  workflow_run:
-    # zizmor: ignore[dangerous-triggers] - workflow_run trigger is secured with role and fork validation
-    branches:
-    - main
-    types:
-    - completed
-    workflows:
-    - Release
 
 permissions: {}
 
@@ -81,10 +76,7 @@ run-name: "Recompile safe-output fixtures"
 jobs:
   activation:
     needs: pre_activation
-    # zizmor: ignore[dangerous-triggers] - workflow_run trigger is secured with role and fork validation
-    if: >
-      (needs.pre_activation.outputs.activated == 'true') && (github.event_name != 'workflow_run' || github.event.workflow_run.repository.id == github.repository_id &&
-      (!(github.event.workflow_run.repository.fork)))
+    if: needs.pre_activation.outputs.activated == 'true'
     runs-on: ubuntu-slim
     permissions:
       actions: read
@@ -206,23 +198,23 @@ jobs:
         run: |
           bash "${RUNNER_TEMP}/gh-aw/actions/create_prompt_first.sh"
           {
-          cat << 'GH_AW_PROMPT_662980cbc5ec33af_EOF'
+          cat << 'GH_AW_PROMPT_94145f90a8e093fb_EOF'
           <system>
-          GH_AW_PROMPT_662980cbc5ec33af_EOF
+          GH_AW_PROMPT_94145f90a8e093fb_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/xpia.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/temp_folder_prompt.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/markdown.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_prompt.md"
-          cat << 'GH_AW_PROMPT_662980cbc5ec33af_EOF'
+          cat << 'GH_AW_PROMPT_94145f90a8e093fb_EOF'
           <safe-output-tools>
           Tools: create_pull_request, close_pull_request(max:5), missing_tool, missing_data, noop
-          GH_AW_PROMPT_662980cbc5ec33af_EOF
+          GH_AW_PROMPT_94145f90a8e093fb_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_create_pull_request.md"
-          cat << 'GH_AW_PROMPT_662980cbc5ec33af_EOF'
+          cat << 'GH_AW_PROMPT_94145f90a8e093fb_EOF'
           </safe-output-tools>
-          GH_AW_PROMPT_662980cbc5ec33af_EOF
+          GH_AW_PROMPT_94145f90a8e093fb_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/mcp_cli_tools_prompt.md"
-          cat << 'GH_AW_PROMPT_662980cbc5ec33af_EOF'
+          cat << 'GH_AW_PROMPT_94145f90a8e093fb_EOF'
           <github-context>
           The following GitHub context information is available for this workflow:
           {{#if github.actor}}
@@ -251,12 +243,12 @@ jobs:
           {{/if}}
           </github-context>
           
-          GH_AW_PROMPT_662980cbc5ec33af_EOF
+          GH_AW_PROMPT_94145f90a8e093fb_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/github_mcp_tools_with_safeoutputs_prompt.md"
-          cat << 'GH_AW_PROMPT_662980cbc5ec33af_EOF'
+          cat << 'GH_AW_PROMPT_94145f90a8e093fb_EOF'
           </system>
           {{#runtime-import .github/workflows/recompile-safe-output-fixtures.md}}
-          GH_AW_PROMPT_662980cbc5ec33af_EOF
+          GH_AW_PROMPT_94145f90a8e093fb_EOF
           } > "$GH_AW_PROMPT"
       - name: Interpolate variables and render templates
         uses: actions/github-script@d746ffe35508b1917358783b479e04febd2b8f71 # v9.0.0
@@ -470,9 +462,9 @@ jobs:
           mkdir -p "${RUNNER_TEMP}/gh-aw/safeoutputs"
           mkdir -p /tmp/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/mcp-logs/safeoutputs
-          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_5269c3d093b06e0a_EOF'
+          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_f5513b792da01ede_EOF'
           {"close_pull_request":{"max":5,"required_title_prefix":"chore(workflows): recompile safe-output fixtures","target":"*"},"create_pull_request":{"allowed_files":["tests/safe-outputs/**/*.lock.yml"],"max":1,"max_patch_files":100,"max_patch_size":1024,"protect_top_level_dot_folders":true,"protected_files":["package.json","bun.lockb","bunfig.toml","deno.json","deno.jsonc","deno.lock","global.json","NuGet.Config","Directory.Packages.props","mix.exs","mix.lock","go.mod","go.sum","stack.yaml","stack.yaml.lock","pom.xml","build.gradle","build.gradle.kts","settings.gradle","settings.gradle.kts","gradle.properties","package-lock.json","yarn.lock","pnpm-lock.yaml","npm-shrinkwrap.json","requirements.txt","Pipfile","Pipfile.lock","pyproject.toml","setup.py","setup.cfg","Gemfile","Gemfile.lock","uv.lock","CODEOWNERS","DESIGN.md","README.md","CONTRIBUTING.md","CHANGELOG.md","SECURITY.md","CODE_OF_CONDUCT.md","AGENTS.md","CLAUDE.md","GEMINI.md"],"protected_files_policy":"request_review","title_prefix":"chore(workflows): "},"create_report_incomplete_issue":{},"missing_data":{},"missing_tool":{},"noop":{"max":1,"report-as-issue":"true"},"report_incomplete":{}}
-          GH_AW_SAFE_OUTPUTS_CONFIG_5269c3d093b06e0a_EOF
+          GH_AW_SAFE_OUTPUTS_CONFIG_f5513b792da01ede_EOF
       - name: Generate Safe Outputs Tools
         env:
           GH_AW_TOOLS_META_JSON: |
@@ -704,7 +696,7 @@ jobs:
           
           mkdir -p /home/runner/.copilot
           GH_AW_NODE=$(which node 2>/dev/null || command -v node 2>/dev/null || echo node)
-          cat << GH_AW_MCP_CONFIG_eadd2e0dbdfb8c56_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
+          cat << GH_AW_MCP_CONFIG_dd79c41ee5f23d3f_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
           {
             "mcpServers": {
               "github": {
@@ -745,7 +737,7 @@ jobs:
               "payloadDir": "${MCP_GATEWAY_PAYLOAD_DIR}"
             }
           }
-          GH_AW_MCP_CONFIG_eadd2e0dbdfb8c56_EOF
+          GH_AW_MCP_CONFIG_dd79c41ee5f23d3f_EOF
       - name: Mount MCP servers as CLIs
         id: mount-mcp-clis
         continue-on-error: true

--- a/.github/workflows/recompile-safe-output-fixtures.md
+++ b/.github/workflows/recompile-safe-output-fixtures.md
@@ -1,9 +1,7 @@
 ---
 on:
-  workflow_run:
-    workflows: ["Release"]
-    types: [completed]
-    branches: [main]
+  release:
+    types: [published]
   workflow_dispatch:
     inputs:
       version:
@@ -39,28 +37,7 @@ You are a deterministic release-driven recompiler for the **ado-aw** project. Ev
 
 Your goal each run is to land **at most one** focused PR that recompiles `tests/safe-outputs/*.lock.yml` against the **latest released** `ado-aw` binary. If nothing in the directory actually changes after recompilation, emit `noop` and exit.
 
-## Step 0 — Bail out early on irrelevant `workflow_run` triggers
-
-This workflow may be triggered by `workflow_run` after the `Release` workflow completes. The Release workflow runs on every push to `main`; only successful runs that actually published a release have new artifacts.
-
-If invoked via `workflow_run`:
-
-```bash
-TRIGGER="${GITHUB_EVENT_NAME:-unknown}"
-echo "trigger=$TRIGGER"
-if [ "$TRIGGER" = "workflow_run" ]; then
-  CONCLUSION="$(jq -r '.workflow_run.conclusion // empty' "$GITHUB_EVENT_PATH" 2>/dev/null || echo "")"
-  HEAD_BRANCH="$(jq -r '.workflow_run.head_branch // empty' "$GITHUB_EVENT_PATH" 2>/dev/null || echo "")"
-  echo "release_conclusion=$CONCLUSION head_branch=$HEAD_BRANCH"
-  if [ "$CONCLUSION" != "success" ] || [ "$HEAD_BRANCH" != "main" ]; then
-    echo "Release run did not succeed on main; nothing to recompile."
-    # Emit noop and stop. Do not proceed to any further steps.
-    exit 0
-  fi
-fi
-```
-
-If you exit here, emit `noop` with a one-line reason naming `$CONCLUSION` and `$HEAD_BRANCH` so the run is observable, and do not perform any other steps.
+> **Note on triggers.** This workflow is invoked by the `release` event when a new ado-aw release is published, or manually via `workflow_dispatch`. Release-please publishes the GitHub Release first; the `build` job inside the `Release` workflow then uploads the platform binaries and `checksums.txt`. By the time the `release` event fires both should be present, but Step 2 below adds a bounded retry so a slightly delayed asset upload does not cause a hard failure.
 
 ## Step 1 — Resolve the target ado-aw version
 
@@ -88,7 +65,7 @@ If the resolved tag is malformed (does not match `v[0-9]+\.[0-9]+\.[0-9]+(-[A-Za
 
 ## Step 2 — Download and verify the released `ado-aw-linux-x64` binary
 
-Release-please publishes the GitHub Release first; the `build` job inside the `Release` workflow then uploads the platform binaries and `checksums.txt`. By the time `workflow_run` fires, both should be present, but add a bounded retry so a slightly delayed asset upload does not cause a hard failure.
+Release-please publishes the GitHub Release first; the `build` job inside the `Release` workflow then uploads the platform binaries and `checksums.txt`. By the time the `release` event fires both should be present, but add a bounded retry so a slightly delayed asset upload does not cause a hard failure.
 
 ```bash
 set -euo pipefail
@@ -265,7 +242,6 @@ The `safe-outputs.close-pull-request` configuration on this workflow targets any
 
 ## When NOT to open a PR
 
-- `workflow_run` fired for a Release-workflow run that did not succeed on `main` (Step 0).
 - The resolved tag is missing or malformed (Step 1) — emit `missing-data`.
 - Release assets never appear within the bounded retry window (Step 2) — emit `report-incomplete`.
 - `ado-aw --version` does not contain `BARE` (Step 2) — emit `missing-data`.


### PR DESCRIPTION
## Summary

Fixes the bail-out bug seen in [run 27021589908](https://github.com/githubnext/ado-aw/actions/runs/27021589908/job/79750763346). After PR #868 landed, the `release` workflow finished for the merge commit and `workflow_run` fired the recompile workflow. The agent ran Step 0's bash and got back empty strings for both `release_conclusion` and `head_branch`, so it bailed out with `noop` — even though `head_branch` on the run itself was clearly `main`.

Root cause: Step 0 read `github.event.workflow_run.{conclusion,head_branch}` from `$GITHUB_EVENT_PATH` inside the AWF chroot sandbox. The event file isn't reliably readable by the sandboxed `awfuser` (UID 1001), so `jq … 2>/dev/null || echo ""` silently returned empty for both fields and the `if "$CONCLUSION" != "success"` branch fired on every invocation. Confirmed in the agent's process log (`tooluse_qYI5wexrspAEDMxqn0RkIZ`) which shows the model interpreting both fields as empty.

This PR:

1. **Switches the trigger** from `workflow_run: { workflows: [Release] }` to `release: { types: [published] }`. The new trigger only fires when a release is actually published, instead of on every push to `main` (which previously caused a no-op recompile cycle every time anything landed). The brief window between release creation and binary asset upload is already handled by Step 2's bounded retry.

2. **Removes Step 0 entirely**. The two cases it was trying to guard against are already handled downstream:
   - "Release didn't publish anything new" — now impossible under the `release: published` trigger.
   - "Release published but assets missing" — Step 2's bounded retry hits `report-incomplete` after the retry window expires.

3. **Drops the corresponding bullet** from the "When NOT to open a PR" list and updates the prose note explaining the trigger.

## Test plan

- Manually inspected `tooluse_qYI5wexrspAEDMxqn0RkIZ` in the agent process log to confirm both `CONCLUSION` and `HEAD_BRANCH` were empty even though `head_branch` on the run was `main`.
- Verified `release: { types: [published] }` is supported by gh-aw v0.77.5 (`pkg/workflow/trigger_parser.go`).
- Lock file regenerated with `gh aw compile recompile-safe-output-fixtures`.
- Will be exercised end-to-end on the next ado-aw release.

Follows from #868 (per-file compile loop + integrity heuristic, also already merged).
