### PR TITLE
fix(release): use built-in GITHUB_TOKEN to dispatch recompile workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -191,20 +191,23 @@ jobs:
     name: Trigger safe-output fixture recompile
     needs: [release-please, checksums]
     # Run only once all release assets (binaries + checksums.txt) are uploaded.
-    # Releases published via release-please use the default GITHUB_TOKEN, which
-    # does NOT fire the `release: published` event on other workflows (GitHub
-    # actively suppresses this to prevent recursive triggers). Dispatch the
-    # recompile workflow explicitly here using a PAT so the dispatched run can
-    # itself open a PR.
+    # Releases published via release-please do NOT fire the `release: published`
+    # event on other workflows (GitHub suppresses this to prevent recursive
+    # triggers), so we explicitly dispatch the recompile workflow here. The
+    # default GITHUB_TOKEN has the `actions:write` scope needed to run
+    # `gh workflow run`; the dispatched workflow uses its own secrets for any
+    # downstream PR creation.
     if: >-
       always() &&
       (needs.release-please.outputs.release_created == 'true' || github.event_name == 'workflow_dispatch') &&
       needs.checksums.result == 'success'
     runs-on: ubuntu-22.04
+    permissions:
+      actions: write
     steps:
       - name: Dispatch recompile-safe-output-fixtures
         env:
-          GITHUB_TOKEN: ${{ secrets.GH_AW_CI_TRIGGER_TOKEN }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -euo pipefail
           TAG="${{ needs.release-please.outputs.tag_name || github.event.inputs.tag_name }}"


### PR DESCRIPTION
## What

The post-release `trigger-recompile-safe-output-fixtures` job in `.github/workflows/release.yml` was authenticating `gh workflow run` with `secrets.GH_AW_CI_TRIGGER_TOKEN`. That secret is a [gh-aw](https://github.com/githubnext/gh-aw) runtime convention specifically scoped to agentic workflows' safe-output PR-creation flow — it is not appropriate for a plain GitHub Actions workflow like `release.yml`.

The repo doesn't currently have `GH_AW_CI_TRIGGER_TOKEN` provisioned as a repo or org-shared secret, so the dispatch step resolves it to an empty string and fails. The agentic lock files that also reference this secret tolerate it being empty (the safe-output handler only consumes it for specific PR-trigger operations), so this failure is isolated to the release dispatch step.

Observed in [run 27193012425](https://github.com/githubnext/ado-aw/actions/runs/27193012425/job/80278416331):

```
Dispatching recompile-safe-output-fixtures for v0.33.1
gh: To use GitHub CLI in a GitHub Actions workflow, set the GH_TOKEN environment variable.
##[error]Process completed with exit code 4.
```

## Change

- Switch the dispatch to the built-in `secrets.GITHUB_TOKEN`, which is always available.
- Add explicit `permissions: actions: write` on the job so the default token has the scope `gh workflow run` requires.
- Rename the in-step env var to `GH_TOKEN` (the convention `gh` looks for in Actions).
- Rewrite the comment to remove the misleading "PAT is needed so the dispatched run can open a PR" rationale — the dispatched recompile workflow uses its own secrets for any downstream PR creation, so no behavior is lost.

## Why this works

`gh workflow run` only needs `actions:write` on the same repo, which `GITHUB_TOKEN` provides once we declare the permission. The dispatched `recompile-safe-output-fixtures` workflow is a separate run with its own auth context and continues to handle CI-triggering PRs the same way it always has.

## Test plan

This only affects the release workflow's post-publish dispatch step; it cannot be exercised on a feature branch. Will be validated on the next release-please release.
