### PR TITLE
docs: fix documentation drift — permissions.write incorrectly documented as required

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,22 +204,21 @@ sees.
      write: ado-agent-write
    ```
 
-> [!IMPORTANT]
-> If you configure any safe output that requires write access (e.g.
-> `create-pull-request`, `create-work-item`, `add-pr-comment`, `queue-build`,
-> `upload-pipeline-artifact`, and others — see the [Safe Outputs](#safe-outputs)
-> table for the full list) but omit `permissions.write`, compilation will fail
-> with a clear error. This is a safety check — write operations must always
-> have an explicitly configured credential.
+> [!NOTE]
+> `permissions.write` is **optional**. The Stage 3 executor always has a
+> write-capable token available via `$(System.AccessToken)` (the pipeline's
+> built-in OAuth token, running as *Project Collection Build Service*). Configure
+> `permissions.write` only when you need cross-org writes or named-identity
+> attribution — it overrides the default token with an ARM-minted credential.
 
 #### Permission Combinations
 
 | Configuration | Agent can read ADO? | Safe outputs can write? |
 |---|---|---|
-| Both `read` + `write` | ✅ | ✅ |
-| Only `read` | ✅ | ❌ |
-| Only `write` | ❌ | ✅ |
-| Neither (default) | ❌ | ❌ |
+| Both `read` + `write` | ✅ | ✅ (via ARM-minted token) |
+| Only `read` | ✅ | ✅ (via `$(System.AccessToken)`) |
+| Only `write` | ❌ | ✅ (via ARM-minted token) |
+| Neither (default) | ❌ | ✅ (via `$(System.AccessToken)`) |
 
 ### Step 4: Authorize the Pipeline
 
@@ -255,6 +254,7 @@ the service connections. Approve the permissions and the pipeline is ready.
 | `network` | object | — | Additional allowed/blocked hosts |
 | `inlined-imports` | boolean | `false` | When `true`, resolves all `{{#runtime-import …}}` markers at compile time; the generated YAML is self-contained but prompt-body edits require recompilation. See [runtime-imports.md](docs/runtime-imports.md). |
 | `env` | map | — | Workflow-level environment variables (reserved, not yet implemented) |
+| `execution-context` | object | — | Configuration for the always-on execution-context plugin (PR context precompute). See [execution-context.md](docs/execution-context.md). |
 
 ### Markdown Body
 


### PR DESCRIPTION
Fixes documentation drift in README.md:

- Remove false claim that compilation fails without permissions.write for write safe outputs. The Stage 3 executor always has write access via $(System.AccessToken); permissions.write only overrides the default with an ARM-minted credential.
- Correct the Permission Combinations table. Both the 'Only read' and 'Neither (default)' rows incorrectly showed safe outputs cannot write. All rows can write; the difference is which token is used ($(System.AccessToken) vs ARM-minted).
- Add the missing xecution-context field to the Front Matter Fields table. The field exists in the FrontMatter struct and has its own docs page but was absent from the table.

Generated by agentic workflow run 27088800996.