### PR TITLE
docs(site): fix presenter-mode navigation on deployed deck

### DIFF
--- a/site/slides/package.json
+++ b/site/slides/package.json
@@ -6,7 +6,7 @@
   "description": "Short intro deck for ado-aw — Continuous AI for Azure DevOps",
   "scripts": {
     "dev": "slidev --open",
-    "build": "slidev build --base ./ --out ../public/slides",
+    "build": "slidev build --out ../public/slides && node postbuild.mjs ../public/slides",
     "export": "slidev export --wait 1500 --wait-until networkidle --output dist/ado-aw-intro.pdf"
   },
   "dependencies": {

--- a/site/slides/postbuild.mjs
+++ b/site/slides/postbuild.mjs
@@ -1,0 +1,33 @@
+// Post-build step for the sub-path deployment of the Slidev deck.
+//
+// The deck is built with the default Vite base "/" so that Slidev's in-app
+// navigation (getSlidePath → import.meta.env.BASE_URL) produces clean hash
+// routes (/N and /presenter/N) for both play and presenter mode. JS/CSS asset
+// URLs are emitted relative via experimental.renderBuiltUrl (see vite.config.ts).
+//
+// The only thing left pointing at an absolute "/assets/…" path is the entry
+// markup in the generated HTML files. Rewrite those to "./assets/…" so the
+// bundle also loads correctly when served from …/ado-aw/slides/.
+import { readdir, readFile, writeFile } from 'node:fs/promises'
+import path from 'node:path'
+
+const outDir = process.argv[2]
+if (!outDir) {
+  console.error('usage: node postbuild.mjs <out-dir>')
+  process.exit(1)
+}
+
+const entries = await readdir(outDir, { withFileTypes: true })
+let patched = 0
+for (const e of entries) {
+  if (!e.isFile() || !e.name.endsWith('.html')) continue
+  const fp = path.join(outDir, e.name)
+  const src = await readFile(fp, 'utf8')
+  const out = src.replaceAll('="/assets/', '="./assets/')
+  if (out !== src) {
+    await writeFile(fp, out)
+    patched++
+    console.log(`  rewrote ${e.name}`)
+  }
+}
+console.log(`postbuild: relative-ized assets in ${patched} HTML file(s)`)

--- a/site/slides/vite.config.ts
+++ b/site/slides/vite.config.ts
@@ -1,0 +1,17 @@
+import { defineConfig } from 'vite'
+
+// Deploy the deck under a sub-path (…/ado-aw/slides/) without breaking Slidev's
+// in-app navigation. Slidev's getSlidePath() prepends import.meta.env.BASE_URL
+// to every router target, so a non-"/" Vite base leaks into (or doubles in) the
+// route path — which breaks presenter mode in particular.
+//
+// Fix: keep the Vite base at "/" (so BASE_URL stays "/", and hash routes resolve
+// cleanly as /N and /presenter/N), but emit *relative* asset URLs via
+// renderBuiltUrl so the bundle still loads correctly from the sub-path.
+export default defineConfig({
+  experimental: {
+    renderBuiltUrl() {
+      return { relative: true }
+    },
+  },
+})


### PR DESCRIPTION
## Summary

Fixes **presenter-mode** navigation on the deployed intro deck. After the earlier routing fix (#1153), play mode worked but advancing slides in presenter mode duplicated the path segment:

```
…/ado-aw/slides/#/presenter/presenter/2
```

### Root cause

Slidev builds every in-app navigation target with [`getSlidePath`](https://github.com/slidevjs/slidev/blob/main/packages/client/logic/slides.ts), which prepends the Vite base:

```js
const path = presenter ? `presenter/${no}` : `${no}`
return `${import.meta.env.BASE_URL}${path}`
```

This couples the **asset base** and the **router path** to one value, so no single `--base` works for a sub-path deploy:

- `--base /ado-aw/slides/` → base leaks into the route (`#/ado-aw/slides/2`) — breaks both modes.
- `--base ./` → play works (`#/2`), but presenter pushes `./presenter/2`, which Vue Router resolves **relative** to `/presenter/1` → `/presenter/presenter/2` — breaks presenter.

### Fix

Decouple the two:

1. **Build with the default base `/`** — so `BASE_URL` stays `/` and hash routes resolve cleanly as `/N` and `/presenter/N` for **both** play and presenter mode.
2. **`vite.config.ts` → `experimental.renderBuiltUrl: { relative: true }`** — emits relative URLs for JS/CSS assets so the bundle loads from the sub-path.
3. **`postbuild.mjs`** — rewrites the entry HTML's remaining `/assets/…` references to `./assets/…` (the one thing `renderBuiltUrl` doesn't cover).

`routerMode: hash` (already on `main`) is retained.

## Test plan

Verified the built deck with a headless browser served at its real `/ado-aw/slides/` base:

- **Play**: `#/1` → advance → `#/4` — no duplication, correct slide content.
- **Presenter**: `#/presenter/1` → advance → `#/presenter/4` — **no duplication**, renders.
- **Deep-link reload** at `#/6` renders, including the Mermaid SVG diagram.
- Zero page errors.
- `cd site && npm run build` (the CI path: `npm --prefix slides ci --omit=dev` + slidev build + postbuild + astro build) completes; links validation passes; `dist/slides/*.html` ships relative `./assets/` references.
