### PR TITLE
feat(compile): substitute ADO path-anchor variables in the agent prompt

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -248,7 +248,7 @@ fail-closed and only pauses when the agent actually proposed a reviewed output.
 │   └── ado-script/       # TypeScript workspace for bundled gate/import helpers plus execution-context, conclusion, and approval-summary bundles
 │       └── src/
 │           ├── gate/     # Gate evaluator source (bundled to gate.js)
-│           ├── import/   # Runtime prompt resolver source (bundled to import.js)
+│           ├── import/   # Runtime prompt resolver source (bundled to import.js); resolves {{#runtime-import}} markers + substitutes a compiler-owned allowlist of ADO path-anchor vars via --var flags
 │           ├── exec-context-pr/ # PR-context precompute source (bundled to exec-context-pr.js)
 │           ├── exec-context-pr-synth/ # Synthetic-PR resolver source (bundled to exec-context-pr-synth.js)
 │           ├── exec-context-manual/ # Manual-run context source (bundled to exec-context-manual.js)

--- a/docs/ado-script.md
+++ b/docs/ado-script.md
@@ -93,13 +93,38 @@ The compiler runs it as a post-prepare-prompt step when
 [`runtime-imports.md`](runtime-imports.md) for the author-facing marker
 syntax.
 
-### Env-var contract
+### CLI contract
 
-`import.js` takes no environment variables. Relative-path markers
-resolve against `dirname(argv[2])`; in pipeline use this is irrelevant
-because the compiler always embeds an absolute marker path and
-`import.js` is single-pass (nested markers inside the inlined body are
-not re-expanded).
+`import.js` takes **no environment variables** — all inputs are explicit
+CLI flags, so the resolver cannot be influenced by ambient pipeline state:
+
+```
+node import.js <prompt-file> --base "$(Build.SourcesDirectory)" \
+  --var "Build.SourcesDirectory=$(Build.SourcesDirectory)" \
+  --var "Build.Repository.Name=$(Build.Repository.Name)"
+```
+
+- `--base <path>` — root that relative marker paths resolve against. The
+  compiler always passes `$(Build.SourcesDirectory)` (ADO expands the macro
+  before node runs), and the compiler-emitted marker for the agent body is a
+  **trigger-repo-relative** path (e.g. `agents/foo.md`, or
+  `$(Build.Repository.Name)/agents/foo.md` under multi-checkout) — not
+  absolute. `import.js` rejects absolute and `..` paths.
+- `--var name=value` (repeatable) — a small, **compiler-owned allowlist** of
+  ADO path-anchor variables (currently `Build.SourcesDirectory` and
+  `Build.Repository.Name`, defined by `PROMPT_ADO_VARS` in
+  `src/compile/extensions/ado_script.rs`). ADO expands the `$(...)` macro into
+  the bash arg at runtime, so `import.js` receives the concrete value and
+  literally substitutes every `$(name)` occurrence in the **final** prompt
+  (author body + inlined snippets). Unknown `$(...)` macros are left untouched.
+  `import.js` never reads these from the environment; the allowlist is the set
+  of `--var` flags the compiler emits, so an untrusted agent body cannot
+  introduce new variables. This makes path anchors behave the same whether
+  imports are inlined at compile time (where ADO expands the macro in the
+  heredoc) or resolved here at runtime.
+
+Resolution is single-pass: nested markers inside an inlined body are not
+re-expanded.
 
 The bundle lives at `import.js` and ships in the same
 `ado-script.zip` release asset as `gate.js` and the ten

--- a/docs/front-matter.md
+++ b/docs/front-matter.md
@@ -337,6 +337,12 @@ The trade-off is that the generated YAML is larger, and prompt-body
 edits require `ado-aw compile` plus committing the updated pipeline
 file.
 
+A small, fixed set of ADO path-anchor variables —
+`$(Build.SourcesDirectory)` and `$(Build.Repository.Name)` — is
+substituted into the prompt consistently in **both** modes. Arbitrary
+`$(...)` macros and pipeline/secret variables are not expanded; see
+[ADO variables in the prompt](runtime-imports.md#ado-variables-in-the-prompt).
+
 ## Filter Validation
 
 The compiler validates filter configurations at compile time and will emit

--- a/docs/runtime-imports.md
+++ b/docs/runtime-imports.md
@@ -43,11 +43,39 @@ along with any author-written markers.
   from untrusted PR branches embedding host files into the compiled YAML —
   e.g. `{{#runtime-import /home/runner/.ssh/id_rsa}}` or
   `{{#runtime-import ../../../../etc/passwd}}` are both compile-time errors.
-- **Compiler-generated marker for the agent body** uses an absolute path
-  (`$(Build.SourcesDirectory)/…`) built from the trigger-repo checkout root,
-  so the runtime resolver never has to resolve a relative path. The
-  compile-time restriction does not apply here because the path is
-  tooling-generated, not author-supplied.
+- **Compiler-generated marker for the agent body** uses a **trigger-repo-relative**
+  path resolved against `--base "$(Build.SourcesDirectory)"` — e.g. `agents/foo.md`,
+  or `$(Build.Repository.Name)/agents/foo.md` under multi-checkout (ADO expands the
+  macro before the resolver runs). It is deliberately relative, not absolute:
+  `import.js` rejects absolute paths for everyone. The compile-time `..`/absolute
+  restriction is a compile-host guard and does not constrain this tooling-generated
+  path beyond the runtime resolver's own absolute/`..` rejection.
+
+## ADO variables in the prompt
+
+A small, fixed set of ADO **path-anchor** variables is substituted into the prompt
+by the runtime resolver:
+
+| Variable | Expands to |
+|----------|------------|
+| `$(Build.SourcesDirectory)` | the checkout root |
+| `$(Build.Repository.Name)` | the trigger repo's subfolder name (multi-checkout) |
+
+The compiler passes these to `import.js` as `--var name=$(name)` flags (ADO expands
+the macro at runtime); the resolver then replaces every `$(name)` occurrence in the
+final prompt — author body and inlined snippets alike. This is a deliberately tiny,
+compiler-owned allowlist (defined by `PROMPT_ADO_VARS` in
+`src/compile/extensions/ado_script.rs`), **not** a general expression engine:
+arbitrary `$(...)` macros and any pipeline/secret variables are **not** expanded and
+reach the agent literally. For richer runtime values (PR sha, branch, etc.), use the
+[execution-context `aw-context/` files](execution-context.md) rather than
+interpolating into the prompt.
+
+> **Mode note.** With `inlined-imports: true` the body is folded into a bash step at
+> compile time, so ADO natively expands *any* `$(...)` macro in it. The curated set
+> above behaves identically in both modes; other `$(...)` macros only expand in the
+> inlined path and should not be relied on.
+
 
 ## Single-pass behavior
 

--- a/scripts/ado-script/src/import/__tests__/helpers.ts
+++ b/scripts/ado-script/src/import/__tests__/helpers.ts
@@ -45,6 +45,12 @@ export type RunOptions = {
   env?: NodeJS.ProcessEnv;
   /** Optional `--base <path>` argument forwarded to `import.js`. */
   base?: string;
+  /**
+   * Optional `--var name=value` pairs forwarded to `import.js`. Passed as
+   * raw strings (already in `name=value` form) so tests can also exercise
+   * malformed inputs like `"noequals"`.
+   */
+  vars?: string[];
 };
 
 export function runImportSource(target: string, options: RunOptions = {}): RunResult {
@@ -61,6 +67,9 @@ export function runImportSource(target: string, options: RunOptions = {}): RunRe
   const args = [runnerPath, target];
   if (options.base !== undefined) {
     args.push("--base", options.base);
+  }
+  for (const pair of options.vars ?? []) {
+    args.push("--var", pair);
   }
 
   const result = spawnSync(process.execPath, args, {

--- a/scripts/ado-script/src/import/__tests__/var-substitution.test.ts
+++ b/scripts/ado-script/src/import/__tests__/var-substitution.test.ts
@@ -1,0 +1,121 @@
+import { describe, expect, it } from "vitest";
+import { readText, runImportSource, withScratchDir, writeFixture } from "./helpers.js";
+
+describe("runtime-import ADO variable substitution", () => {
+  it("substitutes a single $(name) token with its value", () => {
+    withScratchDir("var-single", (dir) => {
+      const target = writeFixture(dir, "prompt.md", "cd $(Build.SourcesDirectory) && ls\n");
+
+      const result = runImportSource(target, {
+        vars: ["Build.SourcesDirectory=/agent/_work/1/s"],
+      });
+
+      expect(result.status).toBe(0);
+      expect(readText(target)).toBe("cd /agent/_work/1/s && ls\n");
+    });
+  });
+
+  it("substitutes multiple distinct variables", () => {
+    withScratchDir("var-multi", (dir) => {
+      const target = writeFixture(
+        dir,
+        "prompt.md",
+        "root=$(Build.SourcesDirectory) repo=$(Build.Repository.Name)\n",
+      );
+
+      const result = runImportSource(target, {
+        vars: [
+          "Build.SourcesDirectory=/agent/_work/1/s",
+          "Build.Repository.Name=my-repo",
+        ],
+      });
+
+      expect(result.status).toBe(0);
+      expect(readText(target)).toBe("root=/agent/_work/1/s repo=my-repo\n");
+    });
+  });
+
+  it("substitutes variables inside inlined snippets too", () => {
+    // The substitution pass runs on the fully expanded prompt, so a
+    // `$(...)` token that lives in an imported file is also replaced.
+    withScratchDir("var-in-snippet", (dir) => {
+      writeFixture(dir, "snippet.md", "workdir is $(Build.SourcesDirectory)\n");
+      const target = writeFixture(
+        dir,
+        "prompt.md",
+        "{{#runtime-import ./snippet.md}}\n",
+      );
+
+      const result = runImportSource(target, {
+        vars: ["Build.SourcesDirectory=/agent/_work/1/s"],
+      });
+
+      expect(result.status).toBe(0);
+      expect(readText(target)).toBe("workdir is /agent/_work/1/s\n\n");
+    });
+  });
+
+  it("leaves unknown $(...) macros untouched", () => {
+    withScratchDir("var-unknown", (dir) => {
+      const target = writeFixture(
+        dir,
+        "prompt.md",
+        "known=$(Build.Repository.Name) unknown=$(System.AccessToken)\n",
+      );
+
+      const result = runImportSource(target, {
+        vars: ["Build.Repository.Name=my-repo"],
+      });
+
+      expect(result.status).toBe(0);
+      expect(readText(target)).toBe("known=my-repo unknown=$(System.AccessToken)\n");
+    });
+  });
+
+  it("treats values literally (no regex metacharacter interpretation)", () => {
+    withScratchDir("var-literal-value", (dir) => {
+      const target = writeFixture(dir, "prompt.md", "p=$(Build.SourcesDirectory)\n");
+
+      // A value containing characters that would be special in a regex
+      // replacement (`$&`, `$1`) must be inserted verbatim.
+      const result = runImportSource(target, {
+        vars: ["Build.SourcesDirectory=/a$1b$&c"],
+      });
+
+      expect(result.status).toBe(0);
+      expect(readText(target)).toBe("p=/a$1b$&c\n");
+    });
+  });
+
+  it("replaces every occurrence of a repeated token", () => {
+    withScratchDir("var-repeated", (dir) => {
+      const target = writeFixture(
+        dir,
+        "prompt.md",
+        "$(Build.Repository.Name)/$(Build.Repository.Name)\n",
+      );
+
+      const result = runImportSource(target, {
+        vars: ["Build.Repository.Name=r"],
+      });
+
+      expect(result.status).toBe(0);
+      expect(readText(target)).toBe("r/r\n");
+    });
+  });
+
+  it("rejects a --var argument without an '=' separator", () => {
+    withScratchDir("var-malformed", (dir) => {
+      const target = writeFixture(dir, "prompt.md", "noop\n");
+
+      const result = runImportSource(target, {
+        vars: ["noequals"],
+      });
+
+      expect(result.status).toBe(1);
+      expect(result.stdout).toContain("--var expects name=value");
+      // Target must be left untouched when arg parsing fails.
+      expect(readText(target)).toBe("noop\n");
+    });
+  });
+});

--- a/scripts/ado-script/src/import/index.ts
+++ b/scripts/ado-script/src/import/index.ts
@@ -62,7 +62,7 @@ function fail(messages: string[]): never {
 }
 
 // Parse the CLI:
-//   node import.js <target> [--base <path>]
+//   node import.js <target> [--base <path>] [--var name=value ...]
 // The optional --base flag sets the root that relative marker paths
 // resolve against. When omitted, falls back to `dirname(target)`.
 // In pipeline use the compiler always passes
@@ -70,12 +70,25 @@ function fail(messages: string[]): never {
 // trigger-repo-relative path (NOT absolute) — see
 // `AdoScriptExtension::resolver_step` in
 // src/compile/extensions/ado_script.rs.
-function parseArgs(argv: string[]): { target: string; base: string | null } {
+//
+// The repeatable `--var name=value` flag carries a small, fixed set of
+// ADO path-anchor variables (e.g. `Build.SourcesDirectory`,
+// `Build.Repository.Name`). ADO expands the `$(...)` macros into
+// concrete values in the resolver step's bash args before node runs, so
+// the values arrive here already resolved. The allowlist is owned by the
+// compiler (which emits the flags); import.js is a dumb substitutor and
+// never reads these from the environment.
+function parseArgs(argv: string[]): {
+  target: string;
+  base: string | null;
+  vars: Map<string, string>;
+} {
   if (argv.length === 0) {
     fail(["missing target file argument"]);
   }
   const target = argv[0]!;
   let base: string | null = null;
+  const vars = new Map<string, string>();
   let i = 1;
   while (i < argv.length) {
     const arg = argv[i]!;
@@ -86,15 +99,27 @@ function parseArgs(argv: string[]): { target: string; base: string | null } {
       }
       base = value;
       i += 2;
+    } else if (arg === "--var") {
+      const value = argv[i + 1];
+      if (value === undefined) {
+        fail(["--var requires a value of the form name=value"]);
+      }
+      const eq = value.indexOf("=");
+      // `eq <= 0` rejects both a missing `=` and an empty name.
+      if (eq <= 0) {
+        fail([`--var expects name=value, got: ${sanitizeForVsoMessage(value)}`]);
+      }
+      vars.set(value.slice(0, eq), value.slice(eq + 1));
+      i += 2;
     } else {
       fail([`unknown argument: ${sanitizeForVsoMessage(arg)}`]);
     }
   }
-  return { target, base };
+  return { target, base, vars };
 }
 
 function main(): void {
-  const { target, base: baseArg } = parseArgs(process.argv.slice(2));
+  const { target, base: baseArg, vars } = parseArgs(process.argv.slice(2));
   if (!existsSync(target)) {
     fail([`target file not found: ${sanitizeForVsoMessage(target)}`]);
   }
@@ -158,7 +183,20 @@ function main(): void {
   if (errors.length > 0) {
     fail(errors);
   }
-  writeFileSync(target, expanded, "utf8");
+
+  // Substitute the compiler-provided ADO path-anchor variables (e.g.
+  // `$(Build.SourcesDirectory)`). Runs on the fully expanded prompt, so it
+  // covers both the author body and any inlined snippets, giving the same
+  // result whether imports are inlined at compile time (where ADO expands
+  // the macro in the heredoc) or resolved here at runtime. Literal
+  // split/join avoids regex metacharacter pitfalls in either the name or
+  // the value; unknown `$(...)` macros are left untouched.
+  let substituted = expanded;
+  for (const [name, value] of vars) {
+    substituted = substituted.split(`$(${name})`).join(value);
+  }
+
+  writeFileSync(target, substituted, "utf8");
 }
 
 main();

--- a/scripts/ado-script/src/import/index.ts
+++ b/scripts/ado-script/src/import/index.ts
@@ -109,6 +109,10 @@ function parseArgs(argv: string[]): {
       if (eq <= 0) {
         fail([`--var expects name=value, got: ${sanitizeForVsoMessage(value)}`]);
       }
+      // Last-write-wins on a duplicate name. The compiler emits each var at
+      // most once (see PROMPT_ADO_VARS in
+      // src/compile/extensions/ado_script.rs), so this only matters for
+      // hand-run invocations.
       vars.set(value.slice(0, eq), value.slice(eq + 1));
       i += 2;
     } else {

--- a/src/compile/extensions/ado_script.rs
+++ b/src/compile/extensions/ado_script.rs
@@ -442,6 +442,14 @@ pub(crate) fn install_and_download_steps_typed(
 /// `--var "<name>=$(<name>)"` and ADO expands the macro at runtime before
 /// node runs. Keep this list minimal and non-secret — anything added here
 /// is interpolated verbatim into the (potentially untrusted) agent prompt.
+///
+/// NOTE: each var is emitted as `--var "<name>=$(<name>)"`. If ADO ever
+/// expanded a value containing a literal `"` (e.g. a user-influenced
+/// variable added to this list), it would break bash argument parsing in
+/// the resolver step — the same pre-existing exposure as the adjacent
+/// `--base "$(Build.SourcesDirectory)"`. The current entries are
+/// ADO-controlled path anchors that cannot contain `"`, so this is safe;
+/// re-quote (or shell-escape) before adding any user-influenced variable.
 const PROMPT_ADO_VARS: &[&str] = &["Build.SourcesDirectory", "Build.Repository.Name"];
 
 /// The resolver step that expands runtime import markers in the agent prompt.

--- a/src/compile/extensions/ado_script.rs
+++ b/src/compile/extensions/ado_script.rs
@@ -433,11 +433,31 @@ pub(crate) fn install_and_download_steps_typed(
     vec![Step::Task(install), Step::Bash(download)]
 }
 
+/// Path-anchor ADO variables exposed to the agent prompt via the runtime
+/// import resolver. The compiler owns this allowlist; `import.js`
+/// substitutes only the `$(name)` tokens it is handed — it never reads
+/// these from the environment (see
+/// `scripts/ado-script/src/import/index.ts`). Each entry is both the
+/// substitution key and the ADO macro name, so the resolver emits
+/// `--var "<name>=$(<name>)"` and ADO expands the macro at runtime before
+/// node runs. Keep this list minimal and non-secret — anything added here
+/// is interpolated verbatim into the (potentially untrusted) agent prompt.
+const PROMPT_ADO_VARS: &[&str] = &["Build.SourcesDirectory", "Build.Repository.Name"];
+
 /// The resolver step that expands runtime import markers in the agent prompt.
 fn resolver_step_typed() -> Step {
+    // `--var "<name>=$(<name>)"` for each allowlisted path-anchor var. ADO
+    // substitutes the `$(...)` macro into the bash arg at runtime, so
+    // import.js receives the concrete value and can replace `$(<name>)`
+    // occurrences in the prompt — giving the same result whether imports
+    // are inlined at compile time or resolved here at runtime.
+    let var_flags: String = PROMPT_ADO_VARS
+        .iter()
+        .map(|name| format!(" --var \"{name}=$({name})\""))
+        .collect();
     let script = format!(
         "set -eo pipefail\n\
-         node '{IMPORT_EVAL_PATH}' /tmp/awf-tools/agent-prompt.md --base \"$(Build.SourcesDirectory)\"\n"
+         node '{IMPORT_EVAL_PATH}' /tmp/awf-tools/agent-prompt.md --base \"$(Build.SourcesDirectory)\"{var_flags}\n"
     );
     Step::Bash(
         BashStep::new("Resolve runtime imports (agent prompt)", script)
@@ -1068,6 +1088,23 @@ mod tests {
         assert!(
             !resolver.script.contains("ADO_AW_IMPORT_BASE"),
             "resolver step must not export ADO_AW_IMPORT_BASE — base is passed via --base, not env"
+        );
+        // Each path-anchor var is passed as `--var "<name>=$(<name>)"` so
+        // ADO expands the macro at runtime and import.js substitutes the
+        // concrete value into the prompt (consistent with inlined mode).
+        assert!(
+            resolver
+                .script
+                .contains("--var \"Build.SourcesDirectory=$(Build.SourcesDirectory)\""),
+            "resolver step must pass Build.SourcesDirectory as a --var, got: {}",
+            resolver.script
+        );
+        assert!(
+            resolver
+                .script
+                .contains("--var \"Build.Repository.Name=$(Build.Repository.Name)\""),
+            "resolver step must pass Build.Repository.Name as a --var, got: {}",
+            resolver.script
         );
     }
 


### PR DESCRIPTION
## Summary

`$(...)` ADO macros behaved inconsistently in the agent prompt depending on `inlined-imports`:

- `inlined-imports: true` — the body is folded into the "Prepare agent prompt" heredoc at compile time, so it sits in a bash step's script text and ADO macro-substitutes `$(...)` before the step runs → vars expand.
- `inlined-imports: false` (default) — only a `{{#runtime-import}}` marker is in the step; the real body is read from disk by `import.js`, so ADO never sees that text and `$(...)` reaches the agent literally.

This makes a small, **compiler-owned allowlist** of ADO path-anchor variables behave consistently in **both** modes:

- **`import.js`** gains a repeatable `--var name=value` flag. After import expansion it literally substitutes every `$(name)` occurrence in the final prompt (author body + inlined snippets); unknown `$(...)` macros are left untouched. It stays env-free.
- **The resolver step** (`src/compile/extensions/ado_script.rs`) emits `--var "<name>=$(<name>)"` for each entry in `PROMPT_ADO_VARS` (`Build.SourcesDirectory`, `Build.Repository.Name`). ADO expands the macro into the bash arg at runtime, so `import.js` receives the concrete value.

### Why not a gh-aw-style engine

gh-aw's `runtime_import.cjs` carries a ~66-entry `github.event.*` allowlist + dynamic patterns + prototype-pollution guards — machinery that exists to make GitHub Actions `${{ }}` safe around secrets. ADO `$(...)` macros don't auto-expand secrets, so that apparatus would be overkill. This PR keeps the surface tiny: secrets and arbitrary pipeline variables are **never** interpolated, and the allowlist lives in the Rust compiler (single source of truth) so an untrusted agent body cannot introduce new variables. Richer runtime values should continue to use the execution-context `aw-context/` files.

### Known limitation (documented)

With `inlined-imports: true`, ADO still natively expands arbitrary `$(...)` in the body. The curated set behaves identically in both modes; other macros only expand in the inlined path and should not be relied on.

Also fixes a stale doc note in `docs/runtime-imports.md` that claimed the compiler-generated body marker is absolute — it is trigger-repo-relative, resolved against `--base "$(Build.SourcesDirectory)"`.

## Test plan

- `cd scripts/ado-script && npm run typecheck` ✓
- `npx vitest run src/import` ✓ — 24 tests, including 7 new `var-substitution` cases (single/multiple vars, var inside an inlined snippet, unknown `$(...)` left literal, literal-value safety, repeated token, malformed `--var` rejected)
- `npm run build:import` ✓ — bundle regenerates (gitignored, built at release time)
- `cargo test` ✓ — 2310+ pass, including new resolver-step assertions; no fixture or bash-lint drift
- `cargo clippy --all-targets --all-features` ✓ clean
