### PR TITLE
docs(site): fix slide deck navigation under base path

### DIFF
--- a/site/slides/package.json
+++ b/site/slides/package.json
@@ -6,7 +6,7 @@
   "description": "Short intro deck for ado-aw — Continuous AI for Azure DevOps",
   "scripts": {
     "dev": "slidev --open",
-    "build": "slidev build --base /ado-aw/slides/ --out ../public/slides",
+    "build": "slidev build --base ./ --out ../public/slides",
     "export": "slidev export --wait 1500 --wait-until networkidle --output dist/ado-aw-intro.pdf"
   },
   "dependencies": {

--- a/site/slides/slides.md
+++ b/site/slides/slides.md
@@ -6,6 +6,7 @@ info: |
   CI/CD is the rung we trust. Continuous AI is the next one.
 class: text-center
 colorSchema: dark
+routerMode: hash
 highlighter: shiki
 transition: slide-left
 mdc: true


### PR DESCRIPTION
## Summary

Fixes broken slide navigation on the deployed intro deck (added in #1152).

The deck was built with history routing under an absolute base (`--base /ado-aw/slides/`), so advancing slides appended the base to the URL instead of replacing the route — producing paths like:

```
https://githubnext.github.io/ado-aw/slides/ado-aw/slides/4
```

### Fix

- **`routerMode: hash`** — navigation now stays within a single hash route (`/ado-aw/slides/#/4`), which is the canonical configuration for static hosting under a subpath (GitHub Pages). Deep-link reloads work without server-side SPA fallback.
- **`--base ./`** — assets are referenced relatively (`./assets/…`), so they resolve correctly under `/ado-aw/slides/` regardless of routing.

## Test plan

Verified the built deck with a headless-browser check (served at its real `/ado-aw/slides/` base):

- Advancing 5 slides: `…/slides/#/1` → `…/slides/#/6` — **no base duplication**.
- Slide content renders (e.g. "Key principles …"); zero page errors.
- Deep-link reload at `…/slides/#/6` renders correctly, including the Mermaid SVG diagram.
- Presenter mode loads at `…/slides/#/presenter/1`.
- `cd site && npm run build` still completes; links validation passes.
