### PR TITLE
fix(ado-script): inline azure-devops-node-api to avoid missing ncc chunk

### DIFF
--- a/scripts/ado-script/src/shared/__tests__/auth.test.ts
+++ b/scripts/ado-script/src/shared/__tests__/auth.test.ts
@@ -34,9 +34,5 @@ describe("getWebApi", () => {
     const a = await getWebApi();
     const b = await getWebApi();
     expect(a).toBe(b);
-  }, 30_000);
-  // ^ explicit 30 s timeout: the first call dynamically imports the
-  // ~2.7 MB azure-devops-node-api chunk (see shared/auth.ts comment),
-  // which can take a few seconds when 20 vitest workers race for disk
-  // I/O. Subsequent calls hit the cache and are fast.
+  });
 });

--- a/scripts/ado-script/src/shared/auth.ts
+++ b/scripts/ado-script/src/shared/auth.ts
@@ -5,15 +5,17 @@
  * `SYSTEM_ACCESSTOKEN` and `ADO_COLLECTION_URI` pipeline env vars via
  * `getPersonalAccessTokenHandler`.
  *
- * The `azure-devops-node-api` package is heavy (~1 MB; includes
- * `typed-rest-client` and `tunnel` transitive deps). Loading it eagerly
- * adds ~50–100 ms of startup latency that is wasted whenever the gate
- * is invoked for a code path that never touches the ADO REST API
- * (e.g. a manual build that hits the bypass branch in `bypass.ts`, or
- * a pipeline whose facts are all pipeline variables). The dynamic
- * `import()` below is statically analysable by ncc, so the SDK is
- * still bundled into `gate.js` — only its module-evaluation
- * cost is deferred until the first `getWebApi()` call.
+ * Import shape: the SDK is imported statically. An earlier revision
+ * deferred it via `await import(...)` to save ~50–100 ms of
+ * module-evaluation time on bypass paths, but ncc compiles dynamic
+ * `import()` into a separate webpack chunk file (`<id>.index.js`)
+ * that lives alongside the main bundle in `.ado-build/<name>/`. The
+ * release pipeline ships only the flat `<name>.js` files
+ * (see `scripts/ado-script/package.json`'s `build:*` targets, plus
+ * `src/compile/extensions/ado_script.rs`'s per-file download list),
+ * so at runtime the chunk was missing and `getWebApi()` failed with
+ * `Cannot find module '/tmp/ado-aw-scripts/ado-script/<id>.index.js'`.
+ * A static import keeps everything in a single self-contained bundle.
  *
  * Env-var contract (set by the compiler in
  * `src/compile/filter_ir.rs::compile_gate_step_external` /
@@ -21,6 +23,7 @@
  *   - `SYSTEM_ACCESSTOKEN` ← `$(System.AccessToken)`
  *   - `ADO_COLLECTION_URI` ← `$(System.CollectionUri)`
  */
+import * as azdev from "azure-devops-node-api";
 import type { WebApi } from "azure-devops-node-api";
 import { logError } from "./vso-logger.js";
 
@@ -47,7 +50,6 @@ export async function getWebApi(): Promise<WebApi> {
     throw new Error(msg);
   }
 
-  const azdev = await import("azure-devops-node-api");
   const handler = azdev.getPersonalAccessTokenHandler(token);
   cached = new azdev.WebApi(orgUrl, handler);
   return cached;


### PR DESCRIPTION
## Summary

`exec-context-pr-synth` (and latently `gate.js`) crashed at runtime with:

```
[synth-pr] listActivePullRequestsBySourceRef failed: Cannot find module
'/tmp/ado-aw-scripts/ado-script/485.index.js' imported from
/tmp/ado-aw-scripts/ado-script/exec-context-pr-synth.js
```

### Root cause

`src/shared/auth.ts` lazy-loaded `azure-devops-node-api` via
`await import("azure-devops-node-api")` to defer ~50–100 ms of module
evaluation on bypass paths. ncc 0.38 compiles dynamic `import()` into a
**separate webpack chunk file** (`<id>.index.js`) that lives alongside
the main bundle in `.ado-build/<name>/`. Each `build:*` script in
`scripts/ado-script/package.json` only copies `index.js` out to the flat
`<name>.js` layout that the release workflow ships as individual assets
(see `src/compile/extensions/ado_script.rs`'s per-file download list),
so the chunk silently vanished. At runtime `getWebApi()` tried
`n.e(485).then(n.t.bind(n, 3485, 23))` and Node could not resolve the
missing file.

`gate.js` had the same chunk-split, but most gate evaluations short-
circuit before touching `getWebApi()`, so the bug stayed dormant there
until `exec-context-pr-synth` exercised the ADO REST path on every run.

### Fix

Replace the dynamic import with a static `import * as azdev` in
`src/shared/auth.ts`. ncc now inlines the SDK directly into every
bundle, so each script ships as a single self-contained file that
matches the flat release layout:

| bundle                         | dynamic chunks | size      |
| ------------------------------ | -------------- | --------- |
| `gate.js`                      | 0              | 1 127 kB  |
| `import.js`                    | 0              | 2 kB      |
| `exec-context-pr.js`           | 0              | 8 kB      |
| `exec-context-pr-synth.js`     | 0              | 1 145 kB  |

Updated the doc comment on `auth.ts` to record why the import is static
(linking the failure mode to the flat release layout) and dropped the
now-stale 30 s vitest timeout in `auth.test.ts` that compensated for
the first-call dynamic-import cost.

> [!NOTE]
> No compiler/Rust changes — the broken artefacts only ship via a new
> `ado-aw` release that bundles `scripts/ado-script/*.js` as release
> assets. A release of `ado-aw` is required before pipelines pick up
> the fix end-to-end.

## Test plan

From `scripts/ado-script/`:

- `npm run typecheck` — clean
- `npm test` — 281/281 passing (34 test files)
- `npm run test:smoke` — 6/6 passing
- `npm run build` — all four bundles rebuilt; verified each contains
  **zero** `n.e(<id>)` dynamic chunk loads via a regex sweep over the
  emitted `*.js` files.
