### PR TITLE
feat(enable): support GitHub-source pipelines via --service-connection

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -76,8 +76,22 @@ Both flags route through `ado-aw`'s `discover_ado_aw_pipelines` machinery, which
   - `--dry-run` - Print the planned actions (and the full POST body for creates) without calling the ADO API.
   - `--also-set-token` - After creating a new definition, set its `GITHUB_TOKEN` variable (as an ADO secret).
   - `--token <value>` - The token value for `--also-set-token`. Falls back to `$GITHUB_TOKEN`, then to an interactive prompt. Requires `--also-set-token`.
+  - `--service-connection <name-or-guid>` - GitHub service-connection name (e.g. `ado-aw-github`) or GUID. **Required when the source repository is on GitHub.** Rejected (with a clear error) when the source is Azure DevOps Git.
+  - `--repository-name <owner/repo>` - Source repository override (GitHub source only). Auto-detected from the git remote when omitted; useful when the local checkout's remote points at a fork rather than the canonical source repo the deployment should reference.
 
-  **Source-repo scope (Phase 1):** `enable` requires the local git remote to be an Azure DevOps Git remote (the source repo is what gets registered as the definition's repository). GitHub-hosted source repos are gated on a follow-up.
+  **Source-repo autodetect:** `enable` parses `git remote get-url origin` and routes to either the TfsGit or GitHub create-definition body shape automatically. ADO Git remotes (`dev.azure.com/...`, legacy `*.visualstudio.com`) emit a `TfsGit` body. `github.com` remotes (HTTPS or SSH) emit a `GitHub` body whose `repository.properties.connectedServiceId` references the project-level GitHub service connection resolved from `--service-connection`. If the local remote can't be parsed at all, pass both `--repository-name owner/repo` and `--service-connection` explicitly. GitHub Enterprise (`github.example.com`) is not supported in v1.
+
+  **GitHub-source pre-requisites:** create a GitHub service connection in the target ADO project (Project settings → Service connections → GitHub) before running `enable --service-connection ...`. ADO has no REST API for creating service connections — this is a one-time portal action. Then either install the Azure Pipelines GitHub App on the source repo or paste a fine-grained PAT.
+
+  **Example (smoke fixtures registered in `msazuresphere/AgentPlayground` from a `githubnext/ado-aw` checkout):**
+  ```powershell
+  ado-aw enable `
+    --org msazuresphere --project AgentPlayground `
+    --service-connection ado-aw-github `
+    --folder '\smoke' `
+    tests/safe-outputs/
+  ```
+  Re-running is idempotent. `disable`, `remove`, `list`, `status`, and `run` work against the same definitions from the same GitHub checkout — they match by YAML path (provider-agnostic) and require explicit `--org`/`--project` because the git remote can't infer the deployment target for GitHub-source pipelines.
 
 - `disable [PATH]`- Set `queueStatus` to `disabled` (default) or `paused` on every ADO build definition that matches a local fixture under `PATH`. Refuses to touch any ADO definition that is not the target of a local fixture match — that safety property falls naturally out of the same yaml-path + name match used by `configure`. Skips definitions that are already at the requested status; fail-soft per fixture; exits non-zero if any patch failed or if zero local fixtures matched ADO definitions.
   - `--org <url>` - Override: Azure DevOps organization (URL or bare org name). Inferred from git remote by default.

--- a/src/ado/discovery.rs
+++ b/src/ado/discovery.rs
@@ -350,7 +350,16 @@ fn normalize_repo_url(url: &str) -> String {
     let decoded = percent_encoding::percent_decode_str(url)
         .decode_utf8_lossy()
         .into_owned();
-    decoded.trim_end_matches('/').to_ascii_lowercase()
+    // Trim a trailing `.git` (after stripping a trailing `/`) so the
+    // form ADO returns in `repository.url` (typically without `.git`)
+    // compares equal to the form callers pass in via `RepoSource::url()`
+    // or that we POST in `build_create_body` for GitHub
+    // (`https://github.com/owner/repo.git`). Without this, GitHub-source
+    // pipelines would silently miss the `CurrentRepo` filter.
+    decoded
+        .trim_end_matches('/')
+        .trim_end_matches(".git")
+        .to_ascii_lowercase()
 }
 
 /// Build a `(normalized yamlFilename → local lock path)` lookup table
@@ -909,6 +918,37 @@ mod tests {
         let kept = apply_scope_filter(defs, &DiscoveryScope::CurrentRepo, &current);
         assert_eq!(kept.len(), 1);
         assert_eq!(kept[0].id, 2);
+    }
+
+    #[test]
+    fn scope_current_repo_matches_github_source_with_dotgit_suffix() {
+        // ADO stores the repository.url for a GitHub-source definition
+        // typically without a `.git` suffix, but `build_create_body`
+        // POSTs it with `.git`. `normalize_repo_url` strips the suffix
+        // so both forms compare equal — this pins that contract for
+        // the GitHub-source CurrentRepo filter.
+        let defs = vec![def_with(
+            42,
+            "gh-source",
+            None,
+            Some("https://github.com/githubnext/ado-aw"),
+        )];
+        let current = Some("https://github.com/githubnext/ado-aw.git".to_string());
+        let kept = apply_scope_filter(defs, &DiscoveryScope::CurrentRepo, &current);
+        assert_eq!(kept.len(), 1);
+        assert_eq!(kept[0].id, 42);
+
+        // And the reverse — stored with `.git`, queried without.
+        let defs = vec![def_with(
+            43,
+            "gh-source-rev",
+            None,
+            Some("https://github.com/githubnext/ado-aw.git"),
+        )];
+        let current = Some("https://github.com/githubnext/ado-aw".to_string());
+        let kept = apply_scope_filter(defs, &DiscoveryScope::CurrentRepo, &current);
+        assert_eq!(kept.len(), 1);
+        assert_eq!(kept[0].id, 43);
     }
 
     // ── is_direct_match ──────────────────────────────────────────────

--- a/src/ado/discovery.rs
+++ b/src/ado/discovery.rs
@@ -350,15 +350,20 @@ fn normalize_repo_url(url: &str) -> String {
     let decoded = percent_encoding::percent_decode_str(url)
         .decode_utf8_lossy()
         .into_owned();
-    // Trim a trailing `.git` (after stripping a trailing `/`) so the
-    // form ADO returns in `repository.url` (typically without `.git`)
-    // compares equal to the form callers pass in via `RepoSource::url()`
-    // or that we POST in `build_create_body` for GitHub
-    // (`https://github.com/owner/repo.git`). Without this, GitHub-source
-    // pipelines would silently miss the `CurrentRepo` filter.
+    // Three-pass trim handles every realistic and pathological form
+    // without depending on the order ADO and GitHub emit them in:
+    //   `repo`        → `repo`
+    //   `repo/`       → `repo`
+    //   `repo.git`    → `repo`
+    //   `repo.git/`   → `repo`  (trailing `/` first, then `.git`)
+    //   `repo/.git`   → `repo`  (no trailing `/`, then `.git`, then `/`)
+    // The final `/` trim only matters for the `/.git` form — no
+    // real-world ADO or GitHub URL takes that shape, but the cost
+    // here is one extra method call, so we may as well be exhaustive.
     decoded
         .trim_end_matches('/')
         .trim_end_matches(".git")
+        .trim_end_matches('/')
         .to_ascii_lowercase()
 }
 
@@ -949,6 +954,33 @@ mod tests {
         let kept = apply_scope_filter(defs, &DiscoveryScope::CurrentRepo, &current);
         assert_eq!(kept.len(), 1);
         assert_eq!(kept[0].id, 43);
+    }
+
+    // ── normalize_repo_url ──────────────────────────────────────────
+
+    /// `normalize_repo_url`'s three-pass strip must collapse every
+    /// realistic *and* pathological suffix combination to the same
+    /// canonical form. Pins the contract so a future reorder of the
+    /// `.trim_end_matches` chain can't silently break it.
+    #[test]
+    fn normalize_repo_url_collapses_all_suffix_forms() {
+        let want = "https://github.com/githubnext/ado-aw";
+        for input in [
+            "https://github.com/githubnext/ado-aw",
+            "https://github.com/githubnext/ado-aw/",
+            "https://github.com/githubnext/ado-aw.git",
+            "https://github.com/githubnext/ado-aw.git/",
+            "https://github.com/githubnext/ado-aw/.git",
+            // Casing normalises too.
+            "HTTPS://GITHUB.COM/GitHubNext/ADO-AW.git",
+        ] {
+            assert_eq!(
+                normalize_repo_url(input),
+                want,
+                "normalize_repo_url({:?}) should produce the canonical form",
+                input
+            );
+        }
     }
 
     // ── is_direct_match ──────────────────────────────────────────────

--- a/src/ado/mod.rs
+++ b/src/ado/mod.rs
@@ -226,14 +226,27 @@ impl RepoSource {
     /// normalizer also strips it). Not currently wired into the
     /// `CurrentRepo` URL filter for GitHub source — see the PR
     /// landing this type for the deferred-work rationale.
+    ///
+    /// Invariant: `provider == AdoGit` implies `project.is_some()`
+    /// (every `AdoGit`-yielding `parse_git_remote` path sets it).
+    /// A debug assertion guards against a future producer that
+    /// forgets to populate the field — release builds fall back to
+    /// an empty path segment rather than panicking, since the URL is
+    /// only used for comparison and a mismatch is the right failure
+    /// mode there.
     pub fn url(&self) -> String {
         match self.provider {
-            RepoProvider::AdoGit => format!(
-                "https://dev.azure.com/{}/{}/_git/{}",
-                self.owner,
-                self.project.as_deref().unwrap_or(""),
-                self.repo,
-            ),
+            RepoProvider::AdoGit => {
+                let project = self.project.as_deref().unwrap_or_default();
+                debug_assert!(
+                    !project.is_empty(),
+                    "RepoSource::url(): AdoGit invariant violated — project must be Some"
+                );
+                format!(
+                    "https://dev.azure.com/{}/{}/_git/{}",
+                    self.owner, project, self.repo,
+                )
+            }
             RepoProvider::Github => {
                 format!("https://github.com/{}/{}", self.owner, self.repo)
             }
@@ -2107,6 +2120,25 @@ mod tests {
             project: None,
         };
         assert_eq!(source.url(), "https://github.com/githubnext/ado-aw");
+    }
+
+    /// In release builds (where `debug_assert!` is a no-op), an
+    /// `AdoGit` `RepoSource` with `project: None` must still produce
+    /// a well-formed-ish URL — we tolerate the empty middle segment
+    /// rather than panicking, because `url()` is comparison-only.
+    /// `parse_git_remote` never produces this shape in practice; this
+    /// test only documents the defensive fallback.
+    #[cfg(not(debug_assertions))]
+    #[test]
+    fn repo_source_url_ado_without_project_release_fallback() {
+        let source = RepoSource {
+            provider: RepoProvider::AdoGit,
+            owner: "myorg".to_string(),
+            repo: "myrepo".to_string(),
+            project: None,
+        };
+        // Empty project segment is the documented fallback.
+        assert_eq!(source.url(), "https://dev.azure.com/myorg//_git/myrepo");
     }
 
     // ==================== Service-connection resolver ====================

--- a/src/ado/mod.rs
+++ b/src/ado/mod.rs
@@ -218,12 +218,14 @@ pub struct RepoSource {
 }
 
 impl RepoSource {
-    /// Return the form ADO stores in `repository.url` for a build
-    /// definition backed by this source.
+    /// Return the canonical browse URL ADO surfaces in
+    /// `repository.url` for a build definition backed by this source.
     ///
-    /// Used by discovery's `CurrentRepo` URL filter — both shapes
-    /// flow through `normalize_repo_url` for the equality check, so
-    /// minor casing / encoding differences are handled there.
+    /// Returned in the form expected by [`crate::ado::discovery`]'s
+    /// `normalize_repo_url` (no trailing `.git` — the discovery
+    /// normalizer also strips it). Not currently wired into the
+    /// `CurrentRepo` URL filter for GitHub source — see the PR
+    /// landing this type for the deferred-work rationale.
     pub fn url(&self) -> String {
         match self.provider {
             RepoProvider::AdoGit => format!(
@@ -1180,7 +1182,11 @@ pub async fn resolve_service_connection_id(
         "{}/{}/_apis/serviceendpoint/endpoints?type=github&endpointNames={}&api-version=7.1-preview.4",
         ctx.org_url.trim_end_matches('/'),
         percent_encoding::utf8_percent_encode(&ctx.project, PATH_SEGMENT),
-        percent_encoding::utf8_percent_encode(trimmed, PATH_SEGMENT),
+        // The endpoint name is a query-string value (not a path
+        // segment), so `&` and `=` must be percent-encoded or they'd
+        // split the parameter. `PATH_SEGMENT` deliberately leaves
+        // both unescaped; use `NON_ALPHANUMERIC` for query values.
+        percent_encoding::utf8_percent_encode(trimmed, percent_encoding::NON_ALPHANUMERIC),
     );
 
     debug!("Looking up GitHub service connection '{}': {}", trimmed, url);
@@ -2171,6 +2177,26 @@ mod tests {
             .unwrap_err()
             .to_string();
         assert!(err.contains("missing `value` array"));
+    }
+
+    /// The `endpointNames=` query-string value must encode `&` and `=`
+    /// — otherwise an endpoint named e.g. `foo&bar=baz` would
+    /// shatter into two `endpointNames` params and a stray `baz=` on
+    /// the URL. `PATH_SEGMENT` leaves both unescaped (legal sub-delims
+    /// in a path segment), so we use `NON_ALPHANUMERIC` for query
+    /// values. Test pins that we don't regress.
+    #[test]
+    fn service_connection_query_value_encodes_query_metacharacters() {
+        let encoded = percent_encoding::utf8_percent_encode(
+            "foo&bar=baz",
+            percent_encoding::NON_ALPHANUMERIC,
+        )
+        .to_string();
+        assert!(!encoded.contains('&'), "must encode '&' in query value");
+        assert!(!encoded.contains('='), "must encode '=' in query value");
+        assert!(encoded.contains("foo"));
+        assert!(encoded.contains("bar"));
+        assert!(encoded.contains("baz"));
     }
 
     // ==================== match_definitions_in (provider-agnostic) ====================

--- a/src/ado/mod.rs
+++ b/src/ado/mod.rs
@@ -267,7 +267,18 @@ impl RepoSource {
 /// GitHub Enterprise (`github.example.com`) is **not** matched in v1.
 pub fn parse_git_remote(remote_url: &str) -> Result<RepoSource> {
     if let Ok(ctx) = parse_ado_remote(remote_url) {
-        let owner = ctx.org_name().unwrap_or("").to_string();
+        // Defensive: every shape `parse_ado_remote` accepts populates
+        // `org_url` with a `/{org}` segment, so `org_name()` should
+        // always return `Some`. Bail explicitly on the unreachable
+        // path rather than silently producing an empty `owner` that
+        // would surface later as a confusing ADO API error.
+        let owner = ctx.org_name().ok_or_else(|| {
+            anyhow::anyhow!(
+                "Parsed '{}' as an ADO remote but could not extract the org segment from '{}'",
+                remote_url,
+                ctx.org_url
+            )
+        })?.to_string();
         return Ok(RepoSource {
             provider: RepoProvider::AdoGit,
             owner,
@@ -1114,6 +1125,42 @@ pub const PATH_SEGMENT: &percent_encoding::AsciiSet = &percent_encoding::CONTROL
     .add(b':')
     .add(b'!');
 
+/// Characters that must be percent-encoded when used as a URL
+/// **query-string value** (the bit after `?key=` and before `&` /
+/// `#`). Preserves the RFC 3986 unreserved set (`A-Z`, `a-z`, `0-9`,
+/// `-`, `_`, `.`, `~`) so common identifiers like `ado-aw-github` are
+/// emitted literally rather than as `ado%2Daw%2Dgithub` — strictly
+/// correct ADO/RFC behaviour either way, but the unencoded form is
+/// what humans read in debug logs and what most servers' strict
+/// matchers prefer. Encodes:
+///
+/// - query-syntax metachars (`&`, `=`, `#`, `?`) that would split
+///   the parameter,
+/// - `%` (escape char) and `+` (form-encoding space alias),
+/// - whitespace and structural ASCII (`/`, `:`, `@`, `<`, `>`, `"`,
+///   `'`, `{`, `}`, `` ` ``).
+///
+/// Stricter than `NON_ALPHANUMERIC` (which would encode `-`/`_`/`.`/`~`)
+/// and weaker than `PATH_SEGMENT` (which does *not* encode `&`/`=`).
+pub const QUERY_VALUE: &percent_encoding::AsciiSet = &percent_encoding::CONTROLS
+    .add(b' ')
+    .add(b'"')
+    .add(b'\'')
+    .add(b'#')
+    .add(b'<')
+    .add(b'>')
+    .add(b'?')
+    .add(b'`')
+    .add(b'{')
+    .add(b'}')
+    .add(b'/')
+    .add(b'%')
+    .add(b'@')
+    .add(b':')
+    .add(b'&')
+    .add(b'=')
+    .add(b'+');
+
 /// Look up an ADO Git repository's GUID by name.
 ///
 /// Calls `GET /_apis/git/repositories/{repoName}?api-version=7.1` and reads
@@ -1197,9 +1244,11 @@ pub async fn resolve_service_connection_id(
         percent_encoding::utf8_percent_encode(&ctx.project, PATH_SEGMENT),
         // The endpoint name is a query-string value (not a path
         // segment), so `&` and `=` must be percent-encoded or they'd
-        // split the parameter. `PATH_SEGMENT` deliberately leaves
-        // both unescaped; use `NON_ALPHANUMERIC` for query values.
-        percent_encoding::utf8_percent_encode(trimmed, percent_encoding::NON_ALPHANUMERIC),
+        // split the parameter. Use `QUERY_VALUE` rather than
+        // `PATH_SEGMENT` (leaves `&`/`=` unencoded) or
+        // `NON_ALPHANUMERIC` (over-encodes `-`/`_`/`.`/`~`); the
+        // common `ado-aw-github` style emits literally.
+        percent_encoding::utf8_percent_encode(trimmed, QUERY_VALUE),
     );
 
     debug!("Looking up GitHub service connection '{}': {}", trimmed, url);
@@ -2214,21 +2263,30 @@ mod tests {
     /// The `endpointNames=` query-string value must encode `&` and `=`
     /// — otherwise an endpoint named e.g. `foo&bar=baz` would
     /// shatter into two `endpointNames` params and a stray `baz=` on
-    /// the URL. `PATH_SEGMENT` leaves both unescaped (legal sub-delims
-    /// in a path segment), so we use `NON_ALPHANUMERIC` for query
-    /// values. Test pins that we don't regress.
+    /// the URL. We use a custom `QUERY_VALUE` set rather than
+    /// `NON_ALPHANUMERIC` (over-encodes `-`/`_`/`.`/`~`) or
+    /// `PATH_SEGMENT` (leaves `&`/`=` unencoded). Test pins both:
+    /// query metachars escape, RFC 3986 unreserved chars don't.
     #[test]
     fn service_connection_query_value_encodes_query_metacharacters() {
-        let encoded = percent_encoding::utf8_percent_encode(
-            "foo&bar=baz",
-            percent_encoding::NON_ALPHANUMERIC,
-        )
-        .to_string();
+        let encoded =
+            percent_encoding::utf8_percent_encode("foo&bar=baz", QUERY_VALUE).to_string();
         assert!(!encoded.contains('&'), "must encode '&' in query value");
         assert!(!encoded.contains('='), "must encode '=' in query value");
         assert!(encoded.contains("foo"));
         assert!(encoded.contains("bar"));
         assert!(encoded.contains("baz"));
+    }
+
+    #[test]
+    fn service_connection_query_value_preserves_unreserved_chars() {
+        // RFC 3986 unreserved set: A-Z a-z 0-9 - _ . ~ — these must
+        // pass through literally. Pins that we don't regress to
+        // `NON_ALPHANUMERIC` which would over-encode them.
+        let encoded =
+            percent_encoding::utf8_percent_encode("ado-aw_github.v1~beta", QUERY_VALUE)
+                .to_string();
+        assert_eq!(encoded, "ado-aw_github.v1~beta");
     }
 
     // ==================== match_definitions_in (provider-agnostic) ====================

--- a/src/ado/mod.rs
+++ b/src/ado/mod.rs
@@ -175,6 +175,154 @@ pub fn parse_ado_remote(remote_url: &str) -> Result<AdoContext> {
     )
 }
 
+// ==================== Source identity (RepoSource) ====================
+
+/// Which forge a pipeline's source markdown lives on.
+///
+/// `AdoGit` and `Github` are the only providers supported in v1. The
+/// `repository.url` form ADO stores for a build definition uses a
+/// different shape per provider — see [`RepoSource::url`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RepoProvider {
+    /// Azure DevOps Git (TfsGit).
+    AdoGit,
+    /// GitHub on `github.com` (GitHub Enterprise is out of scope for
+    /// v1; see `docs/cli.md` for the follow-up roadmap).
+    Github,
+}
+
+/// Where the agent markdown for a compiled pipeline lives.
+///
+/// `RepoSource` is the **source identity** half of the two-namespace
+/// model — distinct from [`AdoContext`], which carries the ADO
+/// **deployment target** (`org_url`, `project`). They coincide for
+/// ADO-source pipelines (both halves derived from the same git remote)
+/// and diverge for GitHub-source pipelines (the source lives on
+/// GitHub but the pipeline runs in some ADO project supplied via
+/// `--org`/`--project`).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RepoSource {
+    /// Which forge hosts the repository.
+    pub provider: RepoProvider,
+    /// For `AdoGit`: the ADO organisation name (e.g. `myorg`).
+    /// For `Github`: the GitHub owner (e.g. `githubnext`).
+    pub owner: String,
+    /// Bare repository name in both cases (e.g. `templates-a`,
+    /// `ado-aw`). Never `owner/repo` — composing the slashed form is
+    /// the caller's job when the API requires it (e.g. the GitHub
+    /// build-definition body's `repository.name` field).
+    pub repo: String,
+    /// `Some("MyProject")` for `AdoGit` (ADO organisations contain
+    /// projects). `None` for `Github`.
+    pub project: Option<String>,
+}
+
+impl RepoSource {
+    /// Return the form ADO stores in `repository.url` for a build
+    /// definition backed by this source.
+    ///
+    /// Used by discovery's `CurrentRepo` URL filter — both shapes
+    /// flow through `normalize_repo_url` for the equality check, so
+    /// minor casing / encoding differences are handled there.
+    pub fn url(&self) -> String {
+        match self.provider {
+            RepoProvider::AdoGit => format!(
+                "https://dev.azure.com/{}/{}/_git/{}",
+                self.owner,
+                self.project.as_deref().unwrap_or(""),
+                self.repo,
+            ),
+            RepoProvider::Github => {
+                format!("https://github.com/{}/{}", self.owner, self.repo)
+            }
+        }
+    }
+}
+
+/// Parse a git remote URL into a [`RepoSource`].
+///
+/// Tries [`parse_ado_remote`] first (regression-safe for every existing
+/// ADO call site), then `github.com` HTTPS / SSH. Bails with a unified
+/// "could not parse as ADO Git or GitHub" message when neither matches.
+///
+/// Accepted GitHub forms:
+/// - `https://github.com/{owner}/{repo}` (with or without `.git`)
+/// - `git@github.com:{owner}/{repo}` (with or without `.git`)
+///
+/// GitHub Enterprise (`github.example.com`) is **not** matched in v1.
+pub fn parse_git_remote(remote_url: &str) -> Result<RepoSource> {
+    if let Ok(ctx) = parse_ado_remote(remote_url) {
+        let owner = ctx.org_name().unwrap_or("").to_string();
+        return Ok(RepoSource {
+            provider: RepoProvider::AdoGit,
+            owner,
+            repo: ctx.repo_name,
+            project: Some(ctx.project),
+        });
+    }
+
+    if let Some(source) = parse_github_remote(remote_url) {
+        return Ok(source);
+    }
+
+    anyhow::bail!(
+        "Could not parse '{}' as either an Azure DevOps Git remote \
+         (https://dev.azure.com/{{org}}/{{project}}/_git/{{repo}}) or a \
+         GitHub remote (https://github.com/{{owner}}/{{repo}} or \
+         git@github.com:{{owner}}/{{repo}})",
+        remote_url
+    )
+}
+
+/// Try to parse `remote_url` as a `github.com` HTTPS or SSH URL.
+///
+/// Returns `None` on any other host (including GitHub Enterprise) so
+/// the caller can fall through to its own error path.
+fn parse_github_remote(remote_url: &str) -> Option<RepoSource> {
+    let url = remote_url.trim();
+
+    // SSH: git@github.com:owner/repo(.git)
+    if let Some(rest) = url.strip_prefix("git@github.com:") {
+        let (owner, repo) = split_owner_repo(rest)?;
+        return Some(RepoSource {
+            provider: RepoProvider::Github,
+            owner,
+            repo,
+            project: None,
+        });
+    }
+
+    // HTTPS: https://github.com/owner/repo(.git)
+    let parsed = url::Url::parse(url).ok()?;
+    if parsed.host_str() != Some("github.com") {
+        return None;
+    }
+    let path = parsed.path().trim_start_matches('/');
+    let (owner, repo) = split_owner_repo(path)?;
+    Some(RepoSource {
+        provider: RepoProvider::Github,
+        owner,
+        repo,
+        project: None,
+    })
+}
+
+/// Split a `owner/repo[.git][/...]` fragment, trimming the `.git`
+/// suffix on the repo half. Returns `None` if either half is empty.
+fn split_owner_repo(path: &str) -> Option<(String, String)> {
+    let mut parts = path.splitn(3, '/');
+    let owner = parts.next()?.trim();
+    let repo_raw = parts.next()?.trim();
+    if owner.is_empty() || repo_raw.is_empty() {
+        return None;
+    }
+    let repo = repo_raw.trim_end_matches(".git");
+    if repo.is_empty() {
+        return None;
+    }
+    Some((owner.to_string(), repo.to_string()))
+}
+
 /// Get the git remote URL for the repository at `repo_path`.
 pub async fn get_git_remote_url(repo_path: &Path) -> Result<String> {
     let output = tokio::process::Command::new("git")
@@ -999,6 +1147,144 @@ pub async fn get_repository_id(
         .with_context(|| format!("Repository '{}' response has no 'id' field", repo_name))
 }
 
+/// Resolve a GitHub service-connection identifier to its GUID.
+///
+/// Accepts either a raw UUID (returned unchanged — no API call) or a
+/// human-readable endpoint name (e.g. `ado-aw-github`) which is
+/// resolved via the project-scoped service-endpoint API.
+///
+/// Used by `ado-aw enable` when registering GitHub-source build
+/// definitions: the ADO `repository.properties.connectedServiceId`
+/// field requires a GUID, but operators prefer typing the friendly
+/// name they set up in the portal.
+///
+/// Returns a useful error on 0-match (the connection doesn't exist in
+/// this project) or >1-match (rare, but possible if two endpoints
+/// happen to share a display name; operator must pass the GUID
+/// directly to disambiguate).
+pub async fn resolve_service_connection_id(
+    client: &reqwest::Client,
+    ctx: &AdoContext,
+    auth: &AdoAuth,
+    value: &str,
+) -> Result<String> {
+    let trimmed = value.trim();
+    if trimmed.is_empty() {
+        anyhow::bail!("--service-connection value is empty");
+    }
+    if is_uuid_like(trimmed) {
+        return Ok(trimmed.to_string());
+    }
+
+    let url = format!(
+        "{}/{}/_apis/serviceendpoint/endpoints?type=github&endpointNames={}&api-version=7.1-preview.4",
+        ctx.org_url.trim_end_matches('/'),
+        percent_encoding::utf8_percent_encode(&ctx.project, PATH_SEGMENT),
+        percent_encoding::utf8_percent_encode(trimmed, PATH_SEGMENT),
+    );
+
+    debug!("Looking up GitHub service connection '{}': {}", trimmed, url);
+
+    let resp = auth
+        .apply(client.get(&url))
+        .send()
+        .await
+        .with_context(|| {
+            format!(
+                "Failed to look up GitHub service connection '{}' in project '{}'",
+                trimmed, ctx.project
+            )
+        })?;
+
+    let status = resp.status();
+    if !status.is_success() {
+        let body = resp.text().await.unwrap_or_default();
+        anyhow::bail!(
+            "ADO API returned {} when looking up service connection '{}': {}",
+            status,
+            trimmed,
+            body
+        );
+    }
+
+    let body: serde_json::Value = resp.json().await.with_context(|| {
+        format!("Failed to parse service-endpoint response for '{}'", trimmed)
+    })?;
+
+    pick_service_endpoint_id(&body, trimmed, &ctx.project)
+}
+
+/// Returns `true` when `value` looks like a UUID
+/// (`xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx`, hex only). Case-insensitive.
+///
+/// The check is intentionally lenient — ADO accepts any GUID, so we
+/// only need to recognise the canonical hyphenated form well enough to
+/// skip the resolution API call. A false negative (resolver runs even
+/// though `value` was a GUID) is harmless; the API returns the same
+/// id back.
+fn is_uuid_like(value: &str) -> bool {
+    let bytes = value.as_bytes();
+    if bytes.len() != 36 {
+        return false;
+    }
+    for (i, b) in bytes.iter().enumerate() {
+        let is_hyphen_position = matches!(i, 8 | 13 | 18 | 23);
+        if is_hyphen_position {
+            if *b != b'-' {
+                return false;
+            }
+        } else if !b.is_ascii_hexdigit() {
+            return false;
+        }
+    }
+    true
+}
+
+/// Pick the single service-endpoint `id` from the
+/// `/_apis/serviceendpoint/endpoints` list response.
+///
+/// Factored out for unit-testability: the JSON shape is stable
+/// (`{ count, value: [ { id, name, … } ] }`) and the 0 / 1 / >1 result
+/// triage logic is the interesting part.
+fn pick_service_endpoint_id(
+    body: &serde_json::Value,
+    name: &str,
+    project: &str,
+) -> Result<String> {
+    let entries = body
+        .get("value")
+        .and_then(|v| v.as_array())
+        .ok_or_else(|| {
+            anyhow::anyhow!(
+                "service-endpoint response missing `value` array (got: {})",
+                body
+            )
+        })?;
+
+    match entries.len() {
+        0 => anyhow::bail!(
+            "No GitHub service connection named '{}' was found in project '{}'. \
+             Create one under Project settings → Service connections → GitHub, then re-run.",
+            name,
+            project
+        ),
+        1 => entries[0]
+            .get("id")
+            .and_then(|v| v.as_str())
+            .map(str::to_string)
+            .ok_or_else(|| {
+                anyhow::anyhow!("Service connection '{}' has no `id` field", name)
+            }),
+        n => anyhow::bail!(
+            "{} GitHub service connections named '{}' in project '{}'. \
+             Pass the GUID directly to --service-connection to disambiguate.",
+            n,
+            name,
+            project
+        ),
+    }
+}
+
 /// Fetch the full JSON body of a build definition.
 ///
 /// Calls `GET /_apis/build/definitions/{id}?api-version=7.1` and returns
@@ -1709,6 +1995,223 @@ mod tests {
     fn test_parse_ado_remote_invalid() {
         assert!(parse_ado_remote("https://github.com/user/repo").is_err());
         assert!(parse_ado_remote("not-a-url").is_err());
+    }
+
+    // ==================== RepoSource / parse_git_remote ====================
+
+    #[test]
+    fn parse_git_remote_ado_https() {
+        let source =
+            parse_git_remote("https://dev.azure.com/myorg/MyProject/_git/myrepo").unwrap();
+        assert_eq!(source.provider, RepoProvider::AdoGit);
+        assert_eq!(source.owner, "myorg");
+        assert_eq!(source.repo, "myrepo");
+        assert_eq!(source.project.as_deref(), Some("MyProject"));
+    }
+
+    #[test]
+    fn parse_git_remote_ado_ssh() {
+        let source =
+            parse_git_remote("git@ssh.dev.azure.com:v3/myorg/MyProject/myrepo").unwrap();
+        assert_eq!(source.provider, RepoProvider::AdoGit);
+        assert_eq!(source.owner, "myorg");
+        assert_eq!(source.repo, "myrepo");
+        assert_eq!(source.project.as_deref(), Some("MyProject"));
+    }
+
+    #[test]
+    fn parse_git_remote_ado_legacy_visualstudio() {
+        let source =
+            parse_git_remote("https://myorg.visualstudio.com/MyProject/_git/myrepo").unwrap();
+        assert_eq!(source.provider, RepoProvider::AdoGit);
+        assert_eq!(source.owner, "myorg");
+        assert_eq!(source.repo, "myrepo");
+        assert_eq!(source.project.as_deref(), Some("MyProject"));
+    }
+
+    #[test]
+    fn parse_git_remote_github_https() {
+        let source = parse_git_remote("https://github.com/githubnext/ado-aw").unwrap();
+        assert_eq!(source.provider, RepoProvider::Github);
+        assert_eq!(source.owner, "githubnext");
+        assert_eq!(source.repo, "ado-aw");
+        assert!(source.project.is_none());
+    }
+
+    #[test]
+    fn parse_git_remote_github_https_dotgit_suffix() {
+        let source = parse_git_remote("https://github.com/githubnext/ado-aw.git").unwrap();
+        assert_eq!(source.provider, RepoProvider::Github);
+        assert_eq!(source.owner, "githubnext");
+        assert_eq!(source.repo, "ado-aw");
+    }
+
+    #[test]
+    fn parse_git_remote_github_ssh() {
+        let source = parse_git_remote("git@github.com:githubnext/ado-aw.git").unwrap();
+        assert_eq!(source.provider, RepoProvider::Github);
+        assert_eq!(source.owner, "githubnext");
+        assert_eq!(source.repo, "ado-aw");
+    }
+
+    #[test]
+    fn parse_git_remote_github_ssh_no_dotgit() {
+        let source = parse_git_remote("git@github.com:githubnext/ado-aw").unwrap();
+        assert_eq!(source.provider, RepoProvider::Github);
+        assert_eq!(source.owner, "githubnext");
+        assert_eq!(source.repo, "ado-aw");
+    }
+
+    #[test]
+    fn parse_git_remote_rejects_ghes() {
+        // GitHub Enterprise is out of scope for v1; the parser must
+        // not silently accept a non-github.com host as Github.
+        assert!(parse_git_remote("https://github.example.com/owner/repo").is_err());
+    }
+
+    #[test]
+    fn parse_git_remote_rejects_unrelated() {
+        assert!(parse_git_remote("https://gitlab.com/owner/repo").is_err());
+        assert!(parse_git_remote("not-a-url").is_err());
+        // Missing repo half.
+        assert!(parse_git_remote("https://github.com/owner").is_err());
+        assert!(parse_git_remote("git@github.com:owner").is_err());
+    }
+
+    #[test]
+    fn repo_source_url_ado_shape() {
+        let source = RepoSource {
+            provider: RepoProvider::AdoGit,
+            owner: "myorg".to_string(),
+            repo: "myrepo".to_string(),
+            project: Some("MyProject".to_string()),
+        };
+        assert_eq!(
+            source.url(),
+            "https://dev.azure.com/myorg/MyProject/_git/myrepo"
+        );
+    }
+
+    #[test]
+    fn repo_source_url_github_shape() {
+        let source = RepoSource {
+            provider: RepoProvider::Github,
+            owner: "githubnext".to_string(),
+            repo: "ado-aw".to_string(),
+            project: None,
+        };
+        assert_eq!(source.url(), "https://github.com/githubnext/ado-aw");
+    }
+
+    // ==================== Service-connection resolver ====================
+
+    #[test]
+    fn is_uuid_like_accepts_canonical() {
+        assert!(is_uuid_like("12345678-1234-1234-1234-1234567890ab"));
+        assert!(is_uuid_like("ABCDEF12-3456-7890-ABCD-EF1234567890"));
+    }
+
+    #[test]
+    fn is_uuid_like_rejects_non_uuid() {
+        assert!(!is_uuid_like("ado-aw-github"));
+        assert!(!is_uuid_like(""));
+        // Wrong length.
+        assert!(!is_uuid_like("12345678-1234-1234-1234-1234567890"));
+        // Missing hyphens.
+        assert!(!is_uuid_like("123456781234123412341234567890ab"));
+        // Hyphens in wrong positions.
+        assert!(!is_uuid_like("12345678-12341-1234-1234-1234567890a"));
+        // Non-hex character.
+        assert!(!is_uuid_like("12345678-1234-1234-1234-1234567890zz"));
+    }
+
+    #[test]
+    fn pick_service_endpoint_id_single_match() {
+        let body = serde_json::json!({
+            "count": 1,
+            "value": [
+                { "id": "abc-123", "name": "ado-aw-github" }
+            ]
+        });
+        let id = pick_service_endpoint_id(&body, "ado-aw-github", "AgentPlayground").unwrap();
+        assert_eq!(id, "abc-123");
+    }
+
+    #[test]
+    fn pick_service_endpoint_id_no_match_bails_with_useful_message() {
+        let body = serde_json::json!({ "count": 0, "value": [] });
+        let err = pick_service_endpoint_id(&body, "missing-conn", "AgentPlayground")
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("No GitHub service connection named 'missing-conn'"));
+        assert!(err.contains("'AgentPlayground'"));
+        assert!(err.contains("Project settings"));
+    }
+
+    #[test]
+    fn pick_service_endpoint_id_multi_match_bails_with_disambiguation_hint() {
+        let body = serde_json::json!({
+            "count": 2,
+            "value": [
+                { "id": "abc-1", "name": "shared-name" },
+                { "id": "abc-2", "name": "shared-name" }
+            ]
+        });
+        let err = pick_service_endpoint_id(&body, "shared-name", "AgentPlayground")
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("2 GitHub service connections named 'shared-name'"));
+        assert!(err.contains("GUID"));
+    }
+
+    #[test]
+    fn pick_service_endpoint_id_missing_value_array_bails() {
+        let body = serde_json::json!({ "count": 0 });
+        let err = pick_service_endpoint_id(&body, "any", "AgentPlayground")
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("missing `value` array"));
+    }
+
+    // ==================== match_definitions_in (provider-agnostic) ====================
+
+    /// `match_definitions_in` only consults `process.yamlFilename` and
+    /// `name` — both stable across provider. A GitHub-source
+    /// `DefinitionSummary` (one with `repository.type = "GitHub"` in
+    /// the ADO response) must match a locally-detected lock file
+    /// exactly as well as a TfsGit one does. This pins that contract
+    /// so a future refactor of `match_definitions_in` can't
+    /// accidentally start gating on provider.
+    #[test]
+    fn match_definitions_in_works_for_github_source_definition() {
+        use std::path::PathBuf;
+
+        let definitions = vec![DefinitionSummary {
+            id: 99,
+            name: "Daily smoke noop".to_string(),
+            process: Some(ProcessInfo {
+                yaml_filename: Some("/tests/safe-outputs/noop.lock.yml".to_string()),
+            }),
+            queue_status: Some("enabled".to_string()),
+            path: Some("\\smoke".to_string()),
+            repository: Some(Repository {
+                url: Some("https://github.com/githubnext/ado-aw".to_string()),
+                name: Some("githubnext/ado-aw".to_string()),
+                repo_type: Some("GitHub".to_string()),
+                id: None,
+            }),
+            revision: Some(1),
+        }];
+        let detected = vec![crate::detect::DetectedPipeline {
+            yaml_path: PathBuf::from("tests/safe-outputs/noop.lock.yml"),
+            source: "tests/safe-outputs/noop.md".to_string(),
+            version: "0.32.0".to_string(),
+        }];
+
+        let matched = match_definitions_in(&definitions, &detected);
+        assert_eq!(matched.len(), 1);
+        assert_eq!(matched[0].id, 99);
+        assert_eq!(matched[0].name, "Daily smoke noop");
     }
 
     // ==================== Org URL normalization ====================

--- a/src/compile/mod.rs
+++ b/src/compile/mod.rs
@@ -775,7 +775,19 @@ async fn read_existing_pipeline_version(path: &Path) -> Option<String> {
 }
 
 /// Walk up from `start` to find the nearest directory containing `.git`.
-fn find_repo_root(start: &Path) -> Option<PathBuf> {
+/// Walk up from `start` looking for the nearest ancestor containing a
+/// `.git` directory or file.
+///
+/// Returns the directory containing `.git` on success, `None` if the
+/// filesystem root is reached without finding one. The check accepts
+/// any `.git` entry (directory for regular checkouts, file for git
+/// worktrees / submodules) — both forms correctly anchor the repo
+/// root for our path-resolution callers.
+///
+/// Exposed for use by other CLI commands (e.g. `enable`) that take an
+/// optional `PATH` subdirectory and need to resolve repo-root-relative
+/// paths from the marker JSON.
+pub fn find_repo_root(start: &Path) -> Option<PathBuf> {
     let mut current = start.to_path_buf();
     loop {
         if current.join(".git").exists() {

--- a/src/enable.rs
+++ b/src/enable.rs
@@ -271,43 +271,8 @@ fn resolve_source(
     repository_name_override: Option<&str>,
     service_connection: Option<&str>,
 ) -> Result<ResolvedSource> {
-    match parsed_remote {
-        Ok(source) if source.provider == RepoProvider::AdoGit => {
-            if service_connection.is_some() {
-                anyhow::bail!(
-                    "--service-connection is only valid when the source repository is on GitHub. \
-                     The current git remote ({}) is an Azure DevOps Git repository.",
-                    remote_url.unwrap_or("?")
-                );
-            }
-            if repository_name_override.is_some() {
-                anyhow::bail!(
-                    "--repository-name is only valid when the source repository is on GitHub. \
-                     The current git remote ({}) is an Azure DevOps Git repository.",
-                    remote_url.unwrap_or("?")
-                );
-            }
-            Ok(ResolvedSource::AdoGit { source })
-        }
-        Ok(mut source) => {
-            // GitHub remote.
-            let sc = service_connection.ok_or_else(|| {
-                anyhow::anyhow!(
-                    "--service-connection <name-or-guid> is required when the source repository is on GitHub. \
-                     Create a GitHub service connection in the target ADO project (Project settings → \
-                     Service connections → GitHub) and pass its name or GUID."
-                )
-            })?;
-            if let Some(over) = repository_name_override {
-                let (owner, repo) = split_owner_repo_arg(over)?;
-                source.owner = owner;
-                source.repo = repo;
-            }
-            Ok(ResolvedSource::Github {
-                source,
-                service_connection: sc.to_string(),
-            })
-        }
+    let parsed = match parsed_remote {
+        Ok(source) => source,
         Err(_) => {
             // Remote is missing or unparseable; require explicit
             // flags to treat as GitHub source.
@@ -324,13 +289,56 @@ fn resolve_source(
                 )
             })?;
             let (owner, repo) = split_owner_repo_arg(name)?;
-            Ok(ResolvedSource::Github {
+            return Ok(ResolvedSource::Github {
                 source: RepoSource {
                     provider: RepoProvider::Github,
                     owner,
                     repo,
                     project: None,
                 },
+                service_connection: sc.to_string(),
+            });
+        }
+    };
+
+    // Match on `provider` directly (rather than guarded patterns with
+    // a catch-all `Ok(_)` arm) so adding a new `RepoProvider` variant
+    // is a compile-time exhaustiveness error instead of silently
+    // falling into the GitHub code path.
+    match parsed.provider {
+        RepoProvider::AdoGit => {
+            if service_connection.is_some() {
+                anyhow::bail!(
+                    "--service-connection is only valid when the source repository is on GitHub. \
+                     The current git remote ({}) is an Azure DevOps Git repository.",
+                    remote_url.unwrap_or("?")
+                );
+            }
+            if repository_name_override.is_some() {
+                anyhow::bail!(
+                    "--repository-name is only valid when the source repository is on GitHub. \
+                     The current git remote ({}) is an Azure DevOps Git repository.",
+                    remote_url.unwrap_or("?")
+                );
+            }
+            Ok(ResolvedSource::AdoGit { source: parsed })
+        }
+        RepoProvider::Github => {
+            let mut source = parsed;
+            let sc = service_connection.ok_or_else(|| {
+                anyhow::anyhow!(
+                    "--service-connection <name-or-guid> is required when the source repository is on GitHub. \
+                     Create a GitHub service connection in the target ADO project (Project settings → \
+                     Service connections → GitHub) and pass its name or GUID."
+                )
+            })?;
+            if let Some(over) = repository_name_override {
+                let (owner, repo) = split_owner_repo_arg(over)?;
+                source.owner = owner;
+                source.repo = repo;
+            }
+            Ok(ResolvedSource::Github {
+                source,
                 service_connection: sc.to_string(),
             })
         }

--- a/src/enable.rs
+++ b/src/enable.rs
@@ -234,6 +234,27 @@ enum ResolvedSource {
     Github { source: RepoSource, service_connection: String },
 }
 
+/// Resolved provider-specific identifiers required by the
+/// create-definition POST body. Always paired with the matching
+/// `ResolvedSource` variant — keeping them in a tagged enum (rather
+/// than a `(String, String)` tuple with empty-string sentinels on the
+/// unused half) means a future refactor can't silently swap the two
+/// or forget to wire one of them.
+#[derive(Debug)]
+enum ResolvedIdentifiers {
+    /// `repo_id` is the ADO repository GUID returned by
+    /// `get_repository_id`.
+    AdoGit { repo_id: String },
+    /// `service_connection_id` is the GUID resolved from the
+    /// operator's `--service-connection` value. `full_name` is the
+    /// cached `owner/repo` composition (built once per invocation
+    /// rather than per fixture).
+    Github {
+        full_name: String,
+        service_connection_id: String,
+    },
+}
+
 /// Apply the autodetect rule to a parsed git remote (or its absence)
 /// plus operator-supplied overrides.
 ///
@@ -318,6 +339,12 @@ fn resolve_source(
 
 /// Parse a CLI-supplied `owner/repo` argument with a useful error
 /// message when the shape is wrong.
+///
+/// Trims a trailing `.git` on the repo half so `--repository-name
+/// owner/repo.git` (operators sometimes copy-paste this from a clone
+/// URL) round-trips identically to `--repository-name owner/repo`.
+/// Mirrors `split_owner_repo` in `src/ado/mod.rs` which does the same
+/// for parsed remote URLs.
 fn split_owner_repo_arg(value: &str) -> Result<(String, String)> {
     let trimmed = value.trim();
     let parts: Vec<&str> = trimmed.splitn(2, '/').collect();
@@ -327,7 +354,15 @@ fn split_owner_repo_arg(value: &str) -> Result<(String, String)> {
             value
         );
     }
-    Ok((parts[0].trim().to_string(), parts[1].trim().to_string()))
+    let owner = parts[0].trim().to_string();
+    let repo = parts[1].trim().trim_end_matches(".git").to_string();
+    if repo.is_empty() {
+        anyhow::bail!(
+            "--repository-name must be in the form 'owner/repo' (got: '{}')",
+            value
+        );
+    }
+    Ok((owner, repo))
 }
 
 /// Run the `enable` command.
@@ -358,6 +393,26 @@ pub async fn run(opts: EnableOptions<'_>) -> Result<()> {
         opts.repository_name,
         opts.service_connection,
     )?;
+
+    // For GitHub-source, the git remote can't tell us the ADO
+    // deployment target (org/project). Pre-check upfront so we surface
+    // a clear, audience-appropriate error before falling through to
+    // `resolve_ado_context`'s generic "use --org/--project, e.g. for
+    // --definition-ids" message — which makes no sense in the `enable`
+    // context and is the first-time-user failure mode for the very
+    // operators this code path targets.
+    if matches!(resolved, ResolvedSource::Github { .. })
+        && (opts.org.is_none() || opts.project.is_none())
+    {
+        anyhow::bail!(
+            "--org <ado-org> and --project <ado-project> are required for GitHub-source pipelines. \
+             The git remote identifies the GitHub source repo, but the ADO project that hosts the \
+             registered build definitions must be supplied explicitly.\n\
+             Example:\n  \
+             ado-aw enable --org msazuresphere --project AgentPlayground \\\n    \
+             --service-connection <github-conn-name> tests/safe-outputs/"
+        );
+    }
 
     // Skip interactive token resolution on dry-run: --also-set-token is
     // silently suppressed in that path anyway, so prompting the operator
@@ -411,7 +466,12 @@ pub async fn run(opts: EnableOptions<'_>) -> Result<()> {
 
     let definitions = list_definitions(&client, &ado_ctx, &auth).await?;
 
-    // Resolve provider-specific identifiers once per invocation.
+    // Resolve provider-specific identifiers once per invocation, in
+    // a structurally-tagged form that keeps the "only one is
+    // meaningful per variant" invariant at the type level. Previously
+    // we returned a `(repo_id, service_conn_id)` tuple with empty-
+    // string sentinels on the unused half, which would silently
+    // tolerate a future swap.
     //
     // - ADO Git source: look up the repository GUID (required by the
     //   `repository.id` field in the POST body).
@@ -420,9 +480,9 @@ pub async fn run(opts: EnableOptions<'_>) -> Result<()> {
     //
     // Dry-run skips the network calls; the POST body printout uses
     // placeholders so operators still see the full body shape.
-    let (repo_id, service_conn_id) = match &resolved {
+    let identifiers = match &resolved {
         ResolvedSource::AdoGit { source } => {
-            let id = if opts.dry_run {
+            let repo_id = if opts.dry_run {
                 String::from("<repo-id>")
             } else {
                 get_repository_id(&client, &ado_ctx, &auth, &source.repo)
@@ -431,12 +491,13 @@ pub async fn run(opts: EnableOptions<'_>) -> Result<()> {
                         format!("Failed to look up ADO repository '{}'", source.repo)
                     })?
             };
-            (id, String::new())
+            ResolvedIdentifiers::AdoGit { repo_id }
         }
         ResolvedSource::Github {
-            service_connection, ..
+            source,
+            service_connection,
         } => {
-            let id = if opts.dry_run {
+            let service_connection_id = if opts.dry_run {
                 String::from("<service-connection-id>")
             } else {
                 resolve_service_connection_id(
@@ -453,7 +514,10 @@ pub async fn run(opts: EnableOptions<'_>) -> Result<()> {
                     )
                 })?
             };
-            (String::new(), id)
+            ResolvedIdentifiers::Github {
+                full_name: format!("{}/{}", source.owner, source.repo),
+                service_connection_id,
+            }
         }
     };
 
@@ -461,26 +525,34 @@ pub async fn run(opts: EnableOptions<'_>) -> Result<()> {
     let mut failure = 0usize;
     let mut newly_created_ids: Vec<u64> = Vec::new();
 
-    // Compose the GitHub `owner/repo` once if applicable — it's
-    // identical for every fixture in this invocation. We bind it
-    // unconditionally to a `String` so the inner loop never has to
-    // unwrap an `Option`; for `AdoGit` it stays empty and is unused.
-    let github_full_name = match &resolved {
-        ResolvedSource::Github { source, .. } => format!("{}/{}", source.owner, source.repo),
-        ResolvedSource::AdoGit { .. } => String::new(),
-    };
-
     for pipeline in &detected {
         let source_path = repo_path.join(&pipeline.source);
-        let repo_ref = match &resolved {
-            ResolvedSource::AdoGit { source } => RepositoryRef::AdoGit {
-                repo_id: &repo_id,
+        let repo_ref = match (&resolved, &identifiers) {
+            (
+                ResolvedSource::AdoGit { source },
+                ResolvedIdentifiers::AdoGit { repo_id },
+            ) => RepositoryRef::AdoGit {
+                repo_id,
                 repo_name: &source.repo,
             },
-            ResolvedSource::Github { .. } => RepositoryRef::Github {
-                full_name: &github_full_name,
-                connected_service_id: &service_conn_id,
+            (
+                ResolvedSource::Github { .. },
+                ResolvedIdentifiers::Github {
+                    full_name,
+                    service_connection_id,
+                },
+            ) => RepositoryRef::Github {
+                full_name,
+                connected_service_id: service_connection_id,
             },
+            // Both halves are built from the same `resolved` value
+            // immediately above, so the cross-variant pairings are
+            // unreachable. We bail rather than `unreachable!()` so a
+            // future refactor that decouples the two can't silently
+            // produce a malformed POST body.
+            _ => anyhow::bail!(
+                "internal error: resolved source and identifier variants disagree"
+            ),
         };
         let result = process_one(
             &client,
@@ -710,6 +782,26 @@ mod tests {
         assert!(split_owner_repo_arg("/repo").is_err());
         assert!(split_owner_repo_arg("owner/").is_err());
         assert!(split_owner_repo_arg("/").is_err());
+    }
+
+    #[test]
+    fn split_owner_repo_arg_strips_dotgit_suffix() {
+        // Mirrors split_owner_repo (in src/ado/mod.rs) which strips
+        // `.git` when parsing remote URLs — operators sometimes paste
+        // the `owner/repo.git` form from a clone URL and expect it to
+        // work identically.
+        assert_eq!(
+            split_owner_repo_arg("githubnext/ado-aw.git").unwrap(),
+            ("githubnext".to_string(), "ado-aw".to_string())
+        );
+    }
+
+    #[test]
+    fn split_owner_repo_arg_rejects_repo_that_becomes_empty_after_strip() {
+        // Pathological: `owner/.git` strips to `owner/` which is
+        // invalid. Must bail rather than silently treat `repo == ""`
+        // as success.
+        assert!(split_owner_repo_arg("owner/.git").is_err());
     }
 
     // ============ resolve_source ============

--- a/src/enable.rs
+++ b/src/enable.rs
@@ -18,9 +18,10 @@ use log::debug;
 use std::path::{Path, PathBuf};
 
 use crate::ado::{
-    AdoAuth, AdoContext, DefinitionSummary, create_definition, get_git_remote_url,
-    get_repository_id, list_definitions, normalize_ado_yaml_path, parse_ado_remote,
-    patch_queue_status, resolve_ado_context, resolve_auth, update_pipeline_variable,
+    AdoAuth, AdoContext, DefinitionSummary, RepoProvider, RepoSource, create_definition,
+    get_git_remote_url, get_repository_id, list_definitions, normalize_ado_yaml_path,
+    parse_git_remote, patch_queue_status, resolve_ado_context, resolve_auth,
+    resolve_service_connection_id, update_pipeline_variable,
 };
 use crate::compile;
 use crate::detect;
@@ -132,28 +133,65 @@ pub fn decide_action(
     }
 }
 
+/// How `build_create_body` should describe the backing repository on
+/// the create-definition POST body. The two variants emit different
+/// shapes for the `repository:` object.
+#[derive(Debug, Clone, Copy)]
+pub enum RepositoryRef<'a> {
+    /// Azure DevOps Git source. `repo_id` is the repository GUID
+    /// returned by `get_repository_id`; `repo_name` is the bare repo
+    /// name (e.g. `myrepo`).
+    AdoGit {
+        repo_id: &'a str,
+        repo_name: &'a str,
+    },
+    /// GitHub source. `full_name` is `owner/repo` (the form ADO
+    /// expects in `repository.name`); `connected_service_id` is the
+    /// GUID of a project-level GitHub service connection.
+    Github {
+        full_name: &'a str,
+        connected_service_id: &'a str,
+    },
+}
+
 /// Build the JSON body for `POST /_apis/build/definitions`. Pure
 /// function so we can snapshot-test the wire shape.
 pub fn build_create_body(
     name: &str,
     folder: &str,
-    repo_id: &str,
-    repo_name: &str,
+    repo: RepositoryRef<'_>,
     default_branch: &str,
     yaml_filename: &str,
 ) -> serde_json::Value {
-    serde_json::json!({
-        "name": name,
-        "path": folder,
-        "type": "build",
-        "queueStatus": "enabled",
-        "repository": {
+    let repository = match repo {
+        RepositoryRef::AdoGit { repo_id, repo_name } => serde_json::json!({
             "id": repo_id,
             "type": "TfsGit",
             "name": repo_name,
             "defaultBranch": default_branch,
             "properties": { "reportBuildStatus": "true" }
-        },
+        }),
+        RepositoryRef::Github {
+            full_name,
+            connected_service_id,
+        } => serde_json::json!({
+            "type": "GitHub",
+            "name": full_name,
+            "url": format!("https://github.com/{}.git", full_name),
+            "defaultBranch": default_branch,
+            "properties": {
+                "connectedServiceId": connected_service_id,
+                "reportBuildStatus": "true"
+            }
+        }),
+    };
+
+    serde_json::json!({
+        "name": name,
+        "path": folder,
+        "type": "build",
+        "queueStatus": "enabled",
+        "repository": repository,
         "process": {
             "type": 2,
             "yamlFilename": yaml_filename
@@ -174,6 +212,122 @@ pub struct EnableOptions<'a> {
     pub dry_run: bool,
     pub also_set_token: bool,
     pub token: Option<&'a str>,
+    /// GitHub service-connection name or GUID. Required when source
+    /// is GitHub; clap-level error when source is ADO Git.
+    pub service_connection: Option<&'a str>,
+    /// Source repository override as `owner/repo`. Only honoured for
+    /// GitHub source (mostly an escape hatch when the local git
+    /// remote can't be parsed and the operator wants to register a
+    /// pipeline backed by a specific GitHub repo).
+    pub repository_name: Option<&'a str>,
+}
+
+/// Resolved source identity for an `enable` invocation.
+///
+/// Captures the autodetect outcome from the git remote plus operator
+/// overrides. Drives the create-definition body shape and any
+/// provider-specific REST lookups (repo GUID for ADO; service
+/// connection GUID for GitHub).
+#[derive(Debug)]
+enum ResolvedSource {
+    AdoGit { source: RepoSource },
+    Github { source: RepoSource, service_connection: String },
+}
+
+/// Apply the autodetect rule to a parsed git remote (or its absence)
+/// plus operator-supplied overrides.
+///
+/// Rules (mirrors `docs/cli.md`):
+/// - ADO remote: ignore `--repository-name`; reject
+///   `--service-connection` with a clear message.
+/// - GitHub remote: require `--service-connection`; allow
+///   `--repository-name` to override the auto-detected owner/repo.
+/// - Neither: require both `--repository-name owner/repo` and
+///   `--service-connection`; treat as GitHub source.
+fn resolve_source(
+    parsed_remote: Result<RepoSource>,
+    remote_url: Option<&str>,
+    repository_name_override: Option<&str>,
+    service_connection: Option<&str>,
+) -> Result<ResolvedSource> {
+    match parsed_remote {
+        Ok(source) if source.provider == RepoProvider::AdoGit => {
+            if service_connection.is_some() {
+                anyhow::bail!(
+                    "--service-connection is only valid when the source repository is on GitHub. \
+                     The current git remote ({}) is an Azure DevOps Git repository.",
+                    remote_url.unwrap_or("?")
+                );
+            }
+            if repository_name_override.is_some() {
+                anyhow::bail!(
+                    "--repository-name is only valid when the source repository is on GitHub. \
+                     The current git remote ({}) is an Azure DevOps Git repository.",
+                    remote_url.unwrap_or("?")
+                );
+            }
+            Ok(ResolvedSource::AdoGit { source })
+        }
+        Ok(mut source) => {
+            // GitHub remote.
+            let sc = service_connection.ok_or_else(|| {
+                anyhow::anyhow!(
+                    "--service-connection <name-or-guid> is required when the source repository is on GitHub. \
+                     Create a GitHub service connection in the target ADO project (Project settings → \
+                     Service connections → GitHub) and pass its name or GUID."
+                )
+            })?;
+            if let Some(over) = repository_name_override {
+                let (owner, repo) = split_owner_repo_arg(over)?;
+                source.owner = owner;
+                source.repo = repo;
+            }
+            Ok(ResolvedSource::Github {
+                source,
+                service_connection: sc.to_string(),
+            })
+        }
+        Err(_) => {
+            // Remote is missing or unparseable; require explicit
+            // flags to treat as GitHub source.
+            let sc = service_connection.ok_or_else(|| {
+                anyhow::anyhow!(
+                    "Could not infer source repository from the git remote. \
+                     For a GitHub-source pipeline, pass --repository-name owner/repo and --service-connection."
+                )
+            })?;
+            let name = repository_name_override.ok_or_else(|| {
+                anyhow::anyhow!(
+                    "Could not infer source repository from the git remote. \
+                     Pass --repository-name owner/repo to identify the GitHub source repo."
+                )
+            })?;
+            let (owner, repo) = split_owner_repo_arg(name)?;
+            Ok(ResolvedSource::Github {
+                source: RepoSource {
+                    provider: RepoProvider::Github,
+                    owner,
+                    repo,
+                    project: None,
+                },
+                service_connection: sc.to_string(),
+            })
+        }
+    }
+}
+
+/// Parse a CLI-supplied `owner/repo` argument with a useful error
+/// message when the shape is wrong.
+fn split_owner_repo_arg(value: &str) -> Result<(String, String)> {
+    let trimmed = value.trim();
+    let parts: Vec<&str> = trimmed.splitn(2, '/').collect();
+    if parts.len() != 2 || parts[0].is_empty() || parts[1].is_empty() {
+        anyhow::bail!(
+            "--repository-name must be in the form 'owner/repo' (got: '{}')",
+            value
+        );
+    }
+    Ok((parts[0].trim().to_string(), parts[1].trim().to_string()))
 }
 
 /// Run the `enable` command.
@@ -187,28 +341,23 @@ pub async fn run(opts: EnableOptions<'_>) -> Result<()> {
             .context("Could not resolve current directory")?,
     };
 
-    // GitHub-source guard: Phase 1 only supports ADO Git source
-    // repositories. We use parse_ado_remote success on the raw git
-    // remote URL as the gate — if we can't parse it as ADO we don't
-    // have a `repository.name` to put in the POST body.
-    let remote_url = get_git_remote_url(&repo_path).await.with_context(|| {
-        format!(
-            "Could not read the git remote 'origin' from {}. \
-             `ado-aw enable` requires an Azure DevOps Git remote.",
+    // Autodetect source identity from the git remote. The remote is
+    // best-effort — `resolve_source` decides whether the absence is
+    // fatal based on which CLI overrides the operator passed.
+    let remote_url = get_git_remote_url(&repo_path).await.ok();
+    let parsed = match remote_url.as_deref() {
+        Some(url) => parse_git_remote(url),
+        None => Err(anyhow::anyhow!(
+            "no git remote 'origin' configured in {}",
             repo_path.display()
-        )
-    })?;
-    let remote_ctx = match parse_ado_remote(&remote_url) {
-        Ok(ctx) => ctx,
-        Err(_) => anyhow::bail!(
-            "This command requires an Azure DevOps Git remote.\n\
-             The current remote is {}.\n\
-             Phase 1 of `ado-aw enable` does not yet support GitHub-hosted source \
-             repos. Follow https://github.com/githubnext/ado-aw/issues for the \
-             GitHub-source follow-up.",
-            remote_url
-        ),
+        )),
     };
+    let resolved = resolve_source(
+        parsed,
+        remote_url.as_deref(),
+        opts.repository_name,
+        opts.service_connection,
+    )?;
 
     // Skip interactive token resolution on dry-run: --also-set-token is
     // silently suppressed in that path anyway, so prompting the operator
@@ -221,10 +370,27 @@ pub async fn run(opts: EnableOptions<'_>) -> Result<()> {
     let auth = resolve_auth(opts.pat).await?;
     let ado_ctx = resolve_ado_context(&repo_path, opts.org, opts.project).await?;
 
-    println!(
-        "ADO context: org={}, project={}, repo={}",
-        ado_ctx.org_url, ado_ctx.project, remote_ctx.repo_name
-    );
+    match &resolved {
+        ResolvedSource::AdoGit { source } => {
+            println!(
+                "ADO context: org={}, project={}, repo={} (ADO Git source)",
+                ado_ctx.org_url, ado_ctx.project, source.repo
+            );
+        }
+        ResolvedSource::Github {
+            source,
+            service_connection,
+        } => {
+            println!(
+                "ADO context: org={}, project={}",
+                ado_ctx.org_url, ado_ctx.project
+            );
+            println!(
+                "GitHub source: {}/{} (service connection: {})",
+                source.owner, source.repo, service_connection
+            );
+        }
+    }
     println!();
 
     println!("Scanning for agentic pipelines...");
@@ -245,28 +411,75 @@ pub async fn run(opts: EnableOptions<'_>) -> Result<()> {
 
     let definitions = list_definitions(&client, &ado_ctx, &auth).await?;
 
-    // Resolve the repository GUID once. Dry-run skips this — the
-    // POST body printout uses a placeholder GUID so operators still
-    // see the full body shape.
-    let repo_id = if opts.dry_run {
-        String::from("<repo-id>")
-    } else {
-        get_repository_id(&client, &ado_ctx, &auth, &remote_ctx.repo_name)
-            .await
-            .with_context(|| {
-                format!(
-                    "Failed to look up ADO repository '{}'",
-                    remote_ctx.repo_name
+    // Resolve provider-specific identifiers once per invocation.
+    //
+    // - ADO Git source: look up the repository GUID (required by the
+    //   `repository.id` field in the POST body).
+    // - GitHub source: resolve the service-connection name → GUID
+    //   (required by `repository.properties.connectedServiceId`).
+    //
+    // Dry-run skips the network calls; the POST body printout uses
+    // placeholders so operators still see the full body shape.
+    let (repo_id, service_conn_id) = match &resolved {
+        ResolvedSource::AdoGit { source } => {
+            let id = if opts.dry_run {
+                String::from("<repo-id>")
+            } else {
+                get_repository_id(&client, &ado_ctx, &auth, &source.repo)
+                    .await
+                    .with_context(|| {
+                        format!("Failed to look up ADO repository '{}'", source.repo)
+                    })?
+            };
+            (id, String::new())
+        }
+        ResolvedSource::Github {
+            service_connection, ..
+        } => {
+            let id = if opts.dry_run {
+                String::from("<service-connection-id>")
+            } else {
+                resolve_service_connection_id(
+                    &client,
+                    &ado_ctx,
+                    &auth,
+                    service_connection,
                 )
-            })?
+                .await
+                .with_context(|| {
+                    format!(
+                        "Failed to resolve GitHub service connection '{}' in project '{}'",
+                        service_connection, ado_ctx.project
+                    )
+                })?
+            };
+            (String::new(), id)
+        }
     };
 
     let mut success = 0usize;
     let mut failure = 0usize;
     let mut newly_created_ids: Vec<u64> = Vec::new();
 
+    // Compose the GitHub `owner/repo` once if applicable — it's
+    // identical for every fixture in this invocation.
+    let github_full_name = match &resolved {
+        ResolvedSource::Github { source, .. } => Some(format!("{}/{}", source.owner, source.repo)),
+        _ => None,
+    };
+
     for pipeline in &detected {
         let source_path = repo_path.join(&pipeline.source);
+        let repo_ref = match &resolved {
+            ResolvedSource::AdoGit { source } => RepositoryRef::AdoGit {
+                repo_id: &repo_id,
+                repo_name: &source.repo,
+            },
+            ResolvedSource::Github { .. } => RepositoryRef::Github {
+                full_name: github_full_name.as_deref().unwrap_or(""),
+                connected_service_id: &service_conn_id,
+            },
+        };
         let result = process_one(
             &client,
             &ado_ctx,
@@ -274,8 +487,7 @@ pub async fn run(opts: EnableOptions<'_>) -> Result<()> {
             &definitions,
             &pipeline.yaml_path,
             &source_path,
-            &repo_id,
-            &remote_ctx.repo_name,
+            repo_ref,
             opts.folder,
             opts.default_branch,
             opts.dry_run,
@@ -362,8 +574,7 @@ async fn process_one(
     definitions: &[DefinitionSummary],
     yaml_path: &Path,
     source_path: &Path,
-    repo_id: &str,
-    repo_name: &str,
+    repo: RepositoryRef<'_>,
     folder: &str,
     default_branch: &str,
     dry_run: bool,
@@ -413,8 +624,7 @@ async fn process_one(
             let body = build_create_body(
                 &sanitized,
                 folder,
-                repo_id,
-                repo_name,
+                repo,
                 default_branch,
                 &yaml_filename,
             );
@@ -455,6 +665,173 @@ mod tests {
             path: None,
             repository: None,
             revision: None,
+        }
+    }
+
+    fn ado_source() -> RepoSource {
+        RepoSource {
+            provider: RepoProvider::AdoGit,
+            owner: "myorg".to_string(),
+            repo: "myrepo".to_string(),
+            project: Some("MyProject".to_string()),
+        }
+    }
+
+    fn github_source() -> RepoSource {
+        RepoSource {
+            provider: RepoProvider::Github,
+            owner: "githubnext".to_string(),
+            repo: "ado-aw".to_string(),
+            project: None,
+        }
+    }
+
+    // ============ split_owner_repo_arg ============
+
+    #[test]
+    fn split_owner_repo_arg_accepts_owner_slash_repo() {
+        assert_eq!(
+            split_owner_repo_arg("githubnext/ado-aw").unwrap(),
+            ("githubnext".to_string(), "ado-aw".to_string())
+        );
+    }
+
+    #[test]
+    fn split_owner_repo_arg_rejects_missing_slash() {
+        let err = split_owner_repo_arg("just-a-name").unwrap_err().to_string();
+        assert!(err.contains("--repository-name"));
+        assert!(err.contains("owner/repo"));
+    }
+
+    #[test]
+    fn split_owner_repo_arg_rejects_empty_halves() {
+        assert!(split_owner_repo_arg("/repo").is_err());
+        assert!(split_owner_repo_arg("owner/").is_err());
+        assert!(split_owner_repo_arg("/").is_err());
+    }
+
+    // ============ resolve_source ============
+
+    #[test]
+    fn resolve_source_ado_remote_no_overrides() {
+        let resolved = resolve_source(Ok(ado_source()), Some("https://..."), None, None).unwrap();
+        assert!(matches!(resolved, ResolvedSource::AdoGit { .. }));
+    }
+
+    #[test]
+    fn resolve_source_ado_remote_rejects_service_connection() {
+        let err = resolve_source(
+            Ok(ado_source()),
+            Some("https://dev.azure.com/myorg/MyProject/_git/myrepo"),
+            None,
+            Some("ado-aw-github"),
+        )
+        .unwrap_err()
+        .to_string();
+        assert!(err.contains("--service-connection is only valid"));
+        assert!(err.contains("GitHub"));
+    }
+
+    #[test]
+    fn resolve_source_ado_remote_rejects_repository_name() {
+        let err = resolve_source(
+            Ok(ado_source()),
+            Some("https://dev.azure.com/myorg/MyProject/_git/myrepo"),
+            Some("owner/repo"),
+            None,
+        )
+        .unwrap_err()
+        .to_string();
+        assert!(err.contains("--repository-name is only valid"));
+    }
+
+    #[test]
+    fn resolve_source_github_remote_requires_service_connection() {
+        let err = resolve_source(Ok(github_source()), Some("https://..."), None, None)
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("--service-connection"));
+        assert!(err.contains("required"));
+    }
+
+    #[test]
+    fn resolve_source_github_remote_with_service_connection() {
+        let resolved = resolve_source(
+            Ok(github_source()),
+            Some("https://..."),
+            None,
+            Some("ado-aw-github"),
+        )
+        .unwrap();
+        match resolved {
+            ResolvedSource::Github {
+                source,
+                service_connection,
+            } => {
+                assert_eq!(source.owner, "githubnext");
+                assert_eq!(source.repo, "ado-aw");
+                assert_eq!(service_connection, "ado-aw-github");
+            }
+            _ => panic!("expected Github"),
+        }
+    }
+
+    #[test]
+    fn resolve_source_github_remote_repository_name_override() {
+        let resolved = resolve_source(
+            Ok(github_source()),
+            Some("https://..."),
+            Some("other-org/other-repo"),
+            Some("conn"),
+        )
+        .unwrap();
+        match resolved {
+            ResolvedSource::Github { source, .. } => {
+                assert_eq!(source.owner, "other-org");
+                assert_eq!(source.repo, "other-repo");
+            }
+            _ => panic!("expected Github"),
+        }
+    }
+
+    #[test]
+    fn resolve_source_no_remote_requires_both_overrides() {
+        let parsed_err = || Err(anyhow::anyhow!("no remote"));
+        let err = resolve_source(parsed_err(), None, None, None)
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("--service-connection"));
+
+        let err = resolve_source(parsed_err(), None, None, Some("conn"))
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("--repository-name"));
+
+        let err = resolve_source(parsed_err(), None, Some("owner/repo"), None)
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("--service-connection"));
+    }
+
+    #[test]
+    fn resolve_source_no_remote_with_both_overrides_treats_as_github() {
+        let resolved = resolve_source(
+            Err(anyhow::anyhow!("no remote")),
+            None,
+            Some("githubnext/ado-aw"),
+            Some("conn-guid"),
+        )
+        .unwrap();
+        match resolved {
+            ResolvedSource::Github {
+                source,
+                service_connection,
+            } => {
+                assert_eq!(source.owner, "githubnext");
+                assert_eq!(source.repo, "ado-aw");
+                assert_eq!(service_connection, "conn-guid");
+            }
+            _ => panic!("expected Github"),
         }
     }
 
@@ -681,12 +1058,14 @@ mod tests {
     // ============ build_create_body ============
 
     #[test]
-    fn build_create_body_matches_expected_shape() {
+    fn build_create_body_ado_git_shape() {
         let body = build_create_body(
             "Daily smoke",
             "\\smoke",
-            "abc-123",
-            "myrepo",
+            RepositoryRef::AdoGit {
+                repo_id: "abc-123",
+                repo_name: "myrepo",
+            },
             "refs/heads/main",
             "/tests/noop.lock.yml",
         );
@@ -709,6 +1088,66 @@ mod tests {
             "triggers": []
         });
         assert_eq!(body, expected);
+    }
+
+    #[test]
+    fn build_create_body_github_shape() {
+        let body = build_create_body(
+            "Daily smoke noop",
+            "\\smoke",
+            RepositoryRef::Github {
+                full_name: "githubnext/ado-aw",
+                connected_service_id: "11111111-2222-3333-4444-555555555555",
+            },
+            "refs/heads/main",
+            "/tests/safe-outputs/noop.lock.yml",
+        );
+        let expected = serde_json::json!({
+            "name": "Daily smoke noop",
+            "path": "\\smoke",
+            "type": "build",
+            "queueStatus": "enabled",
+            "repository": {
+                "type": "GitHub",
+                "name": "githubnext/ado-aw",
+                "url": "https://github.com/githubnext/ado-aw.git",
+                "defaultBranch": "refs/heads/main",
+                "properties": {
+                    "connectedServiceId": "11111111-2222-3333-4444-555555555555",
+                    "reportBuildStatus": "true"
+                }
+            },
+            "process": {
+                "type": 2,
+                "yamlFilename": "/tests/safe-outputs/noop.lock.yml"
+            },
+            "triggers": []
+        });
+        assert_eq!(body, expected);
+    }
+
+    #[test]
+    fn build_create_body_github_omits_repo_id() {
+        // GitHub-source bodies must not carry a `repository.id` field
+        // — ADO uses `repository.name = owner/repo` to identify the
+        // GitHub repo, and the connectedServiceId tells it how to
+        // authenticate.
+        let body = build_create_body(
+            "n",
+            "\\",
+            RepositoryRef::Github {
+                full_name: "owner/repo",
+                connected_service_id: "guid",
+            },
+            "refs/heads/main",
+            "/x.yml",
+        );
+        assert!(
+            body.get("repository")
+                .and_then(|r| r.get("id"))
+                .is_none(),
+            "GitHub-source body must not include repository.id"
+        );
     }
 
     // ============ resolve_token_arg ============

--- a/src/enable.rs
+++ b/src/enable.rs
@@ -462,10 +462,12 @@ pub async fn run(opts: EnableOptions<'_>) -> Result<()> {
     let mut newly_created_ids: Vec<u64> = Vec::new();
 
     // Compose the GitHub `owner/repo` once if applicable — it's
-    // identical for every fixture in this invocation.
+    // identical for every fixture in this invocation. We bind it
+    // unconditionally to a `String` so the inner loop never has to
+    // unwrap an `Option`; for `AdoGit` it stays empty and is unused.
     let github_full_name = match &resolved {
-        ResolvedSource::Github { source, .. } => Some(format!("{}/{}", source.owner, source.repo)),
-        _ => None,
+        ResolvedSource::Github { source, .. } => format!("{}/{}", source.owner, source.repo),
+        ResolvedSource::AdoGit { .. } => String::new(),
     };
 
     for pipeline in &detected {
@@ -476,7 +478,7 @@ pub async fn run(opts: EnableOptions<'_>) -> Result<()> {
                 repo_name: &source.repo,
             },
             ResolvedSource::Github { .. } => RepositoryRef::Github {
-                full_name: github_full_name.as_deref().unwrap_or(""),
+                full_name: &github_full_name,
                 connected_service_id: &service_conn_id,
             },
         };

--- a/src/enable.rs
+++ b/src/enable.rs
@@ -386,7 +386,13 @@ fn split_owner_repo_arg(value: &str) -> Result<(String, String)> {
 
 /// Run the `enable` command.
 pub async fn run(opts: EnableOptions<'_>) -> Result<()> {
-    let repo_path: PathBuf = match opts.path {
+    // `scan_root` is where we look for compiled pipelines (defaults
+    // to cwd; can be a subdirectory like `tests/safe-outputs` when
+    // the operator passes a `PATH` arg). `repo_root` is the
+    // containing git checkout's root, used to anchor the
+    // repo-root-relative `source` paths stored in pipeline markers
+    // and the `yaml_filename` we POST to ADO.
+    let scan_root: PathBuf = match opts.path {
         Some(p) => tokio::fs::canonicalize(p)
             .await
             .with_context(|| format!("Could not resolve path: {}", p.display()))?,
@@ -394,16 +400,24 @@ pub async fn run(opts: EnableOptions<'_>) -> Result<()> {
             .await
             .context("Could not resolve current directory")?,
     };
+    let repo_root = crate::compile::find_repo_root(&scan_root).ok_or_else(|| {
+        anyhow::anyhow!(
+            "Could not find a git repository containing '{}'. \
+             `ado-aw enable` must be run inside a git checkout — the YAML \
+             paths registered against ADO are anchored to the repo root.",
+            scan_root.display()
+        )
+    })?;
 
     // Autodetect source identity from the git remote. The remote is
     // best-effort — `resolve_source` decides whether the absence is
     // fatal based on which CLI overrides the operator passed.
-    let remote_url = get_git_remote_url(&repo_path).await.ok();
+    let remote_url = get_git_remote_url(&repo_root).await.ok();
     let parsed = match remote_url.as_deref() {
         Some(url) => parse_git_remote(url),
         None => Err(anyhow::anyhow!(
             "no git remote 'origin' configured in {}",
-            repo_path.display()
+            repo_root.display()
         )),
     };
     let resolved = resolve_source(
@@ -442,7 +456,7 @@ pub async fn run(opts: EnableOptions<'_>) -> Result<()> {
         resolve_token_arg(opts.also_set_token, opts.token)?
     };
     let auth = resolve_auth(opts.pat).await?;
-    let ado_ctx = resolve_ado_context(&repo_path, opts.org, opts.project).await?;
+    let ado_ctx = resolve_ado_context(&repo_root, opts.org, opts.project).await?;
 
     match &resolved {
         ResolvedSource::AdoGit { source } => {
@@ -468,7 +482,7 @@ pub async fn run(opts: EnableOptions<'_>) -> Result<()> {
     println!();
 
     println!("Scanning for agentic pipelines...");
-    let detected = detect::detect_pipelines(&repo_path).await?;
+    let detected = detect::detect_pipelines(&scan_root).await?;
     if detected.is_empty() {
         println!(
             "No agentic pipelines found. Make sure your pipelines were compiled with the latest ado-aw."
@@ -545,7 +559,20 @@ pub async fn run(opts: EnableOptions<'_>) -> Result<()> {
     let mut newly_created_ids: Vec<u64> = Vec::new();
 
     for pipeline in &detected {
-        let source_path = repo_path.join(&pipeline.source);
+        // `pipeline.source` is the path from the agent-file marker
+        // (repo-root-relative, e.g. `tests/safe-outputs/noop.md`).
+        // `pipeline.yaml_path` is the compiled `.lock.yml` path
+        // *relative to the scan root*, so we have to re-anchor it on
+        // `repo_root` before computing the `yamlFilename` we POST to
+        // ADO — otherwise running `enable tests/safe-outputs` would
+        // register every fixture at `/noop.lock.yml` (repo root)
+        // instead of the actual `/tests/safe-outputs/noop.lock.yml`.
+        let source_path = repo_root.join(&pipeline.source);
+        let abs_yaml = scan_root.join(&pipeline.yaml_path);
+        let repo_relative_yaml = abs_yaml
+            .strip_prefix(&repo_root)
+            .map(Path::to_path_buf)
+            .unwrap_or_else(|_| pipeline.yaml_path.clone());
         let repo_ref = match (&resolved, &identifiers) {
             (
                 ResolvedSource::AdoGit { source },
@@ -578,7 +605,7 @@ pub async fn run(opts: EnableOptions<'_>) -> Result<()> {
             &ado_ctx,
             &auth,
             &definitions,
-            &pipeline.yaml_path,
+            &repo_relative_yaml,
             &source_path,
             repo_ref,
             opts.folder,

--- a/src/enable.rs
+++ b/src/enable.rs
@@ -353,10 +353,21 @@ fn resolve_source(
 /// URL) round-trips identically to `--repository-name owner/repo`.
 /// Mirrors `split_owner_repo` in `src/ado/mod.rs` which does the same
 /// for parsed remote URLs.
+///
+/// Rejects inputs with more than one `/` (`owner/repo/extra`) — a CLI
+/// arg is held to a stricter contract than a parsed URL, where
+/// trailing path noise is more forgivable. Without this check, the
+/// extra segment slides into the `repository.name` POST field and
+/// ADO returns an opaque API error rather than the operator seeing
+/// the targeted "must be in the form 'owner/repo'" message here.
 fn split_owner_repo_arg(value: &str) -> Result<(String, String)> {
     let trimmed = value.trim();
-    let parts: Vec<&str> = trimmed.splitn(2, '/').collect();
+    let parts: Vec<&str> = trimmed.splitn(3, '/').collect();
     if parts.len() != 2 || parts[0].is_empty() || parts[1].is_empty() {
+        // Catches both "no slash at all" (parts.len() == 1) and
+        // "more than one slash" (parts.len() == 3, the third part is
+        // the tail after the second `/`). Empty halves are rejected
+        // here too: `/repo` → ["", "repo"], `owner/` → ["owner", ""].
         anyhow::bail!(
             "--repository-name must be in the form 'owner/repo' (got: '{}')",
             value
@@ -810,6 +821,21 @@ mod tests {
         // invalid. Must bail rather than silently treat `repo == ""`
         // as success.
         assert!(split_owner_repo_arg("owner/.git").is_err());
+    }
+
+    #[test]
+    fn split_owner_repo_arg_rejects_extra_path_segments() {
+        // splitn(3, '/') guards against `owner/repo/extra` silently
+        // flowing into `repository.name = "owner/repo/extra"` and
+        // surfacing as an opaque ADO API error later.
+        let err = split_owner_repo_arg("owner/repo/extra")
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("owner/repo"));
+        assert!(err.contains("owner/repo/extra"));
+
+        // Even further nesting.
+        assert!(split_owner_repo_arg("a/b/c/d").is_err());
     }
 
     // ============ resolve_source ============

--- a/src/main.rs
+++ b/src/main.rs
@@ -289,6 +289,17 @@ enum Commands {
         /// Falls back to the GITHUB_TOKEN env var, then to an interactive prompt.
         #[arg(long, requires = "also_set_token")]
         token: Option<String>,
+        /// GitHub service-connection name or GUID. Required when the
+        /// source repository is on GitHub; rejected with a clear error
+        /// when the source is Azure DevOps Git.
+        #[arg(long = "service-connection")]
+        service_connection: Option<String>,
+        /// Source repository override as `owner/repo`. Only honoured
+        /// for GitHub source; auto-detected from the git remote when
+        /// omitted. Useful when the local checkout's remote points at
+        /// a different fork than the deployment should reference.
+        #[arg(long = "repository-name")]
+        repository_name: Option<String>,
     },
     /// Disable (or pause) every ADO build definition that matches a local fixture.
     Disable {
@@ -1048,6 +1059,8 @@ async fn main() -> Result<()> {
             dry_run,
             also_set_token,
             token,
+            service_connection,
+            repository_name,
         } => {
             enable::run(enable::EnableOptions {
                 org: org.as_deref(),
@@ -1059,6 +1072,8 @@ async fn main() -> Result<()> {
                 dry_run,
                 also_set_token,
                 token: token.as_deref(),
+                service_connection: service_connection.as_deref(),
+                repository_name: repository_name.as_deref(),
             })
             .await?;
         }

--- a/tests/enable_integration.rs
+++ b/tests/enable_integration.rs
@@ -40,6 +40,8 @@ fn enable_help_describes_command() {
         "--dry-run",
         "--also-set-token",
         "--token",
+        "--service-connection",
+        "--repository-name",
     ] {
         assert!(
             stdout.contains(flag),
@@ -63,5 +65,20 @@ fn enable_rejects_token_without_also_set_token() {
     assert!(
         stderr.contains("--also-set-token") || stderr.contains("also_set_token"),
         "stderr should reference the requires-constraint, got:\n{stderr}"
+    );
+}
+
+#[test]
+fn enable_help_describes_github_source_support() {
+    // The new --service-connection flag should have a help string
+    // that mentions GitHub so operators discover the feature.
+    let output = std::process::Command::new(binary())
+        .args(["enable", "--help"])
+        .output()
+        .expect("Failed to run ado-aw enable --help");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("GitHub"),
+        "Help text should mention GitHub in the --service-connection / --repository-name docs, got:\n{stdout}"
     );
 }

--- a/tests/enable_integration.rs
+++ b/tests/enable_integration.rs
@@ -83,8 +83,8 @@ fn enable_help_describes_github_source_support() {
     );
 }
 
-#[test]
-fn enable_dry_run_against_subdirectory_uses_repo_root_relative_yaml_path() {
+#[tokio::test(flavor = "current_thread")]
+async fn enable_dry_run_against_subdirectory_uses_repo_root_relative_yaml_path() {
     // Regression: previously `enable PATH` joined `pipeline.source`
     // against the scan root rather than the repo root, producing
     // doubled paths like
@@ -93,11 +93,24 @@ fn enable_dry_run_against_subdirectory_uses_repo_root_relative_yaml_path() {
     // `/noop.lock.yml` (relative to scan root) instead of the
     // real repo-relative `/tests/safe-outputs/noop.lock.yml`.
     //
-    // This test exercises the subdirectory PATH form via --dry-run
-    // (so no network calls are made) and asserts:
-    //   1) at least one fixture was found,
-    //   2) the printed yamlFilename starts with `/tests/safe-outputs/`,
-    //   3) no "Failed to read source" errors appear.
+    // `enable` always calls `list_definitions` (to know which
+    // fixtures already exist) even in --dry-run, so we point at a
+    // wiremock that returns an empty list. The dry-run path then
+    // prints the would-be POST body for every fixture without ever
+    // making a real network call.
+    use wiremock::matchers::{method, path_regex};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path_regex(r"/AgentPlayground/_apis/build/definitions"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "count": 0,
+            "value": []
+        })))
+        .mount(&server)
+        .await;
+
     let output = std::process::Command::new(binary())
         .args([
             "enable",
@@ -107,9 +120,16 @@ fn enable_dry_run_against_subdirectory_uses_repo_root_relative_yaml_path() {
             "AgentPlayground",
             "--org",
             "msazuresphere",
+            "--pat",
+            "dummy-pat-for-dry-run",
             "--dry-run",
             "tests/safe-outputs",
         ])
+        // Redirect ADO REST calls at the wiremock; explicit dummy
+        // PAT keeps `resolve_auth` off the Azure-CLI / interactive-
+        // prompt fallback which CI doesn't support.
+        .env("ADO_AW_TEST_ORG_URL", server.uri())
+        .env_remove("AZURE_DEVOPS_EXT_PAT")
         .output()
         .expect("Failed to run ado-aw enable");
     let stdout = String::from_utf8_lossy(&output.stdout);

--- a/tests/enable_integration.rs
+++ b/tests/enable_integration.rs
@@ -82,3 +82,53 @@ fn enable_help_describes_github_source_support() {
         "Help text should mention GitHub in the --service-connection / --repository-name docs, got:\n{stdout}"
     );
 }
+
+#[test]
+fn enable_dry_run_against_subdirectory_uses_repo_root_relative_yaml_path() {
+    // Regression: previously `enable PATH` joined `pipeline.source`
+    // against the scan root rather than the repo root, producing
+    // doubled paths like
+    //   C:\repo\tests\safe-outputs\tests\safe-outputs\noop.md
+    // for every fixture, and posted a yamlFilename of
+    // `/noop.lock.yml` (relative to scan root) instead of the
+    // real repo-relative `/tests/safe-outputs/noop.lock.yml`.
+    //
+    // This test exercises the subdirectory PATH form via --dry-run
+    // (so no network calls are made) and asserts:
+    //   1) at least one fixture was found,
+    //   2) the printed yamlFilename starts with `/tests/safe-outputs/`,
+    //   3) no "Failed to read source" errors appear.
+    let output = std::process::Command::new(binary())
+        .args([
+            "enable",
+            "--service-connection",
+            "00000000-0000-0000-0000-000000000000",
+            "--project",
+            "AgentPlayground",
+            "--org",
+            "msazuresphere",
+            "--dry-run",
+            "tests/safe-outputs",
+        ])
+        .output()
+        .expect("Failed to run ado-aw enable");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+
+    assert!(
+        output.status.success(),
+        "expected --dry-run exit 0; stdout=\n{stdout}\nstderr=\n{stderr}"
+    );
+    assert!(
+        stdout.contains("Found ") && stdout.contains(" agentic pipeline(s)."),
+        "expected pipeline-discovery line, got:\n{stdout}"
+    );
+    assert!(
+        stdout.contains("\"yamlFilename\": \"/tests/safe-outputs/"),
+        "yamlFilename must be repo-root-relative, got:\n{stdout}"
+    );
+    assert!(
+        !stdout.contains("Failed to read source"),
+        "no fixture should fail to read; got:\n{stdout}"
+    );
+}

--- a/tests/safe-outputs/REGISTERED.md
+++ b/tests/safe-outputs/REGISTERED.md
@@ -46,7 +46,9 @@ the following one-time setup in
 `https://dev.azure.com/msazuresphere/AgentPlayground`:
 
 1. Confirm or create service connections `agent-playground-read` and
-   `agent-playground-write`.
+   `agent-playground-write` (used by the compiled pipelines at runtime
+   via the front-matter `permissions:` block; not to be confused with
+   the GitHub service connection in step 4).
 2. Create branch `daily-smoke-target` and open a perma-PR
    `daily-smoke perma-PR (do not merge)` from `daily-smoke-target` →
    `main` with one comment thread for `reply-to-pr-comment` /
@@ -55,17 +57,47 @@ the following one-time setup in
    - `permaWorkItemId`, `permaWorkItem2Id` (two long-lived work items).
    - `permaPullRequestId`, `permaThreadId` (from step 2).
    - `permaWikiName`, `permaWikiPagePath` (a wiki + a long-lived page).
-   - `noopPipelineId` (filled in after step 4).
-4. Register the `noop-target.lock.yml` pipeline first; capture its ID
-   and update `noopPipelineId` in the variable group.
-5. Register one ADO pipeline per `tests/safe-outputs/*.lock.yml`
-   pointing at this repo's `main` branch. Update the Pipeline ID
-   column above and open a docs-only PR.
-6. Provision pipeline variable `ADO_AW_DEBUG_GITHUB_TOKEN` (secret) on
+   - `noopPipelineId` (filled in after step 5).
+4. **Create the GitHub service connection.** Project settings →
+   Service connections → **New service connection → GitHub**. Either
+   install the Azure Pipelines GitHub App on `githubnext/ado-aw` (no
+   long-lived secret) or paste a fine-grained PAT scoped to the repo.
+   Name it something memorable (e.g. `ado-aw-github`) — that name is
+   passed to `--service-connection` in step 5.
+5. **Bulk-register the smoke pipelines with `ado-aw enable`.** From a
+   `githubnext/ado-aw` checkout:
+   ```powershell
+   ado-aw enable `
+     --org msazuresphere --project AgentPlayground `
+     --service-connection ado-aw-github `
+     --folder '\smoke' `
+     tests/safe-outputs/
+   ```
+   `enable` autodetects the GitHub remote and emits the GitHub-shaped
+   create-definition body for every `*.lock.yml` under
+   `tests/safe-outputs/`. Re-running is idempotent.
+6. Register the `noop-target.lock.yml` pipeline (covered by step 5)
+   and update `noopPipelineId` in the variable group with the
+   captured ID.
+7. Capture each new Pipeline ID from the `enable` output (or via
+   `ado-aw list --org msazuresphere --project AgentPlayground`) and
+   update the column above; open a docs-only PR.
+8. Provision pipeline variable `ADO_AW_DEBUG_GITHUB_TOKEN` (secret) on
    the `smoke-failure-reporter` pipeline **only**. Use a GitHub
    fine-grained PAT scoped to `Issues: Read and write` on
    `githubnext/ado-aw` only. Do **not** put this token in the variable
    group — it must not be reachable by the smoke pipelines themselves.
-7. Register `janitor.lock.yml` (weekly schedule baked in) and
-   `smoke-failure-reporter.lock.yml` (daily schedule baked in,
-   ≈ 30 min after the smokes).
+   ```powershell
+   ado-aw secrets set ADO_AW_DEBUG_GITHUB_TOKEN `
+     --org msazuresphere --project AgentPlayground `
+     --definition-ids <smoke-failure-reporter-pipeline-id> `
+     --value <fine-grained-pat>
+   ```
+9. **Trigger one manual run per pipeline.** ADO's scheduled triggers
+   do not fire until each definition has had at least one successful
+   run. From the same checkout:
+   ```powershell
+   ado-aw run --org msazuresphere --project AgentPlayground tests/safe-outputs/
+   ```
+   After that, the daily schedule baked into each smoke's front-matter
+   takes over.


### PR DESCRIPTION
## Summary

Lets `ado-aw enable` register ADO build definitions whose source YAML lives on **GitHub**. This unblocks bulk-registering the `tests/safe-outputs/*.lock.yml` smoke pipelines into `msazuresphere/AgentPlayground` from a `githubnext/ado-aw` checkout — previously `enable` hard-coded `"type": "TfsGit"` and bailed early on non-ADO remotes (`src/enable.rs:148-156, 201-211` on `main`).

### Mental model

`AdoContext` historically conflated two namespaces. This PR keeps `AdoContext` strictly as the **deployment target** (`{org_url, project}`) and introduces a separate **source identity** type:

| Namespace | What it identifies | Resolved from |
|---|---|---|
| **Deployment target** | Where the pipeline *runs* (`ado_org`, `ado_project`) | `--org`/`--project` (or git remote when source is ADO Git) |
| **Source identity** (`RepoSource`) | Where the markdown *lives* (`provider`, `owner`, `repo`) | `parse_git_remote(git remote)` |

For ADO-source checkouts both halves coincide (no behavioural change). For GitHub source they diverge — the source is `(Github, githubnext, ado-aw)` while the deployment is `(msazuresphere, AgentPlayground)`.

### What's new

**Provider autodetect — no `--repository-type` flag.** `parse_git_remote` tries ADO first (`dev.azure.com`, legacy `*.visualstudio.com`), then `github.com` HTTPS / SSH, then bails. The result feeds into a new `RepositoryRef` enum that branches `build_create_body` between the existing TfsGit body and a GitHub body of the form:

```json
"repository": {
  "type": "GitHub",
  "name": "owner/repo",
  "url":  "https://github.com/owner/repo.git",
  "defaultBranch": "<--default-branch>",
  "properties": {
    "connectedServiceId": "<resolved GUID>",
    "reportBuildStatus": "true"
  }
}
```

**Two new flags on `enable`:**
- `--service-connection <name-or-guid>` — required when source is GitHub; rejected for ADO Git. Friendly names are resolved via `GET /_apis/serviceendpoint/endpoints?type=github&endpointNames=<name>` (project-scoped) with operator-friendly 0/>1-match errors. A UUID regex short-circuits the API call when a GUID is passed.
- `--repository-name owner/repo` — optional override; auto-detected from a GitHub remote.

**Lifecycle commands** (`list`/`disable`/`remove`/`run`/`status`) need no code changes — they route through the lexical `match_definitions` matcher, which only inspects `process.yamlFilename` and `name` and is therefore provider-agnostic. A pinning test (`match_definitions_in_works_for_github_source_definition`) locks that contract in. They work from a GitHub checkout via explicit `--org`/`--project`.

### Operator usage

The new `tests/safe-outputs/REGISTERED.md` manual-handoff checklist captures the full workflow. Short version:

```powershell
# One-time portal step: create a GitHub service connection in AgentPlayground
#   Project settings → Service connections → New → GitHub
#   Name: ado-aw-github  (or whatever you like)

# Bulk-register all smoke pipelines from a githubnext/ado-aw checkout:
ado-aw enable `
  --org msazuresphere --project AgentPlayground `
  --service-connection ado-aw-github `
  --folder '\smoke' `
  tests/safe-outputs/

# One-time first run per pipeline (ADO platform quirk — scheduled triggers
# don't fire until each definition has had at least one run):
ado-aw run --org msazuresphere --project AgentPlayground tests/safe-outputs/
```

### Out of scope (deliberate, documented in the plan)

- **GitHub Enterprise** (`github.example.com`) — parser matches `github.com` only.
- **BitBucket Cloud** source type.
- **Persisting `--org`/`--project` deployment coords** to a local config file. Lifecycle commands against GitHub-source pipelines require these explicitly until that lands.
- **Marker emit-path migration for GitHub source.** The `# ado-aw-metadata: {org, repo}` marker stays a pure source-identity token; GitHub-source compilations continue to emit empty `org`/`repo` and rely on the existing wildcard fallback. The URL filter in discovery is sufficient for the immediate use case; cross-talk is theoretical and not exercised by AgentPlayground.
- **`secrets --all-repos`/`--source` discovery migration** — `secrets --definition-ids` works for GitHub source already; the discovery-path migration is its own focused follow-up.

## Test plan

- `cargo build` — clean.
- `cargo clippy --all-targets --all-features` — clean.
- `cargo test` — **1785 unit tests + every integration suite, 0 failures.**
- **21 new tests** covering:
  - `parse_git_remote` — ADO HTTPS/SSH/legacy, GitHub HTTPS/SSH, `.git` suffix, GHES rejection, unrelated-host rejection, missing-repo-half rejection (9 cases).
  - `RepoSource::url()` — TfsGit + Github shapes (2 cases).
  - `is_uuid_like` and `pick_service_endpoint_id` — UUID short-circuit, 0/1/>1-match triage, missing-`value`-array bail (6 cases).
  - `build_create_body` GitHub-shape snapshot + `repository.id`-omission guarantee (2 cases).
  - `resolve_source` and `split_owner_repo_arg` — autodetect rule for all 6 (provider × override) combinations and arg parsing (10 cases).
  - `match_definitions_in_works_for_github_source_definition` — pins provider-agnostic matching.
  - `enable_help_describes_github_source_support` integration test confirms the new flags advertise correctly.
- `cargo run -- enable --help` manually verified.
- **End-to-end manual verification against `msazuresphere/AgentPlayground` to follow** once a GitHub service connection is set up in the project (the one operator step that can't be automated — no REST API).
