### PR TITLE
docs: fix documentation drift — permissions.write and azure_cli.rs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -63,6 +63,7 @@ Every compiled pipeline runs as three sequential jobs:
 │   │   │   ├── github.rs # Always-on GitHub MCP extension
 │   │   │   ├── safe_outputs.rs # Always-on SafeOutputs MCP extension
 │   │   │   ├── ado_script.rs # Always-on ado-script extension (gate evaluator + runtime-import resolver, per-job downloads)
+│   │   │   ├── azure_cli.rs # Always-on Azure CLI extension (runtime detection, AWF mounts, az allowlist)
 │   │   │   └── tests.rs  # Extension integration tests
 │   │   ├── codemods/     # Front-matter codemods (one file per transformation)
 │   │   │   ├── mod.rs    # Codemod struct, CODEMODS registry, runner

--- a/prompts/create-ado-agentic-workflow.md
+++ b/prompts/create-ado-agentic-workflow.md
@@ -684,7 +684,7 @@ When generating the agent file:
 1. **Produce exactly one `.md` file.** Do not create separate documentation, architecture notes, or runbooks.
 2. **Respect existing repository conventions** for file placement. Look at where existing pipeline YAML files or agent markdown files are located in the repo. If no convention exists, ask the user where they'd like the file placed.
 3. **Omit optional fields when they match defaults** — no `engine:` for `claude-opus-4.7`, no `workspace:` for `root`, no `target:` for `standalone`.
-4. **Always validate** that write-requiring safe-outputs (`create-pull-request`, `create-work-item`) have `permissions.write` set.
+4. **`permissions.write` is optional** — the Stage 3 executor defaults to `$(System.AccessToken)`. Only add `permissions.write` when the task requires cross-org writes or named-identity attribution.
 
 ## Compilation
 
@@ -802,4 +802,4 @@ safe-outputs:
 - **Explicit allow-lists**: Restrict MCP tools to only what the agent needs.
 - **No direct writes**: All mutations go through safe outputs — the agent cannot push code or call write APIs directly.
 - **Compile before committing**: Always compile with `ado-aw compile` and commit both the `.md` source and generated `.lock.yml` together.
-- **Check validation**: The compiler will error if write safe-outputs are configured without `permissions.write`.
+- **Check validation**: The compiler validates front-matter fields and emits errors for invalid configurations (e.g., conflicting filter rules, missing required fields like `comment-on-work-item.target`). Write-bearing safe outputs do **not** require `permissions.write` — the executor defaults to `$(System.AccessToken)`.


### PR DESCRIPTION
- prompts/create-ado-agentic-workflow.md: Fix two incorrect statements
  about permissions.write being required for write-bearing safe outputs.
  The executor defaults to $(System.AccessToken) and permissions.write
  is only needed for cross-org writes or named-identity attribution.
  Previously Output Instructions step 4 and Key Rules both incorrectly
  stated this was required, contradicting the correct guidance in step 10.

- AGENTS.md: Add missing src/compile/extensions/azure_cli.rs to the
  architecture tree. This always-on extension handles Azure CLI runtime
  detection, conditional AWF bind-mounts, and the az allowlist. It was
  present in the codebase but omitted from the directory listing.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>

<!--
  ⚠️  PR TITLE = CHANGELOG ENTRY
  This repo uses squash-merge, so your PR title becomes the commit on main.
  release-please uses it for the changelog and version bump.

  Format:  type(scope): description
  Example: feat(compile): add S360 Breeze MCP as first-party tool

  Types that appear in the changelog:
    feat  → Features     (bumps minor version)
    fix   → Bug Fixes    (bumps patch version)

  Types that do NOT appear in the changelog (no version bump):
    chore, docs, refactor, test, ci, perf, build

  Bad:  "Allow workspace to target a repo alias"
  Good: "feat(compile): allow workspace to target a repo alias"
-->

## Summary

<!-- Brief description of what this PR does and why. -->

## Test plan

<!-- How was this tested? (cargo test, manual verification, etc.) -->
