### PR TITLE
docs: fix drift for safe_outputs dir name and conclusion trigger

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -174,7 +174,7 @@ fail-closed and only pauses when the agent actually proposed a reviewed output.
 │   ├── validate.rs       # Structural input validators (char allowlists, format checks, injection detectors)
 │   ├── agent_stats.rs    # OTel-based agent statistics parsing (token usage, duration, turns)
 │   ├── hash.rs           # SHA-256 utilities for safe-output file integrity
-│   ├── safeoutputs/      # Safe-output MCP tool implementations (Stage 1 → NDJSON → Stage 3)
+│   ├── safe_outputs/     # Safe-output MCP tool implementations (Stage 1 → NDJSON → Stage 3)
 │   │   ├── mod.rs
 │   │   ├── add_build_tag.rs
 │   │   ├── add_pr_comment.rs

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -187,6 +187,6 @@ These commands are not shown in `--help` but are available for contributors work
 
 ## Pipeline IR Reference
 
-The compiler builds typed Azure DevOps pipeline IR and lowers it through one YAML emitter. The canonical Setup → Agent → Detection → SafeOutputs → Teardown shape, plus the optional always-running Conclusion job when `conclusion:` is configured, lives in `agentic_pipeline.rs` (shared by every target); target-specific builders (`standalone_ir.rs`, `onees_ir.rs`, `job_ir.rs`, and `stage_ir.rs`) own only the per-target envelope (pipeline shape, template parameters, 1ES wrapping).
+The compiler builds typed Azure DevOps pipeline IR and lowers it through one YAML emitter. The canonical Setup → Agent → Detection → SafeOutputs → Teardown shape, plus the optional always-running Conclusion job when `safe-outputs:` is configured, lives in `agentic_pipeline.rs` (shared by every target); target-specific builders (`standalone_ir.rs`, `onees_ir.rs`, `job_ir.rs`, and `stage_ir.rs`) own only the per-target envelope (pipeline shape, template parameters, 1ES wrapping).
 
 See [`docs/ir.md`](ir.md) for the complete IR reference.


### PR DESCRIPTION
Consolidates the still-valid deltas from the docs-drift auditor backlog (#1270, #1266, #1262, #1257, #1256, #1255).

- **AGENTS.md**: the source-tree listing referenced the old safeoutputs/ directory; the actual directory is safe_outputs/.
- **docs/cli.md**: the Pipeline IR Reference said the Conclusion job is emitted `when conclusion: is configured`. It is actually gated on a non-empty safe-outputs: block (uild_conclusion_job in gentic_pipeline.rs returns None when ront_matter.safe_outputs.is_empty()).

The codemod 0003/0004 documentation additions those auditor PRs proposed are already present on main, so this consolidates only the remaining valid deltas. The six superseded PRs will be closed.