### PR TITLE
feat(compile)!: record on.pr.mode (synthetic|policy) trigger model

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,5 +1,9 @@
 name: Release
 
+# Note: the v0.34.0 entry re-records the on.pr.mode change from #922,
+# whose squash-merge body broke release-please's commit parser and was
+# silently dropped from the v0.33.2 release PR (#924).
+
 on:
   push:
     branches:


### PR DESCRIPTION
Re-records the change from #922, whose squash-merge body broke release-please's commit parser. The latest Release workflow run logged:

```
commit could not be parsed: 1130d2a... feat(compile): make on.pr a first-class trigger via synthetic CI-derived PR context (#922)
error message: Error: unexpected token '(' at 149:7, valid tokens [)]
```

Because release-please silently dropped that commit, PR #924 still proposes v0.33.2 (only #923's fix) instead of the v0.34.0 minor bump #922 should have triggered.

This PR's title is a properly-formatted `feat(compile)!:` conventional commit. After squash-merge, release-please will re-run on the push, parse the new commit cleanly, and rebuild #924 as v0.34.0 with both #922's feature and #923's fix in the changelog.

The diff itself is a 3-line comment in `.github/workflows/release.yml` (branch policies require a non-empty PR).

Refs: #922, #924