### PR TITLE
ci(release): dispatch recompile-safe-output-fixtures after asset upload

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -186,3 +186,30 @@ jobs:
         run: |
           TAG="${{ needs.release-please.outputs.tag_name || github.event.inputs.tag_name }}"
           gh release upload "$TAG" checksums.txt --clobber --repo "${{ github.repository }}"
+
+  trigger-recompile-safe-output-fixtures:
+    name: Trigger safe-output fixture recompile
+    needs: [release-please, checksums]
+    # Run only once all release assets (binaries + checksums.txt) are uploaded.
+    # Releases published via release-please use the default GITHUB_TOKEN, which
+    # does NOT fire the `release: published` event on other workflows (GitHub
+    # actively suppresses this to prevent recursive triggers). Dispatch the
+    # recompile workflow explicitly here using a PAT so the dispatched run can
+    # itself open a PR.
+    if: >-
+      always() &&
+      (needs.release-please.outputs.release_created == 'true' || github.event_name == 'workflow_dispatch') &&
+      needs.checksums.result == 'success'
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Dispatch recompile-safe-output-fixtures
+        env:
+          GITHUB_TOKEN: ${{ secrets.GH_AW_CI_TRIGGER_TOKEN }}
+        run: |
+          set -euo pipefail
+          TAG="${{ needs.release-please.outputs.tag_name || github.event.inputs.tag_name }}"
+          echo "Dispatching recompile-safe-output-fixtures for $TAG"
+          gh workflow run recompile-safe-output-fixtures.lock.yml \
+            --repo "${{ github.repository }}" \
+            --ref main \
+            -f "version=$TAG"


### PR DESCRIPTION
## Problem

The `recompile-safe-output-fixtures` workflow is supposed to fire on `release: published`, but no `release`-triggered run has ever happened — v0.32.0 and v0.33.0 both went unhandled:

```
$ gh run list --event=release --workflow=recompile-safe-output-fixtures.lock.yml
(empty)
```

Root cause: `release.yml` uses `release-please-action` with the default `GITHUB_TOKEN`. GitHub Actions actively suppresses workflow triggers from events created by `GITHUB_TOKEN` to prevent recursive runs ([docs](https://docs.github.com/en/actions/security-guides/automatic-token-authentication#using-the-github_token-in-a-workflow)), so the `release: published` event is never delivered.

## Fix

Add a final `trigger-recompile-safe-output-fixtures` job at the end of `release.yml` that explicitly dispatches `recompile-safe-output-fixtures.lock.yml` via `gh workflow run`, using `GH_AW_CI_TRIGGER_TOKEN` (a PAT) so the dispatched run can itself open a PR.

- **Ordering**: `needs: [release-please, checksums]` — runs only after every binary and `checksums.txt` have been uploaded. This makes the recompile workflow's Step 2 bounded retry effectively a no-op.
- **Tag pinning**: passes `-f version=$TAG` so the recompile resolves to the *just-released* version rather than re-querying "latest" (avoids races against a hypothetical newer release that lands mid-run).
- **Both code paths**: handles both `push`-triggered release-please publishes and manual `workflow_dispatch` of `release.yml`, mirroring the existing `if:` pattern on the other build jobs.

## Backfill

Once this merges, run the following to backfill v0.32.0 and v0.33.0:

```bash
gh workflow run recompile-safe-output-fixtures.lock.yml --repo githubnext/ado-aw --ref main -f version=v0.33.0
```

## Why not alternatives

- **Switch release-please to use a PAT** (smaller diff): would work, but would attribute every release to a bot identity, and would still rely on `release: published` reliably propagating ordering after asset uploads. The explicit dispatch approach removes the asset-upload race entirely.
- **`workflow_run` on `Release` completion**: less clean — runs on the default branch and would still need to re-resolve the tag.
