### PR TITLE
feat(engine): allow ADO macros on Copilot BYOM provider env keys

### DIFF
--- a/docs/engine.md
+++ b/docs/engine.md
@@ -94,8 +94,11 @@ the sidecar active:
   raw value is never copied into the agent via `--env-all` (defense-in-depth; AWF
   also overrides them with placeholders).
 
-This isolation applies to the **Agent** stage. The **Detection** (threat-analysis)
-stage runs with the default GitHub token and is not affected.
+This isolation applies to **both** the Agent stage and the Detection
+(threat-analysis) stage: the detection Copilot run inherits the same
+`COPILOT_PROVIDER_*` routing and api-proxy credential isolation, so it reaches
+the same external provider without exposing the credential (matching gh-aw,
+whose detection engine config inherits the main engine's `env`).
 
 #### Network allowlist
 

--- a/docs/engine.md
+++ b/docs/engine.md
@@ -77,6 +77,26 @@ a pipeline variable rather than hard-coded. They may **not** carry ADO
 command injection (`##vso[`). All non-provider `engine.env` values stay
 literal-only.
 
+#### Credential isolation (api-proxy sidecar)
+
+When a BYOM credential key (`COPILOT_PROVIDER_BASE_URL`,
+`COPILOT_PROVIDER_API_KEY`, or `COPILOT_PROVIDER_BEARER_TOKEN`) is present in
+`engine.env`, the compiler automatically enables the AWF **api-proxy sidecar**
+(`--enable-api-proxy`) on the agent step and pre-pulls its container image. With
+the sidecar active:
+
+- The **real** credential is read by the AWF host process and held inside the
+  proxy container; the agent container receives only a placeholder value and a
+  proxy URL. The proxy strips the client's auth header and injects the real
+  credential on the outbound request, so the secret never reaches the Copilot
+  CLI process or the agent sandbox.
+- The credential keys are additionally passed as AWF `--exclude-env` flags so the
+  raw value is never copied into the agent via `--env-all` (defense-in-depth; AWF
+  also overrides them with placeholders).
+
+This isolation applies to the **Agent** stage. The **Detection** (threat-analysis)
+stage runs with the default GitHub token and is not affected.
+
 #### Network allowlist
 
 When `COPILOT_PROVIDER_BASE_URL` is a **literal** URL, the compiler automatically

--- a/docs/engine.md
+++ b/docs/engine.md
@@ -28,7 +28,7 @@ engine:
 | `agent` | string | *(none)* | Custom agent file identifier (Copilot only). Adds `--agent <name>` to the CLI invocation, selecting a custom agent from `.github/agents/`. |
 | `api-target` | string | *(none)* | Custom API endpoint hostname for GHES/GHEC (e.g., `"api.acme.ghe.com"`). Adds `--api-target <hostname>` to the CLI invocation and adds the hostname to the AWF network allowlist. |
 | `args` | list | `[]` | Custom CLI arguments appended after compiler-generated args. Subject to shell-safety validation and blocked from overriding compiler-controlled flags (`--prompt`, `--additional-mcp-config`, `--allow-tool`, `--allow-all-tools`, `--allow-all-paths`, `--disable-builtin-mcps`, `--no-ask-user`, `--ask-user`). |
-| `env` | map | *(none)* | Engine-specific environment variables merged into the sandbox step's `env:` block. Keys must be valid env var names; values must not contain ADO expressions (`$(`, `${{`) or pipeline command injection (`##vso[`). Compiler-controlled keys (`GITHUB_TOKEN`, `PATH`, `BASH_ENV`, etc.) are blocked. |
+| `env` | map | *(none)* | Engine-specific environment variables merged into the sandbox step's `env:` block. Keys must be valid env var names. Values are literal-only and must not contain ADO expressions (`$(`, `${{`, `$[`) or pipeline command injection (`##vso[`), **except** the Copilot BYOM provider keys (`COPILOT_PROVIDER_BASE_URL`, `COPILOT_PROVIDER_API_KEY`, `COPILOT_PROVIDER_BEARER_TOKEN`, `COPILOT_PROVIDER_WIRE_API`), which may carry ADO macro (`$(...)`) / runtime (`$[...]`) expressions — see [Copilot BYOM / BYOK provider configuration](#copilot-byom--byok-provider-configuration). Compiler-controlled keys (`GITHUB_TOKEN`, `PATH`, `BASH_ENV`, etc.) are blocked. |
 | `command` | string | *(none)* | Custom engine executable path (skips the default engine binary installation — NuGet for `target: 1es`, GitHub Releases for all other targets). The path must be accessible inside the AWF container (e.g., `/tmp/...` or workspace-mounted paths). |
 
 
@@ -41,3 +41,73 @@ The `timeout-minutes` field sets a wall-clock limit (in minutes) for the entire 
 - **SLA compliance** — ensuring scheduled agents complete within a known window.
 
 When omitted, Azure DevOps uses its default job timeout (60 minutes). When set, the compiler emits `timeoutInMinutes: <value>` on the agentic job.
+
+### Copilot BYOM / BYOK provider configuration
+
+The Copilot engine can route requests to an external LLM provider — for example a
+private **Azure Copilot Foundry** instance — instead of GitHub's default routing.
+This **Bring Your Own Model / Key (BYOM/BYOK)** mode is activated by setting
+`COPILOT_PROVIDER_BASE_URL` in `engine.env`. The Copilot CLI reads the
+`COPILOT_PROVIDER_*` environment variables to direct requests to the provider.
+
+This mirrors the model used by
+[GitHub Agentic Workflows (gh-aw)](https://github.com/githubnext/gh-aw): only a
+fixed allowlist of provider env keys may carry expressions; every other
+`engine.env` value remains literal-only.
+
+#### Provider variables
+
+| Variable | Required | Description |
+|----------|----------|-------------|
+| `COPILOT_PROVIDER_BASE_URL` | ✅ for BYOM | Base URL of the external provider (e.g. `https://RESOURCE.cognitiveservices.azure.com/openai/v1`). Setting this activates BYOM mode. |
+| `COPILOT_MODEL` | Often required | Model to use (most providers require it). Set via `engine.model` or this env var. |
+| `COPILOT_PROVIDER_API_KEY` | Optional | API key for cloud providers. Not needed for local providers. |
+| `COPILOT_PROVIDER_BEARER_TOKEN` | Optional | Bearer token alternative to `COPILOT_PROVIDER_API_KEY`; takes precedence when set. |
+| `COPILOT_PROVIDER_TYPE` | Optional | Provider format: `openai` (default), `azure`, or `anthropic`. |
+| `COPILOT_PROVIDER_WIRE_API` | Optional | Wire API variant: `completions` (default) or `responses`. |
+
+#### Allowed expressions
+
+The credential/provider keys `COPILOT_PROVIDER_BASE_URL`,
+`COPILOT_PROVIDER_API_KEY`, `COPILOT_PROVIDER_BEARER_TOKEN`, and
+`COPILOT_PROVIDER_WIRE_API` may carry ADO **macro** (`$(...)`) or **runtime**
+(`$[...]`) expressions, so credentials can be sourced from a Setup-job output or
+a pipeline variable rather than hard-coded. They may **not** carry ADO
+**template** expressions (`${{ }}`, evaluated at compile time) or pipeline
+command injection (`##vso[`). All non-provider `engine.env` values stay
+literal-only.
+
+#### Network allowlist
+
+When `COPILOT_PROVIDER_BASE_URL` is a **literal** URL, the compiler automatically
+adds its hostname to the AWF network allowlist. When the base URL is supplied via
+an expression (so the concrete host is unknown at compile time), add the provider
+hostname explicitly to `network.allowed`.
+
+#### Example — Azure Copilot Foundry with a Setup-acquired bearer token
+
+```yaml
+setup:
+  - task: AzureCLI@2
+    inputs:
+      azureSubscription: my-service-connection
+      scriptType: bash
+      inlineScript: |
+        TOKEN=$(az account get-access-token --resource https://cognitiveservices.azure.com/ --query accessToken -o tsv)
+        echo "##vso[task.setvariable variable=FOUNDRY_TOKEN;isOutput=true]$TOKEN"
+    displayName: Acquire Foundry bearer token
+
+engine:
+  id: copilot
+  model: gpt-4o
+  env:
+    COPILOT_PROVIDER_TYPE: azure
+    COPILOT_PROVIDER_BASE_URL: https://my-foundry.cognitiveservices.azure.com/openai/v1
+    COPILOT_PROVIDER_BEARER_TOKEN: $(Setup.FOUNDRY_TOKEN)
+```
+
+Because `COPILOT_PROVIDER_BASE_URL` is a literal URL above,
+`my-foundry.cognitiveservices.azure.com` is added to the AWF allowlist
+automatically. If you instead source the base URL from an expression
+(`COPILOT_PROVIDER_BASE_URL: $(Setup.BASE_URL)`), add the host to
+`network.allowed` yourself.

--- a/docs/engine.md
+++ b/docs/engine.md
@@ -28,7 +28,7 @@ engine:
 | `agent` | string | *(none)* | Custom agent file identifier (Copilot only). Adds `--agent <name>` to the CLI invocation, selecting a custom agent from `.github/agents/`. |
 | `api-target` | string | *(none)* | Custom API endpoint hostname for GHES/GHEC (e.g., `"api.acme.ghe.com"`). Adds `--api-target <hostname>` to the CLI invocation and adds the hostname to the AWF network allowlist. |
 | `args` | list | `[]` | Custom CLI arguments appended after compiler-generated args. Subject to shell-safety validation and blocked from overriding compiler-controlled flags (`--prompt`, `--additional-mcp-config`, `--allow-tool`, `--allow-all-tools`, `--allow-all-paths`, `--disable-builtin-mcps`, `--no-ask-user`, `--ask-user`). |
-| `env` | map | *(none)* | Engine-specific environment variables merged into the sandbox step's `env:` block. Keys must be valid env var names. Values are literal-only and must not contain ADO expressions (`$(`, `${{`, `$[`) or pipeline command injection (`##vso[`), **except** the Copilot BYOM provider keys (`COPILOT_PROVIDER_BASE_URL`, `COPILOT_PROVIDER_API_KEY`, `COPILOT_PROVIDER_BEARER_TOKEN`, `COPILOT_PROVIDER_WIRE_API`), which may carry ADO macro (`$(...)`) / runtime (`$[...]`) expressions — see [Copilot BYOM / BYOK provider configuration](#copilot-byom--byok-provider-configuration). Compiler-controlled keys (`GITHUB_TOKEN`, `PATH`, `BASH_ENV`, etc.) are blocked. |
+| `env` | map | *(none)* | Engine-specific environment variables merged into the sandbox step's `env:` block. Keys must be valid env var names. Values are literal-only and must not contain ADO expressions (`$(`, `${{`, `$[`) or pipeline command injection (`##vso[`), **except** the Copilot BYOM provider keys (`COPILOT_PROVIDER_BASE_URL`, `COPILOT_PROVIDER_API_KEY`, `COPILOT_PROVIDER_BEARER_TOKEN`, `COPILOT_PROVIDER_WIRE_API`), which may carry an ADO macro (`$(...)`) expression — see [Copilot BYOM / BYOK provider configuration](#copilot-byom--byok-provider-configuration). Compiler-controlled keys (`GITHUB_TOKEN`, `PATH`, `BASH_ENV`, etc.) are blocked. |
 | `command` | string | *(none)* | Custom engine executable path (skips the default engine binary installation — NuGet for `target: 1es`, GitHub Releases for all other targets). The path must be accessible inside the AWF container (e.g., `/tmp/...` or workspace-mounted paths). |
 
 
@@ -70,11 +70,13 @@ fixed allowlist of provider env keys may carry expressions; every other
 
 The credential/provider keys `COPILOT_PROVIDER_BASE_URL`,
 `COPILOT_PROVIDER_API_KEY`, `COPILOT_PROVIDER_BEARER_TOKEN`, and
-`COPILOT_PROVIDER_WIRE_API` may carry ADO **macro** (`$(...)`) or **runtime**
-(`$[...]`) expressions, so credentials can be sourced from a Setup-job output or
-a pipeline variable rather than hard-coded. They may **not** carry ADO
-**template** expressions (`${{ }}`, evaluated at compile time) or pipeline
-command injection (`##vso[`). All non-provider `engine.env` values stay
+`COPILOT_PROVIDER_WIRE_API` may carry an ADO **macro** (`$(...)`) expression, so
+credentials can be sourced from a Setup-job output or a pipeline variable rather
+than hard-coded. Macros are the only expression form ADO evaluates inside a step
+`env:` block. These keys may **not** carry ADO **template** expressions (`${{ }}`,
+evaluated at compile time) or **runtime** expressions (`$[ ... ]`, which ADO does
+not evaluate in step env — the literal string would be passed verbatim), nor
+pipeline command injection (`##vso[`). All non-provider `engine.env` values stay
 literal-only.
 
 #### Credential isolation (api-proxy sidecar)

--- a/docs/engine.md
+++ b/docs/engine.md
@@ -109,6 +109,20 @@ adds its hostname to the AWF network allowlist. When the base URL is supplied vi
 an expression (so the concrete host is unknown at compile time), add the provider
 hostname explicitly to `network.allowed`.
 
+If a **literal** value cannot be resolved to a DNS-safe host — for example a
+scheme-less string like `my-foundry/openai/v1`, or an IPv6 literal — the compiler
+cannot add it automatically. Rather than silently dropping it (which would fail at
+runtime with a firewall block), the compiler emits a non-fatal warning:
+
+```
+warning: COPILOT_PROVIDER_BASE_URL: 'my-foundry/openai/v1' is not a parseable
+absolute URL (or its host is not DNS-safe); the host was not added to the AWF
+allowlist — add the provider hostname manually via network.allowed.
+```
+
+Fix it by using a full absolute URL (including `https://`) and/or adding the host
+to `network.allowed`.
+
 #### Example — Azure Copilot Foundry with a Setup-acquired bearer token
 
 ```yaml

--- a/src/compile/agentic_pipeline.rs
+++ b/src/compile/agentic_pipeline.rs
@@ -185,6 +185,10 @@ pub(crate) fn build_pipeline_context(
 
     let mut engine_env = ctx.engine.env(&front_matter.engine)?;
     let byom_active = crate::engine::copilot_byom_active(&front_matter.engine);
+    // Provider-only env subset for the Detection step, so the threat-analysis
+    // Copilot run inherits the same BYOM/BYOK routing + credential isolation as
+    // the main agent (mirrors gh-aw's detection engine-config Env inheritance).
+    let detection_provider_env = crate::engine::copilot_provider_env(&front_matter.engine)?;
     // AWF path env (when extensions declare path prepends)
     let awf_paths = common::collect_awf_path_prepends(&extension_declarations);
     let has_awf_paths = !awf_paths.is_empty();
@@ -314,6 +318,7 @@ pub(crate) fn build_pipeline_context(
         agent_content_value,
         debug_pipeline,
         byom_active,
+        detection_provider_env,
     };
 
     // ─── Build jobs ───────────────────────────────────────────────
@@ -491,6 +496,10 @@ pub(crate) struct StandaloneCtx {
     /// api-proxy sidecar (`--enable-api-proxy`) on the agent step for credential
     /// isolation and pre-pulls the api-proxy container image.
     pub(crate) byom_active: bool,
+    /// Provider-only (`COPILOT_PROVIDER_*`) subset of `engine.env`, rendered as a
+    /// `KEY: "VALUE"` YAML block (empty when none). Applied to the Detection
+    /// (threat-analysis) step so it inherits BYOM provider routing + isolation.
+    pub(crate) detection_provider_env: String,
 }
 
 // ─────────────────────────────────────────────────────────────────────
@@ -1039,11 +1048,12 @@ fn build_detection_job(
     steps.push(Step::Task(DockerInstaller::new("26.1.4").into_step()));
     // Download AWF
     steps.extend(download_awf_step(front_matter.supply_chain()));
-    // Pre-pull AWF (no MCPG image for detection; no api-proxy — detection runs
-    // the threat-analysis agent with the default GitHub token, not BYOM).
+    // Pre-pull AWF (no MCPG image for detection). Pull the api-proxy image when
+    // BYOM is active so the detection Copilot run gets the same credential
+    // isolation as the main agent.
     steps.extend(prepull_images_step(
         false,
-        false,
+        cfg.byom_active,
         front_matter.supply_chain(),
     ));
     // Prepare safe outputs for analysis
@@ -1073,7 +1083,9 @@ fn build_detection_job(
         &cfg.allowed_domains,
         &cfg.working_directory,
         &cfg.engine_run_detection,
-    )));
+        cfg.byom_active,
+        &cfg.detection_provider_env,
+    )?));
     // Prepare analyzed outputs
     steps.push(Step::Bash(prepare_analyzed_outputs_step()));
     // Evaluate threat analysis — DECLARES TYPED OUTPUT
@@ -2407,6 +2419,29 @@ fn start_mcpg_step(
     Ok(step)
 }
 
+/// Build the AWF api-proxy sidecar flag lines for a Copilot BYOM/BYOK run.
+///
+/// When `byom_active`, returns `--enable-api-proxy` plus one `--exclude-env`
+/// line per provider credential key, each as a 2-space-indented `--flag \`
+/// continuation ending in `\\\n` so it slots directly into the AWF command
+/// body. The api-proxy holds the real credential and injects it only at the
+/// proxy layer (keeping it out of the agent container); `--exclude-env` keeps
+/// the raw value out of `--env-all` passthrough (defense-in-depth; AWF also
+/// overrides them with placeholders). Returns an empty string otherwise.
+///
+/// Shared by [`run_agent_step`] and [`run_threat_analysis_step`] so both AWF
+/// invocations enable isolation identically.
+fn awf_api_proxy_flags(byom_active: bool) -> String {
+    if !byom_active {
+        return String::new();
+    }
+    let mut block = String::from("  --enable-api-proxy \\\n");
+    for key in crate::engine::COPILOT_BYOM_CREDENTIAL_ENV_KEYS {
+        block.push_str(&format!("  --exclude-env {key} \\\n"));
+    }
+    block
+}
+
 fn run_agent_step(
     allowed_domains: &str,
     awf_mounts: &str,
@@ -2428,21 +2463,7 @@ fn run_agent_step(
             .collect::<Vec<_>>()
             .join("\n")
     };
-    // Copilot BYOM/BYOK: enable the AWF api-proxy sidecar so the real provider
-    // credential is held by the proxy and never reaches the agent container.
-    // The credential env keys are also excluded from `--env-all` passthrough
-    // (defense-in-depth; AWF also overrides them with placeholders). Each line
-    // is a 2-space-indented `--flag \` continuation ending in `\\\n` so it
-    // slots in directly before the mounts block.
-    let api_proxy_block: String = if byom_active {
-        let mut block = String::from("  --enable-api-proxy \\\n");
-        for key in crate::engine::COPILOT_BYOM_CREDENTIAL_ENV_KEYS {
-            block.push_str(&format!("  --exclude-env {key} \\\n"));
-        }
-        block
-    } else {
-        String::new()
-    };
+    let api_proxy_block = awf_api_proxy_flags(byom_active);
     let script = format!(
         "set -o pipefail\n\
          \n\
@@ -2704,7 +2725,10 @@ fn run_threat_analysis_step(
     allowed_domains: &str,
     working_directory: &str,
     engine_run_detection: &str,
-) -> BashStep {
+    byom_active: bool,
+    detection_provider_env: &str,
+) -> Result<BashStep> {
+    let api_proxy_block = awf_api_proxy_flags(byom_active);
     let script = format!(
         "set -o pipefail\n\
          \n\
@@ -2715,7 +2739,8 @@ fn run_threat_analysis_step(
          sudo -E \"$(Pipeline.Workspace)/awf/awf\" \\\n  \
            --allow-domains \"{allowed_domains}\" \\\n  \
            --skip-pull \\\n  \
-           --env-all \\\n  \
+           --env-all \\\n\
+{api_proxy_block}  \
            --container-workdir \"{working_directory}\" \\\n  \
            --log-level info \\\n  \
            --proxy-logs-dir \"$(Agent.TempDirectory)/threat-analysis-logs/firewall\" \\\n  \
@@ -2739,7 +2764,22 @@ fn run_threat_analysis_step(
             "GITHUB_READ_ONLY",
             EnvValue::RawYamlScalar(serde_yaml::Value::Number(1.into())),
         );
-    step
+    // BYOM/BYOK: apply the COPILOT_PROVIDER_* env so the detection Copilot run
+    // routes to the same external provider as the main agent.
+    if !detection_provider_env.trim().is_empty() {
+        let synthetic_block = format!(
+            "env:\n{}",
+            detection_provider_env
+                .lines()
+                .map(|l| format!("  {l}"))
+                .collect::<Vec<_>>()
+                .join("\n")
+        );
+        for (k, v) in parse_env_block(&synthetic_block)? {
+            step = step.with_env(k, v);
+        }
+    }
+    Ok(step)
 }
 
 fn prepare_analyzed_outputs_step() -> BashStep {

--- a/src/compile/agentic_pipeline.rs
+++ b/src/compile/agentic_pipeline.rs
@@ -184,6 +184,7 @@ pub(crate) fn build_pipeline_context(
     let engine_log_dir = ctx.engine.log_dir().to_string();
 
     let mut engine_env = ctx.engine.env(&front_matter.engine)?;
+    let byom_active = crate::engine::copilot_byom_active(&front_matter.engine);
     // AWF path env (when extensions declare path prepends)
     let awf_paths = common::collect_awf_path_prepends(&extension_declarations);
     let has_awf_paths = !awf_paths.is_empty();
@@ -312,6 +313,7 @@ pub(crate) fn build_pipeline_context(
         integrity_check_yaml,
         agent_content_value,
         debug_pipeline,
+        byom_active,
     };
 
     // ─── Build jobs ───────────────────────────────────────────────
@@ -485,6 +487,10 @@ pub(crate) struct StandaloneCtx {
     /// `{{#runtime-import ...}}` marker).
     pub(crate) agent_content_value: String,
     pub(crate) debug_pipeline: bool,
+    /// True when `engine.env` activates Copilot BYOM/BYOK mode. Enables the AWF
+    /// api-proxy sidecar (`--enable-api-proxy`) on the agent step for credential
+    /// isolation and pre-pulls the api-proxy container image.
+    pub(crate) byom_active: bool,
 }
 
 // ─────────────────────────────────────────────────────────────────────
@@ -834,8 +840,12 @@ fn build_agent_job(
     // 11. Download AWF
     steps.extend(download_awf_step(front_matter.supply_chain()));
 
-    // 12. Pre-pull AWF + MCPG container images
-    steps.extend(prepull_images_step(true, front_matter.supply_chain()));
+    // 12. Pre-pull AWF + MCPG container images (+ api-proxy when BYOM is active)
+    steps.extend(prepull_images_step(
+        true,
+        cfg.byom_active,
+        front_matter.supply_chain(),
+    ));
 
     // 13. Extension prepare steps (typed) + user steps (RawYaml)
     steps.extend(ext_agent_prepare.iter().cloned());
@@ -872,6 +882,7 @@ fn build_agent_job(
         &cfg.working_directory,
         &cfg.engine_run,
         &cfg.engine_env,
+        cfg.byom_active,
     )?));
 
     // 19. Collect safe outputs from AWF container
@@ -1028,8 +1039,13 @@ fn build_detection_job(
     steps.push(Step::Task(DockerInstaller::new("26.1.4").into_step()));
     // Download AWF
     steps.extend(download_awf_step(front_matter.supply_chain()));
-    // Pre-pull AWF (no MCPG image for detection)
-    steps.extend(prepull_images_step(false, front_matter.supply_chain()));
+    // Pre-pull AWF (no MCPG image for detection; no api-proxy — detection runs
+    // the threat-analysis agent with the default GitHub token, not BYOM).
+    steps.extend(prepull_images_step(
+        false,
+        false,
+        front_matter.supply_chain(),
+    ));
     // Prepare safe outputs for analysis
     steps.push(Step::Bash(prepare_safe_outputs_for_analysis(
         &cfg.working_directory,
@@ -2127,7 +2143,11 @@ fn download_awf_step(supply_chain: Option<&SupplyChainConfig>) -> Vec<Step> {
     ))]
 }
 
-fn prepull_images_step(include_mcpg: bool, supply_chain: Option<&SupplyChainConfig>) -> Vec<Step> {
+fn prepull_images_step(
+    include_mcpg: bool,
+    include_api_proxy: bool,
+    supply_chain: Option<&SupplyChainConfig>,
+) -> Vec<Step> {
     let registry = supply_chain.and_then(|sc| sc.registry.as_ref());
     let registry_base = registry.map(|r| r.name.as_str());
 
@@ -2150,6 +2170,20 @@ fn prepull_images_step(include_mcpg: bool, supply_chain: Option<&SupplyChainConf
          docker tag {squid} {squid_latest}\n\
          docker tag {agent} {agent_latest}\n"
     );
+    // Copilot BYOM/BYOK credential isolation: AWF starts the api-proxy sidecar
+    // when `--enable-api-proxy` is passed (see run_agent_step). Pre-pull and
+    // `:latest`-tag the image the same way as squid/agent so `--skip-pull` finds
+    // it locally.
+    if include_api_proxy {
+        let api_proxy =
+            image_ref("ghcr.io/github/gh-aw-firewall/api-proxy", AWF_VERSION, registry_base);
+        let api_proxy_latest =
+            image_ref("ghcr.io/github/gh-aw-firewall/api-proxy", "latest", None);
+        script.push_str(&format!(
+            "docker pull {api_proxy}\n\
+             docker tag {api_proxy} {api_proxy_latest}\n"
+        ));
+    }
     let display = if include_mcpg {
         let mcpg = image_ref(MCPG_IMAGE, &format!("v{MCPG_VERSION}"), registry_base);
         script.push_str(&format!("docker pull {mcpg}\n"));
@@ -2379,6 +2413,7 @@ fn run_agent_step(
     working_directory: &str,
     engine_run: &str,
     engine_env: &str,
+    byom_active: bool,
 ) -> Result<BashStep> {
     // The awf_mounts string is a `\`-joined chain of `--mount "..."` lines.
     // Render each at 2-space indent inside the bash body (the surrounding
@@ -2392,6 +2427,21 @@ fn run_agent_step(
             .map(|l| format!("  {l}"))
             .collect::<Vec<_>>()
             .join("\n")
+    };
+    // Copilot BYOM/BYOK: enable the AWF api-proxy sidecar so the real provider
+    // credential is held by the proxy and never reaches the agent container.
+    // The credential env keys are also excluded from `--env-all` passthrough
+    // (defense-in-depth; AWF also overrides them with placeholders). Each line
+    // is a 2-space-indented `--flag \` continuation ending in `\\\n` so it
+    // slots in directly before the mounts block.
+    let api_proxy_block: String = if byom_active {
+        let mut block = String::from("  --enable-api-proxy \\\n");
+        for key in crate::engine::COPILOT_BYOM_CREDENTIAL_ENV_KEYS {
+            block.push_str(&format!("  --exclude-env {key} \\\n"));
+        }
+        block
+    } else {
+        String::new()
     };
     let script = format!(
         "set -o pipefail\n\
@@ -2417,6 +2467,7 @@ fn run_agent_step(
            --skip-pull \\\n  \
            --env-all \\\n  \
            --enable-host-access \\\n\
+{api_proxy_block}\
 {awf_mounts_block}\n  \
            --container-workdir \"{working_directory}\" \\\n  \
            --log-level info \\\n  \

--- a/src/compile/agentic_pipeline.rs
+++ b/src/compile/agentic_pipeline.rs
@@ -184,11 +184,25 @@ pub(crate) fn build_pipeline_context(
     let engine_log_dir = ctx.engine.log_dir().to_string();
 
     let mut engine_env = ctx.engine.env(&front_matter.engine)?;
-    let byom_active = crate::engine::copilot_byom_active(&front_matter.engine);
+    // BYOM/BYOK isolation is Copilot-specific: gate on the engine type so a
+    // future non-Copilot engine whose env happens to contain a COPILOT_PROVIDER_*
+    // key never erroneously activates the api-proxy sidecar.
+    let is_copilot = matches!(ctx.engine, crate::engine::Engine::Copilot);
+    let byom_active = is_copilot && crate::engine::copilot_byom_active(&front_matter.engine);
+    // Actual provider credential keys (user's casing) for AWF `--exclude-env`.
+    let byom_exclude_keys = if is_copilot {
+        crate::engine::copilot_byom_credential_keys(&front_matter.engine)
+    } else {
+        Vec::new()
+    };
     // Provider-only env subset for the Detection step, so the threat-analysis
     // Copilot run inherits the same BYOM/BYOK routing + credential isolation as
     // the main agent (mirrors gh-aw's detection engine-config Env inheritance).
-    let detection_provider_env = crate::engine::copilot_provider_env(&front_matter.engine)?;
+    let detection_provider_env = if is_copilot {
+        crate::engine::copilot_provider_env(&front_matter.engine)?
+    } else {
+        String::new()
+    };
     // AWF path env (when extensions declare path prepends)
     let awf_paths = common::collect_awf_path_prepends(&extension_declarations);
     let has_awf_paths = !awf_paths.is_empty();
@@ -318,6 +332,7 @@ pub(crate) fn build_pipeline_context(
         agent_content_value,
         debug_pipeline,
         byom_active,
+        byom_exclude_keys,
         detection_provider_env,
     };
 
@@ -492,10 +507,13 @@ pub(crate) struct StandaloneCtx {
     /// `{{#runtime-import ...}}` marker).
     pub(crate) agent_content_value: String,
     pub(crate) debug_pipeline: bool,
-    /// True when `engine.env` activates Copilot BYOM/BYOK mode. Enables the AWF
-    /// api-proxy sidecar (`--enable-api-proxy`) on the agent step for credential
-    /// isolation and pre-pulls the api-proxy container image.
+    /// True when `engine.env` activates Copilot BYOM/BYOK mode. Pre-pulls the
+    /// api-proxy container image in the Agent and Detection jobs.
     pub(crate) byom_active: bool,
+    /// Actual provider credential env keys present (user's casing) to pass to
+    /// AWF `--exclude-env`; non-empty ⇒ enable the api-proxy sidecar. Empty for
+    /// non-BYOM. Case-preserving so case-sensitive `--exclude-env` matches.
+    pub(crate) byom_exclude_keys: Vec<String>,
     /// Provider-only (`COPILOT_PROVIDER_*`) subset of `engine.env`, rendered as a
     /// `KEY: "VALUE"` YAML block (empty when none). Applied to the Detection
     /// (threat-analysis) step so it inherits BYOM provider routing + isolation.
@@ -891,7 +909,7 @@ fn build_agent_job(
         &cfg.working_directory,
         &cfg.engine_run,
         &cfg.engine_env,
-        cfg.byom_active,
+        &cfg.byom_exclude_keys,
     )?));
 
     // 19. Collect safe outputs from AWF container
@@ -1083,7 +1101,7 @@ fn build_detection_job(
         &cfg.allowed_domains,
         &cfg.working_directory,
         &cfg.engine_run_detection,
-        cfg.byom_active,
+        &cfg.byom_exclude_keys,
         &cfg.detection_provider_env,
     )?));
     // Prepare analyzed outputs
@@ -2421,22 +2439,25 @@ fn start_mcpg_step(
 
 /// Build the AWF api-proxy sidecar flag lines for a Copilot BYOM/BYOK run.
 ///
-/// When `byom_active`, returns `--enable-api-proxy` plus one `--exclude-env`
-/// line per provider credential key, each as a 2-space-indented `--flag \`
+/// `exclude_keys` are the actual provider credential env keys present (in the
+/// user's original casing). When non-empty, returns `--enable-api-proxy` plus
+/// one `--exclude-env <key>` line per key, each as a 2-space-indented `--flag \`
 /// continuation ending in `\\\n` so it slots directly into the AWF command
 /// body. The api-proxy holds the real credential and injects it only at the
 /// proxy layer (keeping it out of the agent container); `--exclude-env` keeps
 /// the raw value out of `--env-all` passthrough (defense-in-depth; AWF also
-/// overrides them with placeholders). Returns an empty string otherwise.
+/// overrides them with placeholders). Case-preserving: env-var names are
+/// case-sensitive, so the exact key the user wrote must be excluded. Returns an
+/// empty string when `exclude_keys` is empty (non-BYOM).
 ///
 /// Shared by [`run_agent_step`] and [`run_threat_analysis_step`] so both AWF
 /// invocations enable isolation identically.
-fn awf_api_proxy_flags(byom_active: bool) -> String {
-    if !byom_active {
+fn awf_api_proxy_flags(exclude_keys: &[String]) -> String {
+    if exclude_keys.is_empty() {
         return String::new();
     }
     let mut block = String::from("  --enable-api-proxy \\\n");
-    for key in crate::engine::COPILOT_BYOM_CREDENTIAL_ENV_KEYS {
+    for key in exclude_keys {
         block.push_str(&format!("  --exclude-env {key} \\\n"));
     }
     block
@@ -2448,7 +2469,7 @@ fn run_agent_step(
     working_directory: &str,
     engine_run: &str,
     engine_env: &str,
-    byom_active: bool,
+    byom_exclude_keys: &[String],
 ) -> Result<BashStep> {
     // The awf_mounts string is a `\`-joined chain of `--mount "..."` lines.
     // Render each at 2-space indent inside the bash body (the surrounding
@@ -2463,7 +2484,7 @@ fn run_agent_step(
             .collect::<Vec<_>>()
             .join("\n")
     };
-    let api_proxy_block = awf_api_proxy_flags(byom_active);
+    let api_proxy_block = awf_api_proxy_flags(byom_exclude_keys);
     let script = format!(
         "set -o pipefail\n\
          \n\
@@ -2725,10 +2746,10 @@ fn run_threat_analysis_step(
     allowed_domains: &str,
     working_directory: &str,
     engine_run_detection: &str,
-    byom_active: bool,
+    byom_exclude_keys: &[String],
     detection_provider_env: &str,
 ) -> Result<BashStep> {
-    let api_proxy_block = awf_api_proxy_flags(byom_active);
+    let api_proxy_block = awf_api_proxy_flags(byom_exclude_keys);
     let script = format!(
         "set -o pipefail\n\
          \n\

--- a/src/compile/agentic_pipeline.rs
+++ b/src/compile/agentic_pipeline.rs
@@ -2439,16 +2439,27 @@ fn start_mcpg_step(
 
 /// Build the AWF api-proxy sidecar flag lines for a Copilot BYOM/BYOK run.
 ///
-/// `exclude_keys` are the actual provider credential env keys present (in the
-/// user's original casing). When non-empty, returns `--enable-api-proxy` plus
-/// one `--exclude-env <key>` line per key, each as a 2-space-indented `--flag \`
-/// continuation ending in `\\\n` so it slots directly into the AWF command
-/// body. The api-proxy holds the real credential and injects it only at the
-/// proxy layer (keeping it out of the agent container); `--exclude-env` keeps
-/// the raw value out of `--env-all` passthrough (defense-in-depth; AWF also
-/// overrides them with placeholders). Case-preserving: env-var names are
-/// case-sensitive, so the exact key the user wrote must be excluded. Returns an
-/// empty string when `exclude_keys` is empty (non-BYOM).
+/// `exclude_keys` are the provider credential env keys present in `engine.env`
+/// (canonical uppercase `COPILOT_PROVIDER_*` names). When non-empty, returns
+/// `--enable-api-proxy` plus one `--exclude-env <key>` line per key, each as a
+/// 2-space-indented `--flag \` continuation ending in `\\\n` so it slots
+/// directly into the AWF command body. Returns an empty string when
+/// `exclude_keys` is empty (non-BYOM).
+///
+/// How the credential reaches the provider without reaching the agent: with
+/// `--enable-api-proxy`, AWF starts the api-proxy sidecar which reads the *real*
+/// `COPILOT_PROVIDER_*` values from the host process env, and injects
+/// **placeholders** into the agent container regardless of `--env-all` —
+/// `COPILOT_PROVIDER_BASE_URL` becomes the sidecar URL (e.g.
+/// `http://172.30.0.30:10002`) and `COPILOT_PROVIDER_API_KEY` a dummy token (see
+/// gh-aw-firewall `docs/api-proxy-sidecar.md`, "agent container env" table, and
+/// `containers/api-proxy/providers/copilot.js`, verified against AWF v0.27.9).
+/// The Copilot CLI therefore talks to the sidecar, which strips the client auth
+/// header and injects the real credential on the outbound request. `--exclude-env`
+/// keeps the raw value out of `--env-all` passthrough (defense-in-depth on top of
+/// AWF's placeholder override). Because env-var names are case-sensitive and the
+/// keys are the canonical uppercase names, the emitted `--exclude-env <key>`
+/// matches exactly what AWF overrides and the CLI reads.
 ///
 /// Shared by [`run_agent_step`] and [`run_threat_analysis_step`] so both AWF
 /// invocations enable isolation identically.

--- a/src/compile/agentic_pipeline.rs
+++ b/src/compile/agentic_pipeline.rs
@@ -201,7 +201,7 @@ pub(crate) fn build_pipeline_context(
     let detection_provider_env = if is_copilot {
         crate::engine::copilot_provider_env(&front_matter.engine)?
     } else {
-        String::new()
+        Vec::new()
     };
     // AWF path env (when extensions declare path prepends)
     let awf_paths = common::collect_awf_path_prepends(&extension_declarations);
@@ -510,14 +510,13 @@ pub(crate) struct StandaloneCtx {
     /// True when `engine.env` activates Copilot BYOM/BYOK mode. Pre-pulls the
     /// api-proxy container image in the Agent and Detection jobs.
     pub(crate) byom_active: bool,
-    /// Actual provider credential env keys present (user's casing) to pass to
-    /// AWF `--exclude-env`; non-empty ⇒ enable the api-proxy sidecar. Empty for
-    /// non-BYOM. Case-preserving so case-sensitive `--exclude-env` matches.
+    /// Actual provider credential env keys present to pass to AWF `--exclude-env`;
+    /// non-empty ⇒ enable the api-proxy sidecar. Empty for non-BYOM.
     pub(crate) byom_exclude_keys: Vec<String>,
-    /// Provider-only (`COPILOT_PROVIDER_*`) subset of `engine.env`, rendered as a
-    /// `KEY: "VALUE"` YAML block (empty when none). Applied to the Detection
+    /// Provider-only (`COPILOT_PROVIDER_*`) subset of `engine.env` as validated
+    /// raw `(key, value)` pairs (empty when none). Applied to the Detection
     /// (threat-analysis) step so it inherits BYOM provider routing + isolation.
-    pub(crate) detection_provider_env: String,
+    pub(crate) detection_provider_env: Vec<(String, String)>,
 }
 
 // ─────────────────────────────────────────────────────────────────────
@@ -2758,7 +2757,7 @@ fn run_threat_analysis_step(
     working_directory: &str,
     engine_run_detection: &str,
     byom_exclude_keys: &[String],
-    detection_provider_env: &str,
+    detection_provider_env: &[(String, String)],
 ) -> Result<BashStep> {
     let api_proxy_block = awf_api_proxy_flags(byom_exclude_keys);
     let script = format!(
@@ -2797,19 +2796,10 @@ fn run_threat_analysis_step(
             EnvValue::RawYamlScalar(serde_yaml::Value::Number(1.into())),
         );
     // BYOM/BYOK: apply the COPILOT_PROVIDER_* env so the detection Copilot run
-    // routes to the same external provider as the main agent.
-    if !detection_provider_env.trim().is_empty() {
-        let synthetic_block = format!(
-            "env:\n{}",
-            detection_provider_env
-                .lines()
-                .map(|l| format!("  {l}"))
-                .collect::<Vec<_>>()
-                .join("\n")
-        );
-        for (k, v) in parse_env_block(&synthetic_block)? {
-            step = step.with_env(k, v);
-        }
+    // routes to the same external provider as the main agent. Classify each raw
+    // value directly (macro → PipelineVar, else Literal) — no YAML round-trip.
+    for (k, raw) in detection_provider_env {
+        step = step.with_env(k.clone(), env_value_from_str(raw));
     }
     Ok(step)
 }
@@ -3065,6 +3055,25 @@ fn dedent(s: &str) -> String {
 /// surfacing it loudly is much better than the previous silent
 /// empty-vec fallback (which produced runtime "GITHUB_TOKEN missing"
 /// failures in the pipeline with no compile-time signal).
+/// Classify a single raw env-var value string into a typed [`EnvValue`].
+///
+/// An ADO **macro** `$(NAME)` (with no nested `$` or `(`) becomes an
+/// [`EnvValue::PipelineVar`] so lowering re-emits the unquoted `$(NAME)` form;
+/// anything else becomes an [`EnvValue::Literal`]. Single source of truth for
+/// macro-vs-literal classification, shared by [`parse_env_block`] (which also
+/// handles YAML-typed scalars) and the detection provider-env path.
+fn env_value_from_str(raw: &str) -> super::ir::env::EnvValue {
+    use super::ir::env::EnvValue;
+    if let Some(inner) = raw.strip_prefix("$(").and_then(|s| s.strip_suffix(')'))
+        && !inner.contains('$')
+        && !inner.contains('(')
+    {
+        EnvValue::pipeline_var(inner.to_string())
+    } else {
+        EnvValue::literal(raw.to_string())
+    }
+}
+
 fn parse_env_block(yaml_block: &str) -> Result<Vec<(String, super::ir::env::EnvValue)>> {
     use super::ir::env::EnvValue;
     if yaml_block.trim().is_empty() {
@@ -3108,16 +3117,7 @@ fn parse_env_block(yaml_block: &str) -> Result<Vec<(String, super::ir::env::EnvV
             // lowering preserves the `$(X)` form unquoted; everything
             // else lands as a Literal.
             serde_yaml::Value::String(raw_value) => {
-                if let Some(inner) = raw_value
-                    .strip_prefix("$(")
-                    .and_then(|s| s.strip_suffix(')'))
-                    && !inner.contains('$')
-                    && !inner.contains('(')
-                {
-                    out.push((key, EnvValue::pipeline_var(inner.to_string())));
-                } else {
-                    out.push((key, EnvValue::literal(raw_value.clone())));
-                }
+                out.push((key, env_value_from_str(raw_value)));
             }
             // Non-string scalars (numbers / bools): preserve the
             // typed scalar identity through RawYamlScalar so the

--- a/src/compile/agentic_pipeline.rs
+++ b/src/compile/agentic_pipeline.rs
@@ -3038,23 +3038,6 @@ fn dedent(s: &str) -> String {
     out
 }
 
-/// Parse a legacy YAML env block (`env:\n  KEY: VALUE\n  KEY: VALUE`)
-/// into typed `(name, EnvValue)` pairs preserving insertion order.
-///
-/// Each value is round-tripped through `serde_yaml` so quoted forms
-/// (`"true"`, `"file"`) become bare literals and ADO macros (`$(X)`)
-/// land as `EnvValue::PipelineVar` so the lowering pass re-emits the
-/// macro form. Anything else lands as `EnvValue::Literal`.
-///
-/// # Errors
-///
-/// Returns `Err` if the input fails to parse as YAML or does not
-/// match the `env: { KEY: VALUE, … }` shape. The inputs are
-/// compiler-generated from validated front-matter, so a parse
-/// failure here indicates a compiler bug rather than user error —
-/// surfacing it loudly is much better than the previous silent
-/// empty-vec fallback (which produced runtime "GITHUB_TOKEN missing"
-/// failures in the pipeline with no compile-time signal).
 /// Classify a single raw env-var value string into a typed [`EnvValue`].
 ///
 /// An ADO **macro** `$(NAME)` (with no nested `$` or `(`) becomes an
@@ -3062,6 +3045,13 @@ fn dedent(s: &str) -> String {
 /// anything else becomes an [`EnvValue::Literal`]. Single source of truth for
 /// macro-vs-literal classification, shared by [`parse_env_block`] (which also
 /// handles YAML-typed scalars) and the detection provider-env path.
+///
+/// Only a value that is *exactly* one `$(NAME)` wrapper is treated as a macro.
+/// Compound values (e.g. `$(A)$(B)`, or `prefix-$(X)`) intentionally fall through
+/// to `Literal` — they are emitted as a quoted YAML scalar. This is still
+/// correct at runtime: ADO expands `$( )` macro references inside step-env values
+/// regardless of quoting, so both references still expand. The only observable
+/// difference is the quoted-vs-unquoted rendering in the compiled YAML.
 fn env_value_from_str(raw: &str) -> super::ir::env::EnvValue {
     use super::ir::env::EnvValue;
     if let Some(inner) = raw.strip_prefix("$(").and_then(|s| s.strip_suffix(')'))
@@ -3074,6 +3064,24 @@ fn env_value_from_str(raw: &str) -> super::ir::env::EnvValue {
     }
 }
 
+/// Parse a legacy YAML env block (`env:\n  KEY: VALUE\n  KEY: VALUE`)
+/// into typed `(name, EnvValue)` pairs preserving insertion order.
+///
+/// Each value is round-tripped through `serde_yaml` so quoted forms
+/// (`"true"`, `"file"`) become bare literals; string values are then
+/// classified by [`env_value_from_str`] (ADO macros → `PipelineVar`,
+/// otherwise `Literal`) and non-string scalars are preserved as
+/// `RawYamlScalar`.
+///
+/// # Errors
+///
+/// Returns `Err` if the input fails to parse as YAML or does not
+/// match the `env: { KEY: VALUE, … }` shape. The inputs are
+/// compiler-generated from validated front-matter, so a parse
+/// failure here indicates a compiler bug rather than user error —
+/// surfacing it loudly is much better than the previous silent
+/// empty-vec fallback (which produced runtime "GITHUB_TOKEN missing"
+/// failures in the pipeline with no compile-time signal).
 fn parse_env_block(yaml_block: &str) -> Result<Vec<(String, super::ir::env::EnvValue)>> {
     use super::ir::env::EnvValue;
     if yaml_block.trim().is_empty() {
@@ -3359,6 +3367,30 @@ mod tests {
             pairs[0].1,
             crate::compile::ir::env::EnvValue::PipelineVar(ref name) if name == "GITHUB_TOKEN"
         ));
+    }
+
+    #[test]
+    fn env_value_from_str_single_macro_is_pipeline_var() {
+        use crate::compile::ir::env::EnvValue;
+        assert!(matches!(
+            env_value_from_str("$(Setup.Token)"),
+            EnvValue::PipelineVar(ref n) if n == "Setup.Token"
+        ));
+    }
+
+    #[test]
+    fn env_value_from_str_compound_or_partial_macro_is_literal() {
+        use crate::compile::ir::env::EnvValue;
+        // Concatenated / partial macros are NOT single-wrapper macros, so they
+        // fall through to Literal. They are still correct at runtime: ADO expands
+        // $( ) references inside the (quoted) literal value. This pins the
+        // documented classification boundary.
+        for raw in ["$(A)$(B)", "prefix-$(X)", "$(X)-suffix", "plain-literal"] {
+            assert!(
+                matches!(env_value_from_str(raw), EnvValue::Literal(ref v) if v == raw),
+                "value {raw:?} should classify as a verbatim Literal"
+            );
+        }
     }
 
     #[test]

--- a/src/compile/common.rs
+++ b/src/compile/common.rs
@@ -2285,6 +2285,11 @@ pub fn generate_allowed_domains(
     for host in engine.required_hosts(&front_matter.engine) {
         hosts.insert(host);
     }
+    // Surface non-fatal engine network warnings (e.g. a literal but malformed
+    // COPILOT_PROVIDER_BASE_URL whose host could not be resolved and added).
+    for warning in engine.network_host_warnings(&front_matter.engine) {
+        eprintln!("warning: {warning}");
+    }
 
     // Add user-specified hosts (validated against DNS-safe characters).
     // Entries may be ecosystem identifiers (e.g., "python", "rust") which

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -530,87 +530,124 @@ fn copilot_env(engine_config: &EngineConfig) -> Result<String> {
         sorted_keys.sort();
 
         for key in sorted_keys {
-            let value = &env_map[key];
-
-            // Validate key: must be a valid env var name
-            if key.is_empty() {
-                anyhow::bail!(
-                    "engine.env contains an empty key. \
-                     Keys must match [A-Za-z_][A-Za-z0-9_]*."
-                );
-            }
-            if !is_valid_env_var_name(key) {
-                anyhow::bail!(
-                    "engine.env key '{}' is not a valid environment variable name. \
-                     Must match [A-Za-z_][A-Za-z0-9_]*.",
-                    key
-                );
-            }
-
-            // Block compiler-controlled env vars.
-            // Intentionally case-insensitive: while Linux env vars are case-sensitive,
-            // blocking both "GITHUB_TOKEN" and "github_token" prevents accidental
-            // shadowing and confusion. The trade-off is that a legitimate custom var
-            // whose name collides case-insensitively with a blocked key is rejected.
-            if BLOCKED_ENV_KEYS
-                .iter()
-                .any(|blocked| key.eq_ignore_ascii_case(blocked))
-            {
-                anyhow::bail!(
-                    "engine.env key '{}' conflicts with a compiler-controlled environment variable. \
-                     These variables are managed by the compiler and cannot be overridden.",
-                    key
-                );
-            }
-
-            // Validate value: reject ADO command injection and YAML-breaking content
-            if contains_pipeline_command(value) {
-                anyhow::bail!(
-                    "engine.env value for '{}' contains ADO pipeline command injection ('##vso[' or '##['). \
-                     This is not allowed.",
-                    key
-                );
-            }
-            // Allowlisted BYOM/BYOK provider keys may carry ADO macro/runtime
-            // expressions (e.g. `$(Setup.FOUNDRY_TOKEN)`) so credentials can be
-            // sourced from Setup-job outputs or pipeline variables. They still
-            // may not carry compile-time template expressions (`${{ }}`).
-            // Every other key remains literal-only.
-            if is_provider_expr_env_key(key) {
-                if contains_ado_template_expression(value) {
-                    anyhow::bail!(
-                        "engine.env value for '{}' contains an ADO template expression ('${{{{}}}}'). \
-                         Provider keys may use macro/runtime expressions ('$(...)' or '$[...]') only.",
-                        key
-                    );
-                }
-            } else if contains_ado_expression(value) {
-                anyhow::bail!(
-                    "engine.env value for '{}' contains ADO expression syntax ('$(' or '${{{{}}}}')). \
-                     Use literal values only — ADO macro/expression expansion is not allowed \
-                     (allowed for BYOM provider keys: {}).",
-                    key,
-                    COPILOT_PROVIDER_EXPR_ENV_KEYS.join(", ")
-                );
-            }
-            if contains_newline(value) {
-                anyhow::bail!(
-                    "engine.env value for '{}' contains newline characters, \
-                     which would break YAML formatting.",
-                    key
-                );
-            }
-
-            // YAML-quote the value to prevent injection
-            lines.push(format!(
-                "{}: \"{}\"",
-                key,
-                value.replace('\\', "\\\\").replace('"', "\\\"")
-            ));
+            lines.push(render_engine_env_entry(key, &env_map[key])?);
         }
     }
 
     Ok(lines.join("\n"))
+}
+
+/// Render only the `COPILOT_PROVIDER_*` entries of `engine.env` as a YAML env
+/// block (`KEY: "VALUE"` lines, one per line; empty string when none present).
+///
+/// Used by the Detection (threat-analysis) step so the detection Copilot run
+/// inherits the same BYOM/BYOK provider routing (and credential isolation) as
+/// the main agent. Mirrors gh-aw, whose detection engine config inherits the
+/// main engine's `Env` (`threat_detection_inline_engine.go`). The main model is
+/// already threaded via the `--model` flag on the detection invocation, so only
+/// the provider routing/credential keys are needed here.
+pub fn copilot_provider_env(engine_config: &EngineConfig) -> Result<String> {
+    let Some(env_map) = engine_config.env() else {
+        return Ok(String::new());
+    };
+    let mut keys: Vec<&String> = env_map
+        .keys()
+        .filter(|k| {
+            k.get(..17)
+                .is_some_and(|prefix| prefix.eq_ignore_ascii_case("COPILOT_PROVIDER_"))
+        })
+        .collect();
+    keys.sort();
+
+    let mut lines = Vec::new();
+    for key in keys {
+        lines.push(render_engine_env_entry(key, &env_map[key])?);
+    }
+    Ok(lines.join("\n"))
+}
+
+/// Validate a single `engine.env` entry and render it as a YAML `KEY: "VALUE"`
+/// line. Enforces env-var-name rules, blocks compiler-controlled keys, rejects
+/// pipeline-command injection / newlines, and applies the BYOM provider
+/// expression allowlist (allowlisted keys may carry `$(...)`/`$[...]`; all
+/// others are literal-only). Shared by [`copilot_env`] and
+/// [`copilot_provider_env`] so both paths validate identically.
+fn render_engine_env_entry(key: &str, value: &str) -> Result<String> {
+    // Validate key: must be a valid env var name
+    if key.is_empty() {
+        anyhow::bail!(
+            "engine.env contains an empty key. \
+             Keys must match [A-Za-z_][A-Za-z0-9_]*."
+        );
+    }
+    if !is_valid_env_var_name(key) {
+        anyhow::bail!(
+            "engine.env key '{}' is not a valid environment variable name. \
+             Must match [A-Za-z_][A-Za-z0-9_]*.",
+            key
+        );
+    }
+
+    // Block compiler-controlled env vars.
+    // Intentionally case-insensitive: while Linux env vars are case-sensitive,
+    // blocking both "GITHUB_TOKEN" and "github_token" prevents accidental
+    // shadowing and confusion. The trade-off is that a legitimate custom var
+    // whose name collides case-insensitively with a blocked key is rejected.
+    if BLOCKED_ENV_KEYS
+        .iter()
+        .any(|blocked| key.eq_ignore_ascii_case(blocked))
+    {
+        anyhow::bail!(
+            "engine.env key '{}' conflicts with a compiler-controlled environment variable. \
+             These variables are managed by the compiler and cannot be overridden.",
+            key
+        );
+    }
+
+    // Validate value: reject ADO command injection and YAML-breaking content
+    if contains_pipeline_command(value) {
+        anyhow::bail!(
+            "engine.env value for '{}' contains ADO pipeline command injection ('##vso[' or '##['). \
+             This is not allowed.",
+            key
+        );
+    }
+    // Allowlisted BYOM/BYOK provider keys may carry ADO macro/runtime
+    // expressions (e.g. `$(Setup.FOUNDRY_TOKEN)`) so credentials can be
+    // sourced from Setup-job outputs or pipeline variables. They still
+    // may not carry compile-time template expressions (`${{ }}`).
+    // Every other key remains literal-only.
+    if is_provider_expr_env_key(key) {
+        if contains_ado_template_expression(value) {
+            anyhow::bail!(
+                "engine.env value for '{}' contains an ADO template expression ('${{{{}}}}'). \
+                 Provider keys may use macro/runtime expressions ('$(...)' or '$[...]') only.",
+                key
+            );
+        }
+    } else if contains_ado_expression(value) {
+        anyhow::bail!(
+            "engine.env value for '{}' contains ADO expression syntax ('$(' or '${{{{}}}}')). \
+             Use literal values only — ADO macro/expression expansion is not allowed \
+             (allowed for BYOM provider keys: {}).",
+            key,
+            COPILOT_PROVIDER_EXPR_ENV_KEYS.join(", ")
+        );
+    }
+    if contains_newline(value) {
+        anyhow::bail!(
+            "engine.env value for '{}' contains newline characters, \
+             which would break YAML formatting.",
+            key
+        );
+    }
+
+    // YAML-quote the value to prevent injection
+    Ok(format!(
+        "{}: \"{}\"",
+        key,
+        value.replace('\\', "\\\\").replace('"', "\\\"")
+    ))
 }
 
 /// Generate Copilot CLI install steps for Azure DevOps pipelines.
@@ -833,7 +870,9 @@ fn copilot_invocation(
 
 #[cfg(test)]
 mod tests {
-    use super::{Engine, copilot_byom_active, get_engine, normalize_version_tag};
+    use super::{
+        Engine, copilot_byom_active, copilot_provider_env, get_engine, normalize_version_tag,
+    };
     use crate::compile::{
         extensions::{CompileContext, CompilerExtension, Declarations, collect_extensions},
         parse_markdown,
@@ -1258,6 +1297,38 @@ mod tests {
             !copilot_byom_active(&fm2.engine),
             "WIRE_API alone must not activate BYOM (it is non-credential config)"
         );
+    }
+
+    #[test]
+    fn copilot_provider_env_renders_only_provider_keys() {
+        let (fm, _) = parse_markdown(
+            "---\nname: test\ndescription: test\nengine:\n  id: copilot\n  env:\n    COPILOT_PROVIDER_TYPE: azure\n    COPILOT_PROVIDER_BEARER_TOKEN: \"$(Setup.FOUNDRY_TOKEN)\"\n    MY_VAR: keep-out\n---\n",
+        ).unwrap();
+        let provider_env = copilot_provider_env(&fm.engine).unwrap();
+        assert!(
+            provider_env.contains(r#"COPILOT_PROVIDER_TYPE: "azure""#),
+            "provider env must include COPILOT_PROVIDER_* keys: {provider_env}"
+        );
+        assert!(
+            provider_env.contains(r#"COPILOT_PROVIDER_BEARER_TOKEN: "$(Setup.FOUNDRY_TOKEN)""#),
+            "provider env must carry the macro-valued credential: {provider_env}"
+        );
+        assert!(
+            !provider_env.contains("MY_VAR"),
+            "provider env must exclude non-provider keys: {provider_env}"
+        );
+        assert!(
+            !provider_env.contains("GITHUB_TOKEN"),
+            "provider env must not include the compiler-managed base env: {provider_env}"
+        );
+    }
+
+    #[test]
+    fn copilot_provider_env_empty_without_provider_keys() {
+        let (fm, _) = parse_markdown(
+            "---\nname: test\ndescription: test\nengine:\n  id: copilot\n  env:\n    MY_VAR: hi\n---\n",
+        ).unwrap();
+        assert!(copilot_provider_env(&fm.engine).unwrap().is_empty());
     }
 
     #[test]

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -587,6 +587,16 @@ fn copilot_env(engine_config: &EngineConfig) -> Result<String> {
 /// build typed `EnvValue`s directly — no render-to-YAML-then-reparse round-trip,
 /// and no implicit coupling between a quoting format and a re-parser. Each entry
 /// is validated with [`validate_engine_env_entry`], identical to the agent path.
+///
+/// **Scope note — two distinct provider-key sets, do not conflate:**
+/// - This function forwards **every** `COPILOT_PROVIDER_*` key (prefix match) to
+///   the detection step's env, so detection routes to the same provider as the
+///   agent (including non-credential config like `COPILOT_PROVIDER_TYPE` /
+///   `COPILOT_PROVIDER_WIRE_API`). Unknown extras are harmless — the CLI ignores
+///   keys it doesn't recognise.
+/// - The narrower [`COPILOT_BYOM_CREDENTIAL_ENV_KEYS`] set (via
+///   [`copilot_byom_credential_keys`]) drives BYOM *activation* and the AWF
+///   `--exclude-env` isolation flags — only the actual credential-bearing keys.
 pub fn copilot_provider_env(engine_config: &EngineConfig) -> Result<Vec<(String, String)>> {
     let Some(env_map) = engine_config.env() else {
         return Ok(Vec::new());

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -3,9 +3,9 @@ use anyhow::Result;
 use crate::compile::extensions::Declarations;
 use crate::compile::types::{CompileTarget, EngineConfig, FrontMatter, McpConfig};
 use crate::validate::{
-    contains_ado_expression, contains_newline, contains_pipeline_command, is_valid_arg,
-    is_valid_command_path, is_valid_env_var_name, is_valid_hostname, is_valid_identifier,
-    is_valid_version,
+    contains_ado_expression, contains_ado_template_expression, contains_newline,
+    contains_pipeline_command, is_valid_arg, is_valid_command_path, is_valid_env_var_name,
+    is_valid_hostname, is_valid_identifier, is_valid_version,
 };
 
 /// Flags that the compiler controls — user args must not attempt to override these.
@@ -36,6 +36,42 @@ pub const BLOCKED_ENV_KEYS: &[&str] = &[
     "LD_PRELOAD",
     "LD_LIBRARY_PATH",
 ];
+
+/// Copilot Bring Your Own Model / Key (BYOM/BYOK) provider env-var keys that are
+/// permitted to carry ADO macro (`$(...)`) / runtime (`$[...]`) expressions in
+/// `engine.env`. Every other key remains literal-only.
+///
+/// This mirrors gh-aw's `CopilotEngine.GetSupportedEnvVarKeys()` allowlist
+/// (`COPILOT_PROVIDER_*`), which gates dynamic provider credentials to a known
+/// set of keys rather than relaxing expression handling globally. Setting
+/// `COPILOT_PROVIDER_BASE_URL` activates BYOM mode so requests route to an
+/// external Azure Copilot Foundry / OpenAI-compatible provider.
+///
+/// ADO **template** expressions (`${{ }}`) are still rejected for these keys —
+/// they are evaluated at compile time and have no secret-scoped analog — and
+/// pipeline-command injection (`##vso[`) / newline checks still apply.
+pub const COPILOT_PROVIDER_EXPR_ENV_KEYS: &[&str] = &[
+    "COPILOT_PROVIDER_BASE_URL",
+    "COPILOT_PROVIDER_API_KEY",
+    "COPILOT_PROVIDER_BEARER_TOKEN",
+    "COPILOT_PROVIDER_WIRE_API",
+];
+
+/// Returns true when `key` is an allowlisted BYOM/BYOK provider env-var key that
+/// may carry ADO macro/runtime expressions in `engine.env`.
+fn is_provider_expr_env_key(key: &str) -> bool {
+    COPILOT_PROVIDER_EXPR_ENV_KEYS
+        .iter()
+        .any(|allowed| key.eq_ignore_ascii_case(allowed))
+}
+
+/// Extract the hostname from a literal `COPILOT_PROVIDER_BASE_URL` value so it can
+/// be added to the AWF network allowlist. Returns `None` when the value is not a
+/// parseable absolute URL with a host.
+fn provider_base_url_host(base_url: &str) -> Option<String> {
+    let parsed = url::Url::parse(base_url.trim()).ok()?;
+    parsed.host_str().map(str::to_string)
+}
 
 /// Default model used by the Copilot engine when no model is specified in front matter.
 pub const DEFAULT_COPILOT_MODEL: &str = "claude-opus-4.7";
@@ -124,6 +160,21 @@ impl Engine {
                 let mut hosts = Vec::new();
                 if let Some(api_target) = engine_config.api_target() {
                     hosts.push(api_target.to_string());
+                }
+                // BYOM/BYOK: when COPILOT_PROVIDER_BASE_URL is a literal URL,
+                // add its hostname to the AWF allowlist so the agent can reach
+                // the external provider. When it is an ADO expression the
+                // concrete host is unknown at compile time, so the author must
+                // add it to `network.allowed` manually (mirrors gh-aw).
+                if let Some(env_map) = engine_config.env()
+                    && let Some(base_url) = env_map
+                        .iter()
+                        .find(|(k, _)| k.eq_ignore_ascii_case("COPILOT_PROVIDER_BASE_URL"))
+                        .map(|(_, v)| v)
+                    && !contains_ado_expression(base_url)
+                    && let Some(host) = provider_base_url_host(base_url)
+                {
+                    hosts.push(host);
                 }
                 hosts
             }
@@ -491,11 +542,26 @@ fn copilot_env(engine_config: &EngineConfig) -> Result<String> {
                     key
                 );
             }
-            if contains_ado_expression(value) {
+            // Allowlisted BYOM/BYOK provider keys may carry ADO macro/runtime
+            // expressions (e.g. `$(Setup.FOUNDRY_TOKEN)`) so credentials can be
+            // sourced from Setup-job outputs or pipeline variables. They still
+            // may not carry compile-time template expressions (`${{ }}`).
+            // Every other key remains literal-only.
+            if is_provider_expr_env_key(key) {
+                if contains_ado_template_expression(value) {
+                    anyhow::bail!(
+                        "engine.env value for '{}' contains an ADO template expression ('${{{{}}}}'). \
+                         Provider keys may use macro/runtime expressions ('$(...)' or '$[...]') only.",
+                        key
+                    );
+                }
+            } else if contains_ado_expression(value) {
                 anyhow::bail!(
                     "engine.env value for '{}' contains ADO expression syntax ('$(' or '${{{{}}}}')). \
-                     Use literal values only — ADO macro/expression expansion is not allowed.",
-                    key
+                     Use literal values only — ADO macro/expression expansion is not allowed \
+                     (allowed for BYOM provider keys: {}).",
+                    key,
+                    COPILOT_PROVIDER_EXPR_ENV_KEYS.join(", ")
                 );
             }
             if contains_newline(value) {
@@ -1103,6 +1169,101 @@ mod tests {
                 .unwrap_err()
                 .to_string()
                 .contains("ADO expression syntax")
+        );
+    }
+
+    #[test]
+    fn engine_env_allows_macro_on_provider_key() {
+        // BYOM/BYOK: provider keys may carry ADO macro expressions sourced from
+        // Setup-job outputs.
+        let (fm, _) = parse_markdown(
+            "---\nname: test\ndescription: test\nengine:\n  id: copilot\n  env:\n    COPILOT_PROVIDER_BEARER_TOKEN: \"$(Setup.FOUNDRY_TOKEN)\"\n---\n",
+        ).unwrap();
+        let env = Engine::Copilot.env(&fm.engine).unwrap();
+        assert!(
+            env.contains(r#"COPILOT_PROVIDER_BEARER_TOKEN: "$(Setup.FOUNDRY_TOKEN)""#),
+            "provider key macro expression should be emitted verbatim: {env}"
+        );
+    }
+
+    #[test]
+    fn engine_env_allows_runtime_expr_on_provider_key() {
+        let (fm, _) = parse_markdown(
+            "---\nname: test\ndescription: test\nengine:\n  id: copilot\n  env:\n    COPILOT_PROVIDER_API_KEY: \"$[ variables.Key ]\"\n---\n",
+        ).unwrap();
+        let env = Engine::Copilot.env(&fm.engine).unwrap();
+        assert!(env.contains(r#"COPILOT_PROVIDER_API_KEY: "$[ variables.Key ]""#));
+    }
+
+    #[test]
+    fn engine_env_provider_key_rejects_template_expression() {
+        // Compile-time template expressions remain forbidden even on provider keys.
+        let (fm, _) = parse_markdown(
+            "---\nname: test\ndescription: test\nengine:\n  id: copilot\n  env:\n    COPILOT_PROVIDER_API_KEY: \"${{ variables.Key }}\"\n---\n",
+        ).unwrap();
+        let result = Engine::Copilot.env(&fm.engine);
+        assert!(result.is_err());
+        assert!(
+            result
+                .unwrap_err()
+                .to_string()
+                .contains("ADO template expression")
+        );
+    }
+
+    #[test]
+    fn engine_env_provider_key_rejects_vso_injection() {
+        // Pipeline-command injection is still blocked on provider keys.
+        let (fm, _) = parse_markdown(
+            "---\nname: test\ndescription: test\nengine:\n  id: copilot\n  env:\n    COPILOT_PROVIDER_BASE_URL: \"##vso[task.setvariable]evil\"\n---\n",
+        ).unwrap();
+        let result = Engine::Copilot.env(&fm.engine);
+        assert!(result.is_err());
+        assert!(
+            result
+                .unwrap_err()
+                .to_string()
+                .contains("ADO pipeline command injection")
+        );
+    }
+
+    #[test]
+    fn engine_env_non_provider_key_still_rejects_macro() {
+        // A COPILOT_PROVIDER_* lookalike that is not on the allowlist is rejected.
+        let (fm, _) = parse_markdown(
+            "---\nname: test\ndescription: test\nengine:\n  id: copilot\n  env:\n    COPILOT_PROVIDER_TYPE: \"$(Setup.Type)\"\n---\n",
+        ).unwrap();
+        let result = Engine::Copilot.env(&fm.engine);
+        assert!(result.is_err());
+        assert!(
+            result
+                .unwrap_err()
+                .to_string()
+                .contains("ADO expression syntax")
+        );
+    }
+
+    #[test]
+    fn engine_env_literal_base_url_adds_required_host() {
+        let (fm, _) = parse_markdown(
+            "---\nname: test\ndescription: test\nengine:\n  id: copilot\n  env:\n    COPILOT_PROVIDER_BASE_URL: https://my-foundry.cognitiveservices.azure.com/openai/v1\n---\n",
+        ).unwrap();
+        let hosts = Engine::Copilot.required_hosts(&fm.engine);
+        assert!(
+            hosts.contains(&"my-foundry.cognitiveservices.azure.com".to_string()),
+            "literal base URL host should be added to allowlist: {hosts:?}"
+        );
+    }
+
+    #[test]
+    fn engine_env_expression_base_url_skips_required_host() {
+        let (fm, _) = parse_markdown(
+            "---\nname: test\ndescription: test\nengine:\n  id: copilot\n  env:\n    COPILOT_PROVIDER_BASE_URL: \"$(Setup.BASE_URL)\"\n---\n",
+        ).unwrap();
+        let hosts = Engine::Copilot.required_hosts(&fm.engine);
+        assert!(
+            hosts.is_empty(),
+            "expression-valued base URL must not contribute a host: {hosts:?}"
         );
     }
 

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -38,8 +38,8 @@ pub const BLOCKED_ENV_KEYS: &[&str] = &[
 ];
 
 /// Copilot Bring Your Own Model / Key (BYOM/BYOK) provider env-var keys that are
-/// permitted to carry ADO macro (`$(...)`) / runtime (`$[...]`) expressions in
-/// `engine.env`. Every other key remains literal-only.
+/// permitted to carry an ADO **macro** (`$(...)`) expression in `engine.env`.
+/// Every other key remains literal-only.
 ///
 /// This mirrors gh-aw's `CopilotEngine.GetSupportedEnvVarKeys()` allowlist
 /// (`COPILOT_PROVIDER_*`), which gates dynamic provider credentials to a known
@@ -47,9 +47,18 @@ pub const BLOCKED_ENV_KEYS: &[&str] = &[
 /// `COPILOT_PROVIDER_BASE_URL` activates BYOM mode so requests route to an
 /// external Azure Copilot Foundry / OpenAI-compatible provider.
 ///
-/// ADO **template** expressions (`${{ }}`) are still rejected for these keys —
-/// they are evaluated at compile time and have no secret-scoped analog — and
-/// pipeline-command injection (`##vso[`) / newline checks still apply.
+/// Only ADO **macros** `$(...)` are allowed — they are the sole expression form
+/// ADO evaluates inside a step `env:` block. Template expressions (`${{ }}`,
+/// compile-time, no secret-scoped analog) and runtime expressions (`$[ ... ]`,
+/// not evaluated in step env — passed verbatim, see #1076) are rejected, as are
+/// pipeline-command injection (`##vso[`) and newlines.
+///
+/// Matching against these keys is **case-sensitive** (exact), unlike the
+/// case-insensitive [`BLOCKED_ENV_KEYS`]: the Copilot CLI only reads the
+/// canonical uppercase `COPILOT_PROVIDER_*` names, so a lowercase lookalike is
+/// never a usable provider var. Requiring exact case fails closed — a lowercase
+/// `copilot_provider_api_key` carrying an expression is rejected with a clear
+/// error rather than half-activating BYOM and then silently breaking at runtime.
 pub const COPILOT_PROVIDER_EXPR_ENV_KEYS: &[&str] = &[
     "COPILOT_PROVIDER_BASE_URL",
     "COPILOT_PROVIDER_API_KEY",
@@ -57,12 +66,15 @@ pub const COPILOT_PROVIDER_EXPR_ENV_KEYS: &[&str] = &[
     "COPILOT_PROVIDER_WIRE_API",
 ];
 
+/// Case-sensitive prefix shared by every BYOM provider env-var key. Used to
+/// select the provider subset for the Detection step.
+const COPILOT_PROVIDER_PREFIX: &str = "COPILOT_PROVIDER_";
+
 /// Returns true when `key` is an allowlisted BYOM/BYOK provider env-var key that
-/// may carry ADO macro/runtime expressions in `engine.env`.
+/// may carry ADO macro/runtime expressions in `engine.env`. Case-sensitive: see
+/// [`COPILOT_PROVIDER_EXPR_ENV_KEYS`] for why exact case is required.
 fn is_provider_expr_env_key(key: &str) -> bool {
-    COPILOT_PROVIDER_EXPR_ENV_KEYS
-        .iter()
-        .any(|allowed| key.eq_ignore_ascii_case(allowed))
+    COPILOT_PROVIDER_EXPR_ENV_KEYS.contains(&key)
 }
 
 /// BYOM/BYOK provider **credential** env keys. Their presence in `engine.env`
@@ -72,8 +84,12 @@ fn is_provider_expr_env_key(key: &str) -> bool {
 /// the raw value never reaches the agent via `--env-all` passthrough
 /// (defense-in-depth; AWF also overrides them with placeholders).
 ///
-/// Note this is the credential subset of [`COPILOT_PROVIDER_EXPR_ENV_KEYS`] —
-/// it excludes the non-sensitive `COPILOT_PROVIDER_WIRE_API` config key.
+/// This is the credential subset of [`COPILOT_PROVIDER_EXPR_ENV_KEYS`]:
+/// `COPILOT_PROVIDER_WIRE_API` is **deliberately excluded** because it is
+/// non-sensitive wire-format config, not a credential. Consequently a workflow
+/// that only sets `COPILOT_PROVIDER_WIRE_API` dynamically may carry an expression
+/// on it (it is in the expression allowlist) without activating the api-proxy
+/// sidecar — which is correct, since there is no credential to isolate.
 pub const COPILOT_BYOM_CREDENTIAL_ENV_KEYS: &[&str] = &[
     "COPILOT_PROVIDER_BASE_URL",
     "COPILOT_PROVIDER_API_KEY",
@@ -83,39 +99,26 @@ pub const COPILOT_BYOM_CREDENTIAL_ENV_KEYS: &[&str] = &[
 /// Returns true when `engine.env` activates Copilot BYOM/BYOK mode — i.e. any
 /// provider credential / base-URL key is present. Used by the pipeline compiler
 /// to enable the AWF api-proxy sidecar (`--enable-api-proxy`) for credential
-/// isolation and to pre-pull the api-proxy container image.
+/// isolation and to pre-pull the api-proxy container image. Case-sensitive.
 pub fn copilot_byom_active(engine_config: &EngineConfig) -> bool {
     engine_config.env().is_some_and(|env| {
-        env.keys().any(|key| {
-            COPILOT_BYOM_CREDENTIAL_ENV_KEYS
-                .iter()
-                .any(|cred| key.eq_ignore_ascii_case(cred))
-        })
+        env.keys()
+            .any(|key| COPILOT_BYOM_CREDENTIAL_ENV_KEYS.contains(&key.as_str()))
     })
 }
 
-/// Return the **actual** `engine.env` keys (in the user's original casing) that
-/// match a BYOM credential key case-insensitively. These are the keys that must
-/// be passed to AWF's `--exclude-env` so the raw credential is kept out of the
-/// `--env-all` passthrough.
-///
-/// Case matters: env-var names are case-sensitive on Linux and AWF matches
-/// `--exclude-env` by exact name. Detection ([`copilot_byom_active`]) is
-/// case-insensitive so isolation always activates when a provider key is clearly
-/// intended, but the exclusion list must use the exact key the user wrote —
-/// otherwise a key like `copilot_provider_api_key` would activate the sidecar yet
-/// still leak into the agent container. Sorted for deterministic output.
+/// Return the BYOM credential env keys present in `engine.env`, sorted. These are
+/// passed to AWF's `--exclude-env` so the raw credential is kept out of the
+/// `--env-all` passthrough. Matching is case-sensitive (exact), so the emitted
+/// `--exclude-env <key>` always names the canonical uppercase key AWF and the
+/// Copilot CLI actually use.
 pub fn copilot_byom_credential_keys(engine_config: &EngineConfig) -> Vec<String> {
     let Some(env_map) = engine_config.env() else {
         return Vec::new();
     };
     let mut keys: Vec<String> = env_map
         .keys()
-        .filter(|key| {
-            COPILOT_BYOM_CREDENTIAL_ENV_KEYS
-                .iter()
-                .any(|cred| key.eq_ignore_ascii_case(cred))
-        })
+        .filter(|key| COPILOT_BYOM_CREDENTIAL_ENV_KEYS.contains(&key.as_str()))
         .cloned()
         .collect();
     keys.sort();
@@ -226,7 +229,7 @@ impl Engine {
                 if let Some(env_map) = engine_config.env()
                     && let Some(base_url) = env_map
                         .iter()
-                        .find(|(k, _)| k.eq_ignore_ascii_case("COPILOT_PROVIDER_BASE_URL"))
+                        .find(|(k, _)| k.as_str() == "COPILOT_PROVIDER_BASE_URL")
                         .map(|(_, v)| v)
                     && !contains_ado_expression(base_url)
                     && let Some(host) = provider_base_url_host(base_url)
@@ -584,10 +587,7 @@ pub fn copilot_provider_env(engine_config: &EngineConfig) -> Result<String> {
     };
     let mut keys: Vec<&String> = env_map
         .keys()
-        .filter(|k| {
-            k.get(..17)
-                .is_some_and(|prefix| prefix.eq_ignore_ascii_case("COPILOT_PROVIDER_"))
-        })
+        .filter(|k| k.starts_with(COPILOT_PROVIDER_PREFIX))
         .collect();
     keys.sort();
 
@@ -601,7 +601,7 @@ pub fn copilot_provider_env(engine_config: &EngineConfig) -> Result<String> {
 /// Validate a single `engine.env` entry and render it as a YAML `KEY: "VALUE"`
 /// line. Enforces env-var-name rules, blocks compiler-controlled keys, rejects
 /// pipeline-command injection / newlines, and applies the BYOM provider
-/// expression allowlist (allowlisted keys may carry `$(...)`/`$[...]`; all
+/// expression allowlist (allowlisted keys may carry an ADO macro `$(...)`; all
 /// others are literal-only). Shared by [`copilot_env`] and
 /// [`copilot_provider_env`] so both paths validate identically.
 fn render_engine_env_entry(key: &str, value: &str) -> Result<String> {
@@ -644,16 +644,22 @@ fn render_engine_env_entry(key: &str, value: &str) -> Result<String> {
             key
         );
     }
-    // Allowlisted BYOM/BYOK provider keys may carry ADO macro/runtime
-    // expressions (e.g. `$(Setup.FOUNDRY_TOKEN)`) so credentials can be
-    // sourced from Setup-job outputs or pipeline variables. They still
-    // may not carry compile-time template expressions (`${{ }}`).
+    // Allowlisted BYOM/BYOK provider keys may carry an ADO **macro** expression
+    // (e.g. `$(Setup.FOUNDRY_TOKEN)`) so credentials can be sourced from
+    // Setup-job outputs or pipeline variables. Macros are the only expression
+    // form ADO evaluates inside a step `env:` block. They may NOT carry:
+    //   - template expressions `${{ }}` — expanded at compile time (secret
+    //     exfiltration risk), and
+    //   - runtime expressions `$[ ... ]` — ADO does *not* evaluate these inside
+    //     step env; the literal string is passed verbatim (see ir::lower guard
+    //     and #1076), so permitting them would silently ship a broken value.
     // Every other key remains literal-only.
     if is_provider_expr_env_key(key) {
-        if contains_ado_template_expression(value) {
+        if contains_ado_template_expression(value) || value.contains("$[") {
             anyhow::bail!(
-                "engine.env value for '{}' contains an ADO template expression '${{{{ }}}}'. \
-                 Provider keys may use macro '$(...)' or runtime '$[...]' expressions only.",
+                "engine.env value for '{}' contains an ADO template ('${{{{ }}}}') or \
+                 runtime ('$[...]') expression. Provider keys may use macro '$(...)' \
+                 expressions only (ADO does not evaluate '${{{{ }}}}' or '$[...]' inside step env).",
                 key
             );
         }
@@ -1289,12 +1295,21 @@ mod tests {
     }
 
     #[test]
-    fn engine_env_allows_runtime_expr_on_provider_key() {
+    fn engine_env_rejects_runtime_expr_on_provider_key() {
+        // ADO runtime expressions `$[ ... ]` are NOT evaluated inside step env
+        // (passed verbatim, see #1076), so they are rejected even on provider
+        // keys — only macros `$(...)` are permitted.
         let (fm, _) = parse_markdown(
             "---\nname: test\ndescription: test\nengine:\n  id: copilot\n  env:\n    COPILOT_PROVIDER_API_KEY: \"$[ variables.Key ]\"\n---\n",
         ).unwrap();
-        let env = Engine::Copilot.env(&fm.engine).unwrap();
-        assert!(env.contains(r#"COPILOT_PROVIDER_API_KEY: "$[ variables.Key ]""#));
+        let result = Engine::Copilot.env(&fm.engine);
+        assert!(result.is_err());
+        assert!(
+            result
+                .unwrap_err()
+                .to_string()
+                .contains("runtime ('$[...]') expression")
+        );
     }
 
     #[test]
@@ -1334,14 +1349,42 @@ mod tests {
     }
 
     #[test]
-    fn copilot_byom_credential_keys_preserves_user_casing() {
-        // Exact provider credential keys are returned in the user's casing,
-        // sorted; non-credential and non-provider keys are excluded.
+    fn copilot_byom_credential_keys_returns_present_keys() {
+        // Only the credential keys present are returned (sorted); the
+        // non-credential WIRE_API and unrelated vars are excluded.
         let (fm, _) = parse_markdown(
             "---\nname: test\ndescription: test\nengine:\n  id: copilot\n  env:\n    COPILOT_PROVIDER_BASE_URL: https://x/y\n    COPILOT_PROVIDER_WIRE_API: responses\n    MY_VAR: hi\n---\n",
         ).unwrap();
         let keys = copilot_byom_credential_keys(&fm.engine);
         assert_eq!(keys, vec!["COPILOT_PROVIDER_BASE_URL".to_string()]);
+    }
+
+    #[test]
+    fn provider_key_matching_is_case_sensitive() {
+        // A lowercase provider key is NOT a real Copilot provider var (the CLI
+        // reads uppercase). It must not activate BYOM, must not appear in the
+        // exclude list, and — carrying an expression — must be rejected as a
+        // normal literal-only key (fail-closed, no silent runtime break).
+        let (fm, _) = parse_markdown(
+            "---\nname: test\ndescription: test\nengine:\n  id: copilot\n  env:\n    copilot_provider_api_key: literal-value\n---\n",
+        ).unwrap();
+        assert!(
+            !copilot_byom_active(&fm.engine),
+            "lowercase provider key must not activate BYOM"
+        );
+        assert!(
+            copilot_byom_credential_keys(&fm.engine).is_empty(),
+            "lowercase provider key must not appear in the exclude list"
+        );
+
+        let (fm_expr, _) = parse_markdown(
+            "---\nname: test\ndescription: test\nengine:\n  id: copilot\n  env:\n    copilot_provider_api_key: \"$(Setup.Key)\"\n---\n",
+        ).unwrap();
+        let result = Engine::Copilot.env(&fm_expr.engine);
+        assert!(
+            result.is_err(),
+            "lowercase provider key carrying an expression must be rejected (not silently allowed)"
+        );
     }
 
     #[test]
@@ -1410,7 +1453,7 @@ mod tests {
             result
                 .unwrap_err()
                 .to_string()
-                .contains("ADO template expression")
+                .contains("ADO template ('${{ }}') or")
         );
     }
 

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -133,6 +133,53 @@ fn provider_base_url_host(base_url: &str) -> Option<String> {
     parsed.host_str().map(str::to_string)
 }
 
+/// Outcome of resolving `COPILOT_PROVIDER_BASE_URL` into an AWF-allowlist host.
+///
+/// Single source of truth shared by [`Engine::required_hosts`] (which consumes
+/// the `Host` case) and [`Engine::network_host_warnings`] (which surfaces the
+/// `Unresolved` case as a compile warning), so the two paths can never diverge.
+enum ProviderBaseUrlHost {
+    /// No literal base URL to resolve: the key is absent, or its value is an ADO
+    /// expression (documented as requiring a manual `network.allowed` entry — not
+    /// a surprising silent drop).
+    None,
+    /// A literal URL that parsed to a DNS-safe host — added to the allowlist.
+    Host(String),
+    /// A literal value that is **not** a parseable absolute URL, or whose host is
+    /// not DNS-safe (e.g. an IPv6 literal). Not added — the author must add the
+    /// provider hostname manually. Surfaced as a warning so the misconfiguration
+    /// is visible at compile time rather than failing at runtime with a firewall
+    /// block.
+    Unresolved(String),
+}
+
+/// Classify the literal `COPILOT_PROVIDER_BASE_URL` in `engine_config.env` into a
+/// [`ProviderBaseUrlHost`]. Case-sensitive key match (canonical uppercase).
+fn resolve_provider_base_url_host(engine_config: &EngineConfig) -> ProviderBaseUrlHost {
+    let Some(env_map) = engine_config.env() else {
+        return ProviderBaseUrlHost::None;
+    };
+    let Some(base_url) = env_map
+        .iter()
+        .find(|(k, _)| k.as_str() == "COPILOT_PROVIDER_BASE_URL")
+        .map(|(_, v)| v)
+    else {
+        return ProviderBaseUrlHost::None;
+    };
+    // Expression-valued base URLs resolve to an unknown host at compile time;
+    // the author adds the host to `network.allowed` (documented) — no warning.
+    if contains_ado_expression(base_url) {
+        return ProviderBaseUrlHost::None;
+    }
+    match provider_base_url_host(base_url) {
+        // Validate the parsed host with the same DNS-safe check the api-target
+        // path uses, so non-DNS-safe hosts (e.g. an IPv6 literal `::1`, or an
+        // IDN) never land in `--allow-domains`.
+        Some(host) if is_valid_hostname(&host) => ProviderBaseUrlHost::Host(host),
+        _ => ProviderBaseUrlHost::Unresolved(base_url.clone()),
+    }
+}
+
 /// Default model used by the Copilot engine when no model is specified in front matter.
 pub const DEFAULT_COPILOT_MODEL: &str = "claude-opus-4.7";
 
@@ -223,25 +270,38 @@ impl Engine {
                 }
                 // BYOM/BYOK: when COPILOT_PROVIDER_BASE_URL is a literal URL,
                 // add its hostname to the AWF allowlist so the agent can reach
-                // the external provider. When it is an ADO expression the
-                // concrete host is unknown at compile time, so the author must
-                // add it to `network.allowed` manually (mirrors gh-aw).
-                if let Some(env_map) = engine_config.env()
-                    && let Some(base_url) = env_map
-                        .iter()
-                        .find(|(k, _)| k.as_str() == "COPILOT_PROVIDER_BASE_URL")
-                        .map(|(_, v)| v)
-                    && !contains_ado_expression(base_url)
-                    && let Some(host) = provider_base_url_host(base_url)
-                    // Validate the parsed host with the same DNS-safe check the
-                    // api-target path uses, so non-DNS-safe hosts (e.g. an IPv6
-                    // literal `::1`, or an IDN) never land in `--allow-domains`.
-                    && is_valid_hostname(&host)
+                // the external provider. Expression-valued or malformed URLs
+                // resolve to `None`/`Unresolved` and are handled elsewhere
+                // (`network_host_warnings` surfaces the malformed case).
+                if let ProviderBaseUrlHost::Host(host) =
+                    resolve_provider_base_url_host(engine_config)
                 {
                     hosts.push(host);
                 }
                 hosts
             }
+        }
+    }
+
+    /// Non-fatal compile-time warnings about network-host resolution.
+    ///
+    /// Currently surfaces the case where a **literal** `COPILOT_PROVIDER_BASE_URL`
+    /// could not be resolved to a DNS-safe host (malformed URL, missing scheme, or
+    /// an IPv6/IDN host). Without this the host would be silently dropped from the
+    /// AWF allowlist and the agent would fail at runtime with a firewall block,
+    /// contradicting the documented promise that a literal base URL is added
+    /// automatically. The compile stays non-fatal; the operator is told to add the
+    /// host via `network.allowed`.
+    pub fn network_host_warnings(&self, engine_config: &EngineConfig) -> Vec<String> {
+        match self {
+            Engine::Copilot => match resolve_provider_base_url_host(engine_config) {
+                ProviderBaseUrlHost::Unresolved(value) => vec![format!(
+                    "COPILOT_PROVIDER_BASE_URL: '{value}' is not a parseable absolute URL \
+                     (or its host is not DNS-safe); the host was not added to the AWF \
+                     allowlist — add the provider hostname manually via network.allowed."
+                )],
+                ProviderBaseUrlHost::None | ProviderBaseUrlHost::Host(_) => Vec::new(),
+            },
         }
     }
 
@@ -1531,6 +1591,58 @@ mod tests {
             hosts.is_empty(),
             "expression-valued base URL must not contribute a host: {hosts:?}"
         );
+    }
+
+    #[test]
+    fn engine_env_malformed_base_url_warns() {
+        // A literal but scheme-less / unparseable URL must not silently drop:
+        // required_hosts adds nothing AND a warning is surfaced.
+        let (fm, _) = parse_markdown(
+            "---\nname: test\ndescription: test\nengine:\n  id: copilot\n  env:\n    COPILOT_PROVIDER_BASE_URL: my-foundry/openai/v1\n---\n",
+        ).unwrap();
+        assert!(
+            Engine::Copilot.required_hosts(&fm.engine).is_empty(),
+            "malformed base URL must not contribute a host"
+        );
+        let warnings = Engine::Copilot.network_host_warnings(&fm.engine);
+        assert_eq!(warnings.len(), 1, "expected one warning: {warnings:?}");
+        assert!(
+            warnings[0].contains("COPILOT_PROVIDER_BASE_URL")
+                && warnings[0].contains("my-foundry/openai/v1")
+                && warnings[0].contains("network.allowed"),
+            "warning must name the key, the bad value, and the network.allowed fix: {warnings:?}"
+        );
+    }
+
+    #[test]
+    fn engine_env_ipv6_base_url_warns() {
+        // Non-DNS-safe host (IPv6 literal) is also surfaced, not silently dropped.
+        let (fm, _) = parse_markdown(
+            "---\nname: test\ndescription: test\nengine:\n  id: copilot\n  env:\n    COPILOT_PROVIDER_BASE_URL: \"http://[::1]:8080/v1\"\n---\n",
+        ).unwrap();
+        assert!(Engine::Copilot.required_hosts(&fm.engine).is_empty());
+        assert_eq!(Engine::Copilot.network_host_warnings(&fm.engine).len(), 1);
+    }
+
+    #[test]
+    fn engine_env_no_warning_for_valid_or_expression_or_absent_base_url() {
+        // Valid literal → host added, no warning.
+        let (fm_ok, _) = parse_markdown(
+            "---\nname: test\ndescription: test\nengine:\n  id: copilot\n  env:\n    COPILOT_PROVIDER_BASE_URL: https://x.example.com/v1\n---\n",
+        ).unwrap();
+        assert!(Engine::Copilot.network_host_warnings(&fm_ok.engine).is_empty());
+
+        // Expression-valued → documented manual path, no warning.
+        let (fm_expr, _) = parse_markdown(
+            "---\nname: test\ndescription: test\nengine:\n  id: copilot\n  env:\n    COPILOT_PROVIDER_BASE_URL: \"$(Setup.BASE_URL)\"\n---\n",
+        ).unwrap();
+        assert!(Engine::Copilot.network_host_warnings(&fm_expr.engine).is_empty());
+
+        // Absent → no warning.
+        let (fm_none, _) =
+            parse_markdown("---\nname: test\ndescription: test\nengine:\n  id: copilot\n---\n")
+                .unwrap();
+        assert!(Engine::Copilot.network_host_warnings(&fm_none.engine).is_empty());
     }
 
     #[test]

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -65,6 +65,35 @@ fn is_provider_expr_env_key(key: &str) -> bool {
         .any(|allowed| key.eq_ignore_ascii_case(allowed))
 }
 
+/// BYOM/BYOK provider **credential** env keys. Their presence in `engine.env`
+/// activates BYOM mode and, in turn, the AWF api-proxy sidecar that holds the
+/// real credential and injects it only at the proxy layer — keeping it out of
+/// the agent container. These are also passed as AWF `--exclude-env` flags so
+/// the raw value never reaches the agent via `--env-all` passthrough
+/// (defense-in-depth; AWF also overrides them with placeholders).
+///
+/// Note this is the credential subset of [`COPILOT_PROVIDER_EXPR_ENV_KEYS`] —
+/// it excludes the non-sensitive `COPILOT_PROVIDER_WIRE_API` config key.
+pub const COPILOT_BYOM_CREDENTIAL_ENV_KEYS: &[&str] = &[
+    "COPILOT_PROVIDER_BASE_URL",
+    "COPILOT_PROVIDER_API_KEY",
+    "COPILOT_PROVIDER_BEARER_TOKEN",
+];
+
+/// Returns true when `engine.env` activates Copilot BYOM/BYOK mode — i.e. any
+/// provider credential / base-URL key is present. Used by the pipeline compiler
+/// to enable the AWF api-proxy sidecar (`--enable-api-proxy`) for credential
+/// isolation and to pre-pull the api-proxy container image.
+pub fn copilot_byom_active(engine_config: &EngineConfig) -> bool {
+    engine_config.env().is_some_and(|env| {
+        env.keys().any(|key| {
+            COPILOT_BYOM_CREDENTIAL_ENV_KEYS
+                .iter()
+                .any(|cred| key.eq_ignore_ascii_case(cred))
+        })
+    })
+}
+
 /// Extract the hostname from a literal `COPILOT_PROVIDER_BASE_URL` value so it can
 /// be added to the AWF network allowlist. Returns `None` when the value is not a
 /// parseable absolute URL with a host.
@@ -804,7 +833,7 @@ fn copilot_invocation(
 
 #[cfg(test)]
 mod tests {
-    use super::{Engine, get_engine, normalize_version_tag};
+    use super::{Engine, copilot_byom_active, get_engine, normalize_version_tag};
     use crate::compile::{
         extensions::{CompileContext, CompilerExtension, Declarations, collect_extensions},
         parse_markdown,
@@ -1193,6 +1222,42 @@ mod tests {
         ).unwrap();
         let env = Engine::Copilot.env(&fm.engine).unwrap();
         assert!(env.contains(r#"COPILOT_PROVIDER_API_KEY: "$[ variables.Key ]""#));
+    }
+
+    #[test]
+    fn copilot_byom_active_detects_credential_keys() {
+        for key in [
+            "COPILOT_PROVIDER_BASE_URL",
+            "COPILOT_PROVIDER_API_KEY",
+            "COPILOT_PROVIDER_BEARER_TOKEN",
+        ] {
+            let md = format!(
+                "---\nname: test\ndescription: test\nengine:\n  id: copilot\n  env:\n    {key}: value\n---\n"
+            );
+            let (fm, _) = parse_markdown(&md).unwrap();
+            assert!(
+                copilot_byom_active(&fm.engine),
+                "BYOM should be active when {key} is present"
+            );
+        }
+    }
+
+    #[test]
+    fn copilot_byom_inactive_without_credential_keys() {
+        // No env at all.
+        let (fm, _) =
+            parse_markdown("---\nname: test\ndescription: test\nengine:\n  id: copilot\n---\n")
+                .unwrap();
+        assert!(!copilot_byom_active(&fm.engine));
+
+        // Only the non-credential WIRE_API config key and an unrelated var.
+        let (fm2, _) = parse_markdown(
+            "---\nname: test\ndescription: test\nengine:\n  id: copilot\n  env:\n    COPILOT_PROVIDER_WIRE_API: responses\n    MY_VAR: hi\n---\n",
+        ).unwrap();
+        assert!(
+            !copilot_byom_active(&fm2.engine),
+            "WIRE_API alone must not activate BYOM (it is non-credential config)"
+        );
     }
 
     #[test]

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -94,6 +94,34 @@ pub fn copilot_byom_active(engine_config: &EngineConfig) -> bool {
     })
 }
 
+/// Return the **actual** `engine.env` keys (in the user's original casing) that
+/// match a BYOM credential key case-insensitively. These are the keys that must
+/// be passed to AWF's `--exclude-env` so the raw credential is kept out of the
+/// `--env-all` passthrough.
+///
+/// Case matters: env-var names are case-sensitive on Linux and AWF matches
+/// `--exclude-env` by exact name. Detection ([`copilot_byom_active`]) is
+/// case-insensitive so isolation always activates when a provider key is clearly
+/// intended, but the exclusion list must use the exact key the user wrote —
+/// otherwise a key like `copilot_provider_api_key` would activate the sidecar yet
+/// still leak into the agent container. Sorted for deterministic output.
+pub fn copilot_byom_credential_keys(engine_config: &EngineConfig) -> Vec<String> {
+    let Some(env_map) = engine_config.env() else {
+        return Vec::new();
+    };
+    let mut keys: Vec<String> = env_map
+        .keys()
+        .filter(|key| {
+            COPILOT_BYOM_CREDENTIAL_ENV_KEYS
+                .iter()
+                .any(|cred| key.eq_ignore_ascii_case(cred))
+        })
+        .cloned()
+        .collect();
+    keys.sort();
+    keys
+}
+
 /// Extract the hostname from a literal `COPILOT_PROVIDER_BASE_URL` value so it can
 /// be added to the AWF network allowlist. Returns `None` when the value is not a
 /// parseable absolute URL with a host.
@@ -202,6 +230,10 @@ impl Engine {
                         .map(|(_, v)| v)
                     && !contains_ado_expression(base_url)
                     && let Some(host) = provider_base_url_host(base_url)
+                    // Validate the parsed host with the same DNS-safe check the
+                    // api-target path uses, so non-DNS-safe hosts (e.g. an IPv6
+                    // literal `::1`, or an IDN) never land in `--allow-domains`.
+                    && is_valid_hostname(&host)
                 {
                     hosts.push(host);
                 }
@@ -620,14 +652,15 @@ fn render_engine_env_entry(key: &str, value: &str) -> Result<String> {
     if is_provider_expr_env_key(key) {
         if contains_ado_template_expression(value) {
             anyhow::bail!(
-                "engine.env value for '{}' contains an ADO template expression ('${{{{}}}}'). \
-                 Provider keys may use macro/runtime expressions ('$(...)' or '$[...]') only.",
+                "engine.env value for '{}' contains an ADO template expression '${{{{ }}}}'. \
+                 Provider keys may use macro '$(...)' or runtime '$[...]' expressions only.",
                 key
             );
         }
     } else if contains_ado_expression(value) {
         anyhow::bail!(
-            "engine.env value for '{}' contains ADO expression syntax ('$(' or '${{{{}}}}')). \
+            "engine.env value for '{}' contains an ADO expression \
+             (one of '$(...)', '${{{{ }}}}', or '$[...]'). \
              Use literal values only — ADO macro/expression expansion is not allowed \
              (allowed for BYOM provider keys: {}).",
             key,
@@ -871,7 +904,8 @@ fn copilot_invocation(
 #[cfg(test)]
 mod tests {
     use super::{
-        Engine, copilot_byom_active, copilot_provider_env, get_engine, normalize_version_tag,
+        Engine, copilot_byom_active, copilot_byom_credential_keys, copilot_provider_env,
+        get_engine, normalize_version_tag,
     };
     use crate::compile::{
         extensions::{CompileContext, CompilerExtension, Declarations, collect_extensions},
@@ -1236,7 +1270,7 @@ mod tests {
             result
                 .unwrap_err()
                 .to_string()
-                .contains("ADO expression syntax")
+                .contains("contains an ADO expression")
         );
     }
 
@@ -1296,6 +1330,39 @@ mod tests {
         assert!(
             !copilot_byom_active(&fm2.engine),
             "WIRE_API alone must not activate BYOM (it is non-credential config)"
+        );
+    }
+
+    #[test]
+    fn copilot_byom_credential_keys_preserves_user_casing() {
+        // Exact provider credential keys are returned in the user's casing,
+        // sorted; non-credential and non-provider keys are excluded.
+        let (fm, _) = parse_markdown(
+            "---\nname: test\ndescription: test\nengine:\n  id: copilot\n  env:\n    COPILOT_PROVIDER_BASE_URL: https://x/y\n    COPILOT_PROVIDER_WIRE_API: responses\n    MY_VAR: hi\n---\n",
+        ).unwrap();
+        let keys = copilot_byom_credential_keys(&fm.engine);
+        assert_eq!(keys, vec!["COPILOT_PROVIDER_BASE_URL".to_string()]);
+    }
+
+    #[test]
+    fn copilot_byom_credential_keys_empty_without_provider() {
+        let (fm, _) = parse_markdown(
+            "---\nname: test\ndescription: test\nengine:\n  id: copilot\n  env:\n    MY_VAR: hi\n---\n",
+        ).unwrap();
+        assert!(copilot_byom_credential_keys(&fm.engine).is_empty());
+    }
+
+    #[test]
+    fn engine_expression_base_url_host_rejects_non_dns_safe() {
+        // An IPv6 literal parses to a host but is not DNS-safe, so it must not
+        // be added to the AWF allow-domains list (consistent with api-target).
+        let (fm, _) = parse_markdown(
+            "---\nname: test\ndescription: test\nengine:\n  id: copilot\n  env:\n    COPILOT_PROVIDER_BASE_URL: \"http://[::1]:8080/v1\"\n---\n",
+        ).unwrap();
+        let hosts = Engine::Copilot.required_hosts(&fm.engine);
+        assert!(
+            hosts.is_empty(),
+            "non-DNS-safe host (IPv6 literal) must be rejected from the allowlist: {hosts:?}"
         );
     }
 
@@ -1375,7 +1442,7 @@ mod tests {
             result
                 .unwrap_err()
                 .to_string()
-                .contains("ADO expression syntax")
+                .contains("contains an ADO expression")
         );
     }
 

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -572,8 +572,9 @@ fn copilot_env(engine_config: &EngineConfig) -> Result<String> {
     Ok(lines.join("\n"))
 }
 
-/// Render only the `COPILOT_PROVIDER_*` entries of `engine.env` as a YAML env
-/// block (`KEY: "VALUE"` lines, one per line; empty string when none present).
+/// Return the `COPILOT_PROVIDER_*` entries of `engine.env` as validated,
+/// **raw** `(key, value)` pairs (value un-rendered; empty vec when none present),
+/// sorted by key.
 ///
 /// Used by the Detection (threat-analysis) step so the detection Copilot run
 /// inherits the same BYOM/BYOK provider routing (and credential isolation) as
@@ -581,9 +582,14 @@ fn copilot_env(engine_config: &EngineConfig) -> Result<String> {
 /// main engine's `Env` (`threat_detection_inline_engine.go`). The main model is
 /// already threaded via the `--model` flag on the detection invocation, so only
 /// the provider routing/credential keys are needed here.
-pub fn copilot_provider_env(engine_config: &EngineConfig) -> Result<String> {
+///
+/// Returning raw pairs (rather than a rendered YAML string) lets the call site
+/// build typed `EnvValue`s directly — no render-to-YAML-then-reparse round-trip,
+/// and no implicit coupling between a quoting format and a re-parser. Each entry
+/// is validated with [`validate_engine_env_entry`], identical to the agent path.
+pub fn copilot_provider_env(engine_config: &EngineConfig) -> Result<Vec<(String, String)>> {
     let Some(env_map) = engine_config.env() else {
-        return Ok(String::new());
+        return Ok(Vec::new());
     };
     let mut keys: Vec<&String> = env_map
         .keys()
@@ -591,20 +597,22 @@ pub fn copilot_provider_env(engine_config: &EngineConfig) -> Result<String> {
         .collect();
     keys.sort();
 
-    let mut lines = Vec::new();
+    let mut pairs = Vec::with_capacity(keys.len());
     for key in keys {
-        lines.push(render_engine_env_entry(key, &env_map[key])?);
+        let value = &env_map[key];
+        validate_engine_env_entry(key, value)?;
+        pairs.push((key.clone(), value.clone()));
     }
-    Ok(lines.join("\n"))
+    Ok(pairs)
 }
 
-/// Validate a single `engine.env` entry and render it as a YAML `KEY: "VALUE"`
-/// line. Enforces env-var-name rules, blocks compiler-controlled keys, rejects
-/// pipeline-command injection / newlines, and applies the BYOM provider
-/// expression allowlist (allowlisted keys may carry an ADO macro `$(...)`; all
-/// others are literal-only). Shared by [`copilot_env`] and
-/// [`copilot_provider_env`] so both paths validate identically.
-fn render_engine_env_entry(key: &str, value: &str) -> Result<String> {
+/// Validate a single `engine.env` entry: enforces env-var-name rules, blocks
+/// compiler-controlled keys, rejects pipeline-command injection / newlines, and
+/// applies the BYOM provider expression allowlist (allowlisted keys may carry an
+/// ADO macro `$(...)`; all others are literal-only). Shared by
+/// [`render_engine_env_entry`] (agent path) and [`copilot_provider_env`]
+/// (detection path) so both validate identically.
+fn validate_engine_env_entry(key: &str, value: &str) -> Result<()> {
     // Validate key: must be a valid env var name
     if key.is_empty() {
         anyhow::bail!(
@@ -680,7 +688,13 @@ fn render_engine_env_entry(key: &str, value: &str) -> Result<String> {
             key
         );
     }
+    Ok(())
+}
 
+/// Validate a single `engine.env` entry and render it as a YAML `KEY: "VALUE"`
+/// line for the aggregated agent env block (see [`copilot_env`]).
+fn render_engine_env_entry(key: &str, value: &str) -> Result<String> {
+    validate_engine_env_entry(key, value)?;
     // YAML-quote the value to prevent injection
     Ok(format!(
         "{}: \"{}\"",
@@ -1410,26 +1424,22 @@ mod tests {
     }
 
     #[test]
-    fn copilot_provider_env_renders_only_provider_keys() {
+    fn copilot_provider_env_returns_only_provider_keys() {
         let (fm, _) = parse_markdown(
             "---\nname: test\ndescription: test\nengine:\n  id: copilot\n  env:\n    COPILOT_PROVIDER_TYPE: azure\n    COPILOT_PROVIDER_BEARER_TOKEN: \"$(Setup.FOUNDRY_TOKEN)\"\n    MY_VAR: keep-out\n---\n",
         ).unwrap();
-        let provider_env = copilot_provider_env(&fm.engine).unwrap();
-        assert!(
-            provider_env.contains(r#"COPILOT_PROVIDER_TYPE: "azure""#),
-            "provider env must include COPILOT_PROVIDER_* keys: {provider_env}"
-        );
-        assert!(
-            provider_env.contains(r#"COPILOT_PROVIDER_BEARER_TOKEN: "$(Setup.FOUNDRY_TOKEN)""#),
-            "provider env must carry the macro-valued credential: {provider_env}"
-        );
-        assert!(
-            !provider_env.contains("MY_VAR"),
-            "provider env must exclude non-provider keys: {provider_env}"
-        );
-        assert!(
-            !provider_env.contains("GITHUB_TOKEN"),
-            "provider env must not include the compiler-managed base env: {provider_env}"
+        let pairs = copilot_provider_env(&fm.engine).unwrap();
+        // Validated raw (key, value) pairs, sorted by key; non-provider and
+        // compiler-managed base env excluded.
+        assert_eq!(
+            pairs,
+            vec![
+                (
+                    "COPILOT_PROVIDER_BEARER_TOKEN".to_string(),
+                    "$(Setup.FOUNDRY_TOKEN)".to_string()
+                ),
+                ("COPILOT_PROVIDER_TYPE".to_string(), "azure".to_string()),
+            ]
         );
     }
 

--- a/tests/compiler_tests.rs
+++ b/tests/compiler_tests.rs
@@ -4832,25 +4832,43 @@ fn test_byom_provider_env_compiles_and_merges() {
 
     // Credential isolation: the AWF api-proxy sidecar is enabled and the
     // provider credential env keys are excluded from --env-all passthrough.
-    assert!(
-        compiled.contains("--enable-api-proxy"),
-        "BYOM must enable the AWF api-proxy sidecar for credential isolation: {compiled}"
+    // This must happen in BOTH the Agent and Detection jobs (the detection
+    // threat-analysis Copilot run inherits the same BYOM routing + isolation,
+    // mirroring gh-aw), so each marker appears exactly twice.
+    assert_eq!(
+        compiled.matches("--enable-api-proxy").count(),
+        2,
+        "BYOM must enable the AWF api-proxy sidecar in both the Agent and Detection jobs: {compiled}"
     );
     for key in [
         "--exclude-env COPILOT_PROVIDER_BASE_URL",
         "--exclude-env COPILOT_PROVIDER_API_KEY",
         "--exclude-env COPILOT_PROVIDER_BEARER_TOKEN",
     ] {
-        assert!(
-            compiled.contains(key),
-            "BYOM must exclude provider credential from agent passthrough ({key}): {compiled}"
+        assert_eq!(
+            compiled.matches(key).count(),
+            2,
+            "BYOM must exclude provider credential from passthrough in both jobs ({key}): {compiled}"
         );
     }
-    // The api-proxy container image must be pre-pulled (and :latest-tagged) so
-    // AWF's --skip-pull finds it locally.
-    assert!(
-        compiled.contains("docker pull ghcr.io/github/gh-aw-firewall/api-proxy:"),
-        "BYOM must pre-pull the api-proxy container image: {compiled}"
+    // The api-proxy container image must be pre-pulled (and :latest-tagged) in
+    // both jobs so AWF's --skip-pull finds it locally.
+    assert_eq!(
+        compiled
+            .matches("docker pull ghcr.io/github/gh-aw-firewall/api-proxy:")
+            .count(),
+        2,
+        "BYOM must pre-pull the api-proxy container image in both the Agent and Detection jobs: {compiled}"
+    );
+    // The Detection threat-analysis step inherits the provider routing env
+    // (COPILOT_PROVIDER_* subset) so it reaches the same external provider.
+    // The bearer-token macro therefore appears twice: agent step + detection step.
+    assert_eq!(
+        compiled
+            .matches("COPILOT_PROVIDER_BEARER_TOKEN: $(Setup.FOUNDRY_TOKEN)")
+            .count(),
+        2,
+        "Detection step must inherit the BYOM provider env alongside the agent step: {compiled}"
     );
 }
 

--- a/tests/compiler_tests.rs
+++ b/tests/compiler_tests.rs
@@ -4807,6 +4807,30 @@ fn test_executor_step_has_env_block_with_write_permissions() {
     );
 }
 
+/// Copilot BYOM/BYOK (#1261): provider env keys in `engine.env` may carry ADO
+/// macro expressions (e.g. `$(Setup.FOUNDRY_TOKEN)`), they are merged verbatim
+/// into the agent step's env block, and a literal `COPILOT_PROVIDER_BASE_URL`
+/// host is added to the AWF allow-domains list. Compilation must succeed and
+/// pass integrity checks (no `--skip-integrity`).
+#[test]
+fn test_byom_provider_env_compiles_and_merges() {
+    let compiled = compile_fixture("byom-foundry-agent.md");
+    assert_valid_yaml(&compiled, "byom-foundry-agent.md");
+
+    assert!(
+        compiled.contains("COPILOT_PROVIDER_BEARER_TOKEN: $(Setup.FOUNDRY_TOKEN)"),
+        "BYOM provider macro env value must be merged verbatim into the agent step: {compiled}"
+    );
+    assert!(
+        compiled.contains("COPILOT_PROVIDER_TYPE: azure"),
+        "Literal provider config value must still be emitted: {compiled}"
+    );
+    assert!(
+        compiled.contains("my-foundry.cognitiveservices.azure.com"),
+        "Literal COPILOT_PROVIDER_BASE_URL host must be added to the AWF allow-domains list: {compiled}"
+    );
+}
+
 /// Defense-in-depth: parse a compiled pipeline as YAML, locate the **Agent**
 /// job, and assert no step in that job maps `SYSTEM_ACCESSTOKEN` at all.
 ///

--- a/tests/compiler_tests.rs
+++ b/tests/compiler_tests.rs
@@ -4817,9 +4817,12 @@ fn test_byom_provider_env_compiles_and_merges() {
     let compiled = compile_fixture("byom-foundry-agent.md");
     assert_valid_yaml(&compiled, "byom-foundry-agent.md");
 
+    // Emitted verbatim (unquoted): the typed EnvValue re-serialization renders
+    // an ADO macro without surrounding quotes. Pin the trailing newline so the
+    // assertion fails if quoting is ever (incorrectly) introduced.
     assert!(
-        compiled.contains("COPILOT_PROVIDER_BEARER_TOKEN: $(Setup.FOUNDRY_TOKEN)"),
-        "BYOM provider macro env value must be merged verbatim into the agent step: {compiled}"
+        compiled.contains("COPILOT_PROVIDER_BEARER_TOKEN: $(Setup.FOUNDRY_TOKEN)\n"),
+        "BYOM provider macro env value must be merged verbatim (unquoted) into the agent step: {compiled}"
     );
     assert!(
         compiled.contains("COPILOT_PROVIDER_TYPE: azure"),
@@ -4840,9 +4843,12 @@ fn test_byom_provider_env_compiles_and_merges() {
         2,
         "BYOM must enable the AWF api-proxy sidecar in both the Agent and Detection jobs: {compiled}"
     );
+    // --exclude-env now lists exactly the provider credential keys present in
+    // engine.env (case-preserving), not a hardcoded set. The fixture defines
+    // COPILOT_PROVIDER_BASE_URL + COPILOT_PROVIDER_BEARER_TOKEN (no API_KEY), so
+    // only those two are excluded, in both the Agent and Detection jobs.
     for key in [
         "--exclude-env COPILOT_PROVIDER_BASE_URL",
-        "--exclude-env COPILOT_PROVIDER_API_KEY",
         "--exclude-env COPILOT_PROVIDER_BEARER_TOKEN",
     ] {
         assert_eq!(
@@ -4851,6 +4857,12 @@ fn test_byom_provider_env_compiles_and_merges() {
             "BYOM must exclude provider credential from passthrough in both jobs ({key}): {compiled}"
         );
     }
+    // A credential key NOT present in engine.env must NOT be excluded.
+    assert_eq!(
+        compiled.matches("--exclude-env COPILOT_PROVIDER_API_KEY").count(),
+        0,
+        "credential keys absent from engine.env must not be passed to --exclude-env: {compiled}"
+    );
     // The api-proxy container image must be pre-pulled (and :latest-tagged) in
     // both jobs so AWF's --skip-pull finds it locally.
     assert_eq!(
@@ -4865,7 +4877,7 @@ fn test_byom_provider_env_compiles_and_merges() {
     // The bearer-token macro therefore appears twice: agent step + detection step.
     assert_eq!(
         compiled
-            .matches("COPILOT_PROVIDER_BEARER_TOKEN: $(Setup.FOUNDRY_TOKEN)")
+            .matches("COPILOT_PROVIDER_BEARER_TOKEN: $(Setup.FOUNDRY_TOKEN)\n")
             .count(),
         2,
         "Detection step must inherit the BYOM provider env alongside the agent step: {compiled}"

--- a/tests/compiler_tests.rs
+++ b/tests/compiler_tests.rs
@@ -4829,6 +4829,46 @@ fn test_byom_provider_env_compiles_and_merges() {
         compiled.contains("my-foundry.cognitiveservices.azure.com"),
         "Literal COPILOT_PROVIDER_BASE_URL host must be added to the AWF allow-domains list: {compiled}"
     );
+
+    // Credential isolation: the AWF api-proxy sidecar is enabled and the
+    // provider credential env keys are excluded from --env-all passthrough.
+    assert!(
+        compiled.contains("--enable-api-proxy"),
+        "BYOM must enable the AWF api-proxy sidecar for credential isolation: {compiled}"
+    );
+    for key in [
+        "--exclude-env COPILOT_PROVIDER_BASE_URL",
+        "--exclude-env COPILOT_PROVIDER_API_KEY",
+        "--exclude-env COPILOT_PROVIDER_BEARER_TOKEN",
+    ] {
+        assert!(
+            compiled.contains(key),
+            "BYOM must exclude provider credential from agent passthrough ({key}): {compiled}"
+        );
+    }
+    // The api-proxy container image must be pre-pulled (and :latest-tagged) so
+    // AWF's --skip-pull finds it locally.
+    assert!(
+        compiled.contains("docker pull ghcr.io/github/gh-aw-firewall/api-proxy:"),
+        "BYOM must pre-pull the api-proxy container image: {compiled}"
+    );
+}
+
+/// A non-BYOM agent must NOT enable the api-proxy sidecar or pre-pull its image —
+/// the isolation plumbing is strictly opt-in via the presence of a
+/// `COPILOT_PROVIDER_*` credential key in `engine.env`.
+#[test]
+fn test_non_byom_agent_has_no_api_proxy() {
+    let compiled = compile_fixture("minimal-agent.md");
+    assert_valid_yaml(&compiled, "minimal-agent.md");
+    assert!(
+        !compiled.contains("--enable-api-proxy"),
+        "Non-BYOM agent must not enable the api-proxy sidecar: {compiled}"
+    );
+    assert!(
+        !compiled.contains("api-proxy"),
+        "Non-BYOM agent must not reference the api-proxy image: {compiled}"
+    );
 }
 
 /// Defense-in-depth: parse a compiled pipeline as YAML, locate the **Agent**

--- a/tests/fixtures/byom-foundry-agent.md
+++ b/tests/fixtures/byom-foundry-agent.md
@@ -1,0 +1,18 @@
+---
+name: "BYOM Foundry Agent"
+description: "Exercises Copilot BYOM/BYOK provider env config via engine.env"
+engine:
+  id: copilot
+  env:
+    COPILOT_PROVIDER_TYPE: azure
+    COPILOT_PROVIDER_BASE_URL: https://my-foundry.cognitiveservices.azure.com/openai/v1
+    COPILOT_PROVIDER_BEARER_TOKEN: $(Setup.FOUNDRY_TOKEN)
+setup:
+  - bash: echo "##vso[task.setvariable variable=FOUNDRY_TOKEN;isOutput=true]token-value"
+    displayName: Acquire Foundry bearer token
+---
+
+## BYOM Foundry Agent
+
+This agent routes Copilot requests to a private Azure Copilot Foundry instance
+via Bring Your Own Model (BYOM) provider environment variables.


### PR DESCRIPTION
## Summary

Closes #1261.

`ado-aw` previously blanket-rejected **all** ADO expressions (`$(`, `${{`, `$[`)
in every `engine.env` value, making it impossible to configure Azure Copilot
Foundry **BYOM/BYOK** providers dynamically (e.g.
`COPILOT_PROVIDER_BEARER_TOKEN: $(Setup.FOUNDRY_TOKEN)`). The only workaround was
manually editing compiled `.lock.yml` files, which breaks `ado-aw check`
integrity.

This PR aligns `engine.env` validation with **[gh-aw](https://github.com/githubnext/gh-aw)**'s
BYOM/BYOK model and adds full credential isolation via the AWF api-proxy sidecar
across **both** agentic stages.

### 1. Provider expression allowlist (`engine.env`)
- Only `COPILOT_PROVIDER_BASE_URL`, `COPILOT_PROVIDER_API_KEY`,
  `COPILOT_PROVIDER_BEARER_TOKEN`, and `COPILOT_PROVIDER_WIRE_API` may carry an
  ADO **macro** (`$(...)`) expression — the only expression form ADO evaluates
  inside a step `env:` block. Every other `engine.env` value remains literal-only
  (unchanged behavior).
- Template expressions (`${{ }}`), **runtime expressions (`$[ ... ]`, which ADO
  does not evaluate in step env)**, pipeline command injection (`##vso[`), and
  newlines remain blocked for **all** keys, provider keys included.

### 2. Network auto-allow
- When `COPILOT_PROVIDER_BASE_URL` is a **literal** URL, its hostname is
  automatically added to the AWF network allowlist. When it is an expression, the
  author adds the host to `network.allowed` manually.

### 3. Credential isolation via AWF api-proxy sidecar (Agent **and** Detection)
- When a BYOM credential key is present, the compiler enables the AWF api-proxy
  sidecar (`--enable-api-proxy`) and pre-pulls its container image. The sidecar
  holds the **real** credential and injects it only at the proxy layer — the
  secret never reaches the agent container or the Copilot CLI process. Credential
  keys are also passed as `--exclude-env` flags (defense-in-depth).
- This applies to **both** the **Agent** stage and the **Detection**
  (threat-analysis) stage. The Detection Copilot run inherits the
  `COPILOT_PROVIDER_*` routing subset so it reaches the same external provider —
  matching gh-aw, whose detection engine config inherits the main engine's `env`
  (`threat_detection_inline_engine.go`). Without this, Foundry-only workflows
  (no GitHub Copilot token) could not run threat detection at all.
- Verified the pinned **AWF v0.27.9** exposes `--enable-api-proxy` and ships the
  `copilot-byok` provider.

Backward compatible: literal-valued `engine.env`, all non-provider keys, and
non-BYOM agents behave exactly as before (no api-proxy plumbing emitted).

### Changed files
- `src/engine.rs` — `COPILOT_PROVIDER_EXPR_ENV_KEYS` allowlist, relaxed
  `copilot_env` validation, `required_hosts` base-URL host extraction,
  `COPILOT_BYOM_CREDENTIAL_ENV_KEYS` + `copilot_byom_active()`,
  `copilot_provider_env()` (Detection provider subset) + shared
  `render_engine_env_entry()`, unit tests.
- `src/compile/agentic_pipeline.rs` — thread `byom_active` +
  `detection_provider_env` through `StandaloneCtx`; shared `awf_api_proxy_flags()`
  helper; emit `--enable-api-proxy` + `--exclude-env` and pre-pull the api-proxy
  image in both the Agent and Detection jobs when BYOM is active; Detection step
  applies the provider env.
- `tests/fixtures/byom-foundry-agent.md` — new Azure Foundry fixture.
- `tests/compiler_tests.rs` — integration tests (provider env merge + host
  allowlist + api-proxy enablement/pre-pull/provider-env in **both** jobs;
  non-BYOM negative test).
- `docs/engine.md` — "Copilot BYOM / BYOK provider configuration" section incl.
  credential-isolation subsection (both stages).

## Test plan

- `cargo build` ✅
- `cargo test` ✅ (full suite, no failures; new `engine_env_*` / `copilot_byom_*`
  / `copilot_provider_env_*` unit tests and
  `test_byom_provider_env_compiles_and_merges` /
  `test_non_byom_agent_has_no_api_proxy` integration tests)
- `cargo test --test bash_lint_tests` ✅ (shellcheck enforced on the modified
  agent + detection bash bodies)
- `cargo clippy --all-targets --all-features` ✅ (0 warnings)

