### PR TITLE
fix(workflows): allow github-actions[bot] to trigger recompile-safe-output-fixtures

### DIFF
--- a/.github/workflows/recompile-safe-output-fixtures.lock.yml
+++ b/.github/workflows/recompile-safe-output-fixtures.lock.yml
@@ -1,4 +1,4 @@
-# gh-aw-metadata: {"schema_version":"v4","frontmatter_hash":"00079c330e8a15f4ee222799911fdab35543359b5d23568c205f487d17307acf","body_hash":"09ab817be62be5e8bf9912909ac1fedcbaf36e8c048cdc21c1a8ef7cddee3b7c","compiler_version":"v0.77.5","strict":true,"agent_id":"copilot"}
+# gh-aw-metadata: {"schema_version":"v4","frontmatter_hash":"8c179bd493d77482c30ffc64270b5e8d5072abb833896184b00e2780ba76e1f6","body_hash":"09ab817be62be5e8bf9912909ac1fedcbaf36e8c048cdc21c1a8ef7cddee3b7c","compiler_version":"v0.77.5","strict":true,"agent_id":"copilot"}
 # gh-aw-manifest: {"version":1,"secrets":["COPILOT_GITHUB_TOKEN","GH_AW_CI_TRIGGER_TOKEN","GH_AW_GITHUB_MCP_SERVER_TOKEN","GH_AW_GITHUB_TOKEN","GITHUB_TOKEN"],"actions":[{"repo":"actions/checkout","sha":"de0fac2e4500dabe0009e67214ff5f5447ce83dd","version":"v6.0.2"},{"repo":"actions/download-artifact","sha":"3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c","version":"v8.0.1"},{"repo":"actions/github-script","sha":"373c709c69115d41ff229c7e5df9f8788daa9553","version":"v9"},{"repo":"actions/github-script","sha":"3a2844b7e9c422d3c10d287c895573f7108da1b3","version":"v9.0.0"},{"repo":"actions/github-script","sha":"d746ffe35508b1917358783b479e04febd2b8f71","version":"v9.0.0"},{"repo":"actions/setup-node","sha":"48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e","version":"v6.4.0"},{"repo":"actions/upload-artifact","sha":"043fb46d1a93c77aae656e7c1c64a875d1fc6a0a","version":"v7.0.1"},{"repo":"github/gh-aw-actions/setup","sha":"3ea13c02d765410340d533515cb31a7eef2baaf0","version":"v0.77.5"}],"containers":[{"image":"ghcr.io/github/gh-aw-firewall/agent:0.25.58"},{"image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.25.58"},{"image":"ghcr.io/github/gh-aw-firewall/squid:0.25.58"},{"image":"ghcr.io/github/gh-aw-mcpg:v0.3.22"},{"image":"ghcr.io/github/github-mcp-server:v1.1.0"},{"image":"node:lts-alpine","digest":"sha256:2bdb65ed1dab192432bc31c95f94155ca5ad7fc1392fb7eb7526ab682fa5bf14","pinned_image":"node:lts-alpine@sha256:2bdb65ed1dab192432bc31c95f94155ca5ad7fc1392fb7eb7526ab682fa5bf14"}]}
 #    ___                   _   _      
 #   / _ \                 | | (_)     
@@ -51,6 +51,8 @@
 
 name: "Recompile safe-output fixtures"
 on:
+  # bots: # Bots processed as bot check in pre-activation job
+  # - github-actions[bot] # Bots processed as bot check in pre-activation job
   release:
     types:
     - published
@@ -198,23 +200,23 @@ jobs:
         run: |
           bash "${RUNNER_TEMP}/gh-aw/actions/create_prompt_first.sh"
           {
-          cat << 'GH_AW_PROMPT_a060e0b3ad68ecfa_EOF'
+          cat << 'GH_AW_PROMPT_278b008edee021dc_EOF'
           <system>
-          GH_AW_PROMPT_a060e0b3ad68ecfa_EOF
+          GH_AW_PROMPT_278b008edee021dc_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/xpia.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/temp_folder_prompt.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/markdown.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_prompt.md"
-          cat << 'GH_AW_PROMPT_a060e0b3ad68ecfa_EOF'
+          cat << 'GH_AW_PROMPT_278b008edee021dc_EOF'
           <safe-output-tools>
           Tools: create_pull_request, close_pull_request(max:5), missing_tool, missing_data, noop
-          GH_AW_PROMPT_a060e0b3ad68ecfa_EOF
+          GH_AW_PROMPT_278b008edee021dc_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_create_pull_request.md"
-          cat << 'GH_AW_PROMPT_a060e0b3ad68ecfa_EOF'
+          cat << 'GH_AW_PROMPT_278b008edee021dc_EOF'
           </safe-output-tools>
-          GH_AW_PROMPT_a060e0b3ad68ecfa_EOF
+          GH_AW_PROMPT_278b008edee021dc_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/mcp_cli_tools_prompt.md"
-          cat << 'GH_AW_PROMPT_a060e0b3ad68ecfa_EOF'
+          cat << 'GH_AW_PROMPT_278b008edee021dc_EOF'
           <github-context>
           The following GitHub context information is available for this workflow:
           {{#if github.actor}}
@@ -243,12 +245,12 @@ jobs:
           {{/if}}
           </github-context>
           
-          GH_AW_PROMPT_a060e0b3ad68ecfa_EOF
+          GH_AW_PROMPT_278b008edee021dc_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/github_mcp_tools_with_safeoutputs_prompt.md"
-          cat << 'GH_AW_PROMPT_a060e0b3ad68ecfa_EOF'
+          cat << 'GH_AW_PROMPT_278b008edee021dc_EOF'
           </system>
           {{#runtime-import .github/workflows/recompile-safe-output-fixtures.md}}
-          GH_AW_PROMPT_a060e0b3ad68ecfa_EOF
+          GH_AW_PROMPT_278b008edee021dc_EOF
           } > "$GH_AW_PROMPT"
       - name: Interpolate variables and render templates
         uses: actions/github-script@d746ffe35508b1917358783b479e04febd2b8f71 # v9.0.0
@@ -462,9 +464,9 @@ jobs:
           mkdir -p "${RUNNER_TEMP}/gh-aw/safeoutputs"
           mkdir -p /tmp/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/mcp-logs/safeoutputs
-          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_6010daecaf97b125_EOF'
+          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_983485d794a5e7b6_EOF'
           {"close_pull_request":{"max":5,"required_title_prefix":"chore(workflows): recompile safe-output fixtures","target":"*"},"create_pull_request":{"allowed_files":["tests/safe-outputs/*.lock.yml","tests/safe-outputs/**/*.lock.yml"],"max":1,"max_patch_files":100,"max_patch_size":1024,"protect_top_level_dot_folders":true,"protected_files":["package.json","bun.lockb","bunfig.toml","deno.json","deno.jsonc","deno.lock","global.json","NuGet.Config","Directory.Packages.props","mix.exs","mix.lock","go.mod","go.sum","stack.yaml","stack.yaml.lock","pom.xml","build.gradle","build.gradle.kts","settings.gradle","settings.gradle.kts","gradle.properties","package-lock.json","yarn.lock","pnpm-lock.yaml","npm-shrinkwrap.json","requirements.txt","Pipfile","Pipfile.lock","pyproject.toml","setup.py","setup.cfg","Gemfile","Gemfile.lock","uv.lock","CODEOWNERS","DESIGN.md","README.md","CONTRIBUTING.md","CHANGELOG.md","SECURITY.md","CODE_OF_CONDUCT.md","AGENTS.md","CLAUDE.md","GEMINI.md"],"protected_files_policy":"request_review","title_prefix":"chore(workflows): "},"create_report_incomplete_issue":{},"missing_data":{},"missing_tool":{},"noop":{"max":1,"report-as-issue":"true"},"report_incomplete":{}}
-          GH_AW_SAFE_OUTPUTS_CONFIG_6010daecaf97b125_EOF
+          GH_AW_SAFE_OUTPUTS_CONFIG_983485d794a5e7b6_EOF
       - name: Generate Safe Outputs Tools
         env:
           GH_AW_TOOLS_META_JSON: |
@@ -696,7 +698,7 @@ jobs:
           
           mkdir -p /home/runner/.copilot
           GH_AW_NODE=$(which node 2>/dev/null || command -v node 2>/dev/null || echo node)
-          cat << GH_AW_MCP_CONFIG_d16c51e94de8107a_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
+          cat << GH_AW_MCP_CONFIG_1f50dec07ca059e2_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
           {
             "mcpServers": {
               "github": {
@@ -737,7 +739,7 @@ jobs:
               "payloadDir": "${MCP_GATEWAY_PAYLOAD_DIR}"
             }
           }
-          GH_AW_MCP_CONFIG_d16c51e94de8107a_EOF
+          GH_AW_MCP_CONFIG_1f50dec07ca059e2_EOF
       - name: Mount MCP servers as CLIs
         id: mount-mcp-clis
         continue-on-error: true
@@ -1374,6 +1376,7 @@ jobs:
         uses: actions/github-script@d746ffe35508b1917358783b479e04febd2b8f71 # v9.0.0
         env:
           GH_AW_REQUIRED_ROLES: "admin,maintainer,write"
+          GH_AW_ALLOWED_BOTS: "github-actions[bot]"
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |

--- a/.github/workflows/recompile-safe-output-fixtures.md
+++ b/.github/workflows/recompile-safe-output-fixtures.md
@@ -1,5 +1,6 @@
 ---
 on:
+  bots: ["github-actions[bot]"]
   release:
     types: [published]
   workflow_dispatch:


### PR DESCRIPTION
The elease: published event for `recompile-safe-output-fixtures` is dispatched by `github-actions[bot]` when release-please cuts a new `ado-aw` release. The workflow's pre_activation gate enforces the default required roles (`admin,maintainer,write`), so the bot actor was rejected and the workflow never activated on release — e.g. run [27278581112](https://github.com/githubnext/ado-aw/actions/runs/27278581112) skipped activation with:

> Access denied: User 'github-actions[bot]' is not authorized. Required permissions: admin, maintainer, write.

## Change

- Add `bots: ["github-actions[bot]"]` to `on:` in `recompile-safe-output-fixtures.md` so release-triggered runs can activate.
- Recompile `recompile-safe-output-fixtures.lock.yml` (renders `GH_AW_ALLOWED_BOTS: "github-actions[bot]"` env on the pre_activation step plus a bots comment under `on:`).

Human `workflow_dispatch` runs continue to go through the normal role check unchanged.