### PR TITLE
feat(compile): add per-repo checkout fetch depth/tags tuning

### DIFF
--- a/docs/front-matter.md
+++ b/docs/front-matter.md
@@ -324,13 +324,57 @@ Each entry can be:
 
 Object fields:
 
-| Field      | Default                | Description |
-|------------|------------------------|-------------|
-| `name`     | *(required)*           | Full `org/repo` name (maps to ADO `name:`) |
-| `alias`    | last segment of `name` | Repository alias (maps to ADO `repository:`) |
-| `type`     | `git`                  | ADO repository resource type |
-| `ref`      | `refs/heads/main`      | Branch or tag reference |
-| `checkout` | `true`                 | Whether the agent job clones this repo |
+| Field         | Default                | Description |
+|---------------|------------------------|-------------|
+| `name`        | *(required)*           | Full `org/repo` name (maps to ADO `name:`) |
+| `alias`       | last segment of `name` | Repository alias (maps to ADO `repository:`) |
+| `type`        | `git`                  | ADO repository resource type |
+| `ref`         | `refs/heads/main`      | Branch or tag reference |
+| `checkout`    | `true`                 | Whether the agent job clones this repo |
+| `fetch-depth` | *(ADO default)*        | Shallow-clone depth for this repo's checkout (ADO `fetchDepth`). `0` = full history |
+| `fetch-tags`  | *(ADO default)*        | Whether to fetch git tags during checkout (ADO `fetchTags`) |
+
+### Tuning checkout fetch behavior (`fetch-depth` / `fetch-tags`)
+
+On large monorepos the checkout step can dominate the run: ADO's default
+`checkout` performs a full-history clone **and** `git fetch --tags`, which may
+take tens of minutes. `fetch-depth` and `fetch-tags` let you tune this
+per-repository:
+
+```yaml
+repos:
+  - name: my-org/monorepo
+    fetch-depth: 1      # shallow — only the tip commit
+    fetch-tags: false   # skip the (often huge) tag fetch
+```
+
+- `fetch-depth: 0` means **full history** (no `fetchDepth` is emitted).
+- When a field is omitted the ADO default applies, so agents that don't set
+  these compile **unchanged**.
+
+#### Tuning the trigger repository (`self`)
+
+The trigger repository is always checked out as `checkout: self` and is not
+otherwise a `repos:` entry. To tune its fetch behavior, add a reserved entry
+whose `name` is exactly `self`:
+
+```yaml
+repos:
+  - name: self
+    fetch-depth: 1
+    fetch-tags: false
+```
+
+A `self` entry contributes **only** fetch tuning — it does not declare an extra
+repository resource or an additional checkout. The tuning is applied to the
+`checkout: self` step in every job (Setup, Agent, Detection, SafeOutputs,
+Teardown). Because the tuning comes from source, the compiled lock stays in
+sync and the runtime **"Verify pipeline integrity"** step keeps passing — no
+need to hand-edit the lock or set `ado-aw-debug.skip-integrity`.
+
+> `persistCredentials` is intentionally not exposed on `self`; see
+> [`docs/execution-context.md`](execution-context.md) for the trust-boundary
+> rationale.
 
 ### Examples
 

--- a/docs/front-matter.md
+++ b/docs/front-matter.md
@@ -351,6 +351,8 @@ repos:
 - `fetch-depth: 0` means **full history** (no `fetchDepth` is emitted).
 - When a field is omitted the ADO default applies, so agents that don't set
   these compile **unchanged**.
+- Setting `fetch-depth`/`fetch-tags` on an entry with `checkout: false` has no
+  effect (no checkout step is emitted for it); the compiler emits a warning.
 
 #### Tuning the trigger repository (`self`)
 
@@ -371,6 +373,11 @@ repository resource or an additional checkout. The tuning is applied to the
 Teardown). Because the tuning comes from source, the compiled lock stays in
 sync and the runtime **"Verify pipeline integrity"** step keeps passing — no
 need to hand-edit the lock or set `ado-aw-debug.skip-integrity`.
+
+A `self` entry accepts only `fetch-depth` and `fetch-tags`; setting any other
+field (`alias`, `type`, `ref`, `checkout`) on it is rejected at compile time.
+A bare `self` entry with no fetch fields (e.g. `- name: self` or the `- self`
+shorthand) is a harmless no-op — it changes nothing.
 
 > `persistCredentials` is intentionally not exposed on `self`; see
 > [`docs/execution-context.md`](execution-context.md) for the trust-boundary

--- a/src/compile/agentic_pipeline.rs
+++ b/src/compile/agentic_pipeline.rs
@@ -86,8 +86,8 @@ use super::ir::{
     PrTrigger, RepositoryResource, Resources, Schedule, Triggers,
 };
 use super::types::{
-    ApprovalConfig, ApprovalOnTimeout, FrontMatter, OnConfig, PrMode, Repository as RepoCfg,
-    SupplyChainConfig,
+    ApprovalConfig, ApprovalOnTimeout, CheckoutFetchOpts, FrontMatter, OnConfig, PrMode,
+    Repository as RepoCfg, SELF_CHECKOUT_ALIAS, SupplyChainConfig,
 };
 
 /// Built pipeline context — the result of running every validation,
@@ -308,6 +308,11 @@ pub(crate) fn build_pipeline_context(
     let cfg = StandaloneCtx {
         pool: pool.clone(),
         agent_display_name: agent_display_name.clone(),
+        self_checkout_fetch: front_matter
+            .checkout_fetch
+            .get(SELF_CHECKOUT_ALIAS)
+            .cloned()
+            .unwrap_or_default(),
         working_directory: working_directory.clone(),
         trigger_repo_directory: trigger_repo_directory.clone(),
         compiler_version: compiler_version.clone(),
@@ -466,6 +471,9 @@ impl<'a> JobPrefix<'a> {
 pub(crate) struct StandaloneCtx {
     pub(crate) pool: Pool,
     pub(crate) agent_display_name: String,
+    /// Fetch tuning for the auto-generated `checkout: self` step, resolved from
+    /// a reserved `self` entry in `repos:` (empty ⇒ ADO defaults).
+    pub(crate) self_checkout_fetch: CheckoutFetchOpts,
     pub(crate) working_directory: String,
     pub(crate) trigger_repo_directory: String,
     pub(crate) compiler_version: String,
@@ -750,7 +758,7 @@ fn build_setup_job(
         return Ok(None);
     }
     let mut steps: Vec<Step> = Vec::new();
-    steps.push(checkout_self_step());
+    steps.push(checkout_self_step(&cfg.self_checkout_fetch));
     steps.extend(ext_setup_steps.iter().cloned());
 
     // User setup steps as RawYaml — they're arbitrary user-authored ADO YAML
@@ -808,14 +816,16 @@ fn build_agent_job(
     let mut steps: Vec<Step> = Vec::new();
 
     // 1. checkout: self
-    steps.push(checkout_self_step());
+    steps.push(checkout_self_step(&cfg.self_checkout_fetch));
     // 2. additional repo checkouts
     for repo in &front_matter.checkout {
+        let fetch = front_matter.checkout_fetch.get(repo).cloned().unwrap_or_default();
         steps.push(Step::Checkout(CheckoutStep {
             repository: CheckoutRepo::Named(repo.clone()),
             clean: None,
             submodules: None,
-            fetch_depth: None,
+            fetch_depth: fetch.depth_for_emit(),
+            fetch_tags: fetch.fetch_tags,
             persist_credentials: None,
         }));
     }
@@ -1042,7 +1052,7 @@ fn build_detection_job(
     prefix: &JobPrefix<'_>,
 ) -> Result<Job> {
     let mut steps: Vec<Step> = Vec::new();
-    steps.push(checkout_self_step());
+    steps.push(checkout_self_step(&cfg.self_checkout_fetch));
     // Detection job pulls the Agent's output artifact via cross-job download
     steps.push(Step::Download(DownloadStep {
         source: "current".to_string(),
@@ -1202,7 +1212,7 @@ fn build_safeoutputs_job(
     variant: &SafeOutputsVariant,
 ) -> Result<Job> {
     let mut steps: Vec<Step> = Vec::new();
-    steps.push(checkout_self_step());
+    steps.push(checkout_self_step(&cfg.self_checkout_fetch));
     // Acquire write token (when configured)
     push_raw_yaml_if_nonempty(&mut steps, &cfg.acquire_write_token)?;
     // Download analyzed outputs
@@ -1494,7 +1504,7 @@ fn build_teardown_job(
         return Ok(None);
     }
     let mut steps: Vec<Step> = Vec::new();
-    steps.push(checkout_self_step());
+    steps.push(checkout_self_step(&cfg.self_checkout_fetch));
     for user_step_val in &front_matter.teardown {
         steps.push(Step::RawYaml(step_to_raw_yaml_string(user_step_val)?));
     }
@@ -1839,12 +1849,13 @@ fn wire_explicit_dependencies(jobs: &mut [Job], prefix: &JobPrefix<'_>) -> Resul
 // Step body builders — typed BashStep/TaskStep with format!() bodies
 // ─────────────────────────────────────────────────────────────────────
 
-fn checkout_self_step() -> Step {
+fn checkout_self_step(fetch: &CheckoutFetchOpts) -> Step {
     Step::Checkout(CheckoutStep {
         repository: CheckoutRepo::Self_,
         clean: None,
         submodules: None,
-        fetch_depth: None,
+        fetch_depth: fetch.depth_for_emit(),
+        fetch_tags: fetch.fetch_tags,
         persist_credentials: None,
     })
 }

--- a/src/compile/codemods/0004_legacy_path_markers.rs
+++ b/src/compile/codemods/0004_legacy_path_markers.rs
@@ -99,7 +99,7 @@ fn derive_checkout_aliases(fm: &Mapping) -> Result<Vec<String>> {
     let items: Vec<ReposItem> = serde_yaml::from_value(repos_val.clone()).map_err(|e| {
         anyhow::anyhow!("failed to read `repos:` while migrating legacy path markers: {e}")
     })?;
-    let (_repositories, checkout) = lower_repos(&items)?;
+    let (_repositories, checkout, _fetch) = lower_repos(&items)?;
     Ok(checkout)
 }
 

--- a/src/compile/common.rs
+++ b/src/compile/common.rs
@@ -552,6 +552,24 @@ pub fn lower_repos(items: &[ReposItem]) -> Result<LoweredRepos> {
     let mut seen_aliases: HashSet<String> = HashSet::new();
 
     for item in items {
+        // Reserved `self` entry: tunes the auto-generated `checkout: self`
+        // rather than declaring an additional repository resource. Detected by
+        // an explicit `self` *name* (not a derived/aliased collision like
+        // `org/self` or `self=org/repo`, which still hit the reserved guard
+        // below so real repos can't be silently swallowed).
+        if let Some(self_opts) = self_entry_fetch_opts(item)? {
+            if fetch
+                .insert(SELF_CHECKOUT_ALIAS.to_string(), self_opts)
+                .is_some()
+            {
+                anyhow::bail!(
+                    "Duplicate 'self' entry in repos. Declare the self-checkout \
+                    fetch tuning at most once."
+                );
+            }
+            continue;
+        }
+
         let (name, alias, repo_type, repo_ref, do_checkout, fetch_opts) = match item {
             ReposItem::Shorthand(s) => {
                 let (alias, name) = parse_shorthand(s)?;
@@ -583,24 +601,6 @@ pub fn lower_repos(items: &[ReposItem]) -> Result<LoweredRepos> {
             }
         };
 
-        // Reserved `self` entry: tunes the auto-generated `checkout: self`
-        // rather than declaring an additional repository resource. Detected by
-        // an explicit `self` *name* (not a derived/aliased collision like
-        // `org/self` or `self=org/repo`, which still hit the reserved guard
-        // below so real repos can't be silently swallowed).
-        if name == SELF_CHECKOUT_ALIAS {
-            if fetch
-                .insert(SELF_CHECKOUT_ALIAS.to_string(), fetch_opts)
-                .is_some()
-            {
-                anyhow::bail!(
-                    "Duplicate 'self' entry in repos. Declare the self-checkout \
-                    fetch tuning at most once."
-                );
-            }
-            continue;
-        }
-
         // Reject duplicate aliases
         if !seen_aliases.insert(alias.clone()) {
             anyhow::bail!(
@@ -620,6 +620,16 @@ pub fn lower_repos(items: &[ReposItem]) -> Result<LoweredRepos> {
             );
         }
 
+        // Fetch tuning on a repo that is not checked out is a no-op — the
+        // checkout step is never emitted, so the opts are never read. Warn so
+        // authors don't assume the tuning took effect.
+        if !do_checkout && !fetch_opts.is_empty() {
+            eprintln!(
+                "Warning: repository '{alias}' sets fetch-depth/fetch-tags but has \
+                checkout: false — the fetch tuning is ignored (no checkout step is emitted)."
+            );
+        }
+
         repositories.push(Repository {
             repository: alias.clone(),
             repo_type,
@@ -629,13 +639,67 @@ pub fn lower_repos(items: &[ReposItem]) -> Result<LoweredRepos> {
 
         if do_checkout {
             checkout.push(alias.clone());
-        }
-        if !fetch_opts.is_empty() {
-            fetch.insert(alias, fetch_opts);
+            if !fetch_opts.is_empty() {
+                fetch.insert(alias, fetch_opts);
+            }
         }
     }
 
     Ok((repositories, checkout, fetch))
+}
+
+/// If `item` is a reserved `self` entry (its resolved *name* is exactly
+/// `self`), return its fetch tuning. Rejects any other field on a `self`
+/// entry (`alias`/`type`/`ref`/`checkout`), which is silently meaningless for
+/// the trigger repo, so the mistake surfaces at compile time. Returns `None`
+/// for ordinary repository entries.
+fn self_entry_fetch_opts(item: &ReposItem) -> Result<Option<CheckoutFetchOpts>> {
+    match item {
+        ReposItem::Shorthand(s) => {
+            let (alias, name) = parse_shorthand(s)?;
+            if name != SELF_CHECKOUT_ALIAS {
+                return Ok(None);
+            }
+            // Only the bare `self` shorthand is meaningful; an `alias=self`
+            // form assigns an alias the trigger repo cannot take.
+            if alias != SELF_CHECKOUT_ALIAS {
+                anyhow::bail!(
+                    "A 'self' repos entry only tunes the trigger checkout and takes no alias; \
+                    write it as `- name: self` with `fetch-depth`/`fetch-tags`."
+                );
+            }
+            Ok(Some(CheckoutFetchOpts::default()))
+        }
+        ReposItem::Full(entry) => {
+            if entry.name != SELF_CHECKOUT_ALIAS {
+                return Ok(None);
+            }
+            let mut unsupported = Vec::new();
+            if entry.alias.is_some() {
+                unsupported.push("alias");
+            }
+            if entry.repo_type != "git" {
+                unsupported.push("type");
+            }
+            if entry.repo_ref != "refs/heads/main" {
+                unsupported.push("ref");
+            }
+            if !entry.checkout {
+                unsupported.push("checkout");
+            }
+            if !unsupported.is_empty() {
+                anyhow::bail!(
+                    "A 'self' repos entry only accepts `fetch-depth`/`fetch-tags`; \
+                    remove unsupported field(s): {}.",
+                    unsupported.join(", ")
+                );
+            }
+            Ok(Some(CheckoutFetchOpts {
+                fetch_depth: entry.fetch_depth,
+                fetch_tags: entry.fetch_tags,
+            }))
+        }
+    }
 }
 
 /// Parse a shorthand string: `"org/repo"` → (derived alias, name), or
@@ -6303,7 +6367,7 @@ safe-outputs:
     // ──────────────────────────────────────────────────────────────────────
 
     use super::{derive_alias, lower_repos, parse_shorthand, resolve_repos};
-    use crate::compile::types::{RepoEntry, ReposItem};
+    use crate::compile::types::{CheckoutFetchOpts, RepoEntry, ReposItem};
 
     #[test]
     fn test_repos_shorthand_simple() {
@@ -6515,6 +6579,62 @@ safe-outputs:
         ];
         let err = lower_repos(&items).unwrap_err();
         assert!(err.to_string().contains("Duplicate 'self' entry"), "{err}");
+    }
+
+    #[test]
+    fn test_repos_self_entry_rejects_unsupported_fields() {
+        // A `self` entry with a non-default `ref` (and an `alias`) must be
+        // rejected — those fields are meaningless for the trigger repo.
+        let items = vec![ReposItem::Full(RepoEntry {
+            name: "self".to_string(),
+            alias: Some("mine".to_string()),
+            repo_type: "git".to_string(),
+            repo_ref: "refs/heads/feature".to_string(),
+            checkout: false,
+            fetch_depth: Some(1),
+            fetch_tags: None,
+        })];
+        let err = lower_repos(&items).unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("only accepts"), "{msg}");
+        assert!(msg.contains("alias"), "{msg}");
+        assert!(msg.contains("ref"), "{msg}");
+        assert!(msg.contains("checkout"), "{msg}");
+    }
+
+    #[test]
+    fn test_repos_self_shorthand_rejects_alias() {
+        let items = vec![ReposItem::Shorthand("mine=self".to_string())];
+        let err = lower_repos(&items).unwrap_err();
+        assert!(err.to_string().contains("takes no alias"), "{err}");
+    }
+
+    #[test]
+    fn test_repos_bare_self_shorthand_is_noop() {
+        let items = vec![ReposItem::Shorthand("self".to_string())];
+        let (repos, checkout, fetch) = lower_repos(&items).unwrap();
+        assert!(repos.is_empty());
+        assert!(checkout.is_empty());
+        // A bare `self` records empty tuning under the reserved key.
+        assert_eq!(fetch.get("self"), Some(&CheckoutFetchOpts::default()));
+    }
+
+    #[test]
+    fn test_repos_fetch_opts_dropped_when_not_checked_out() {
+        let items = vec![ReposItem::Full(RepoEntry {
+            name: "my-org/monorepo".to_string(),
+            alias: None,
+            repo_type: "git".to_string(),
+            repo_ref: "refs/heads/main".to_string(),
+            checkout: false,
+            fetch_depth: Some(1),
+            fetch_tags: Some(false),
+        })];
+        let (repos, checkout, fetch) = lower_repos(&items).unwrap();
+        assert_eq!(repos.len(), 1);
+        assert!(checkout.is_empty());
+        // Not checked out ⇒ no fetch entry retained (it would never be read).
+        assert!(fetch.is_empty());
     }
 
     #[test]

--- a/src/compile/common.rs
+++ b/src/compile/common.rs
@@ -8,7 +8,8 @@ use super::extensions::{
     CompilerExtension, Declarations, McpgConfig, McpgGatewayConfig, McpgServerConfig,
 };
 use super::types::{
-    CompileTarget, FrontMatter, PipelineParameter, PoolConfig, ReposItem, Repository,
+    CheckoutFetchOpts, CompileTarget, FrontMatter, PipelineParameter, PoolConfig, ReposItem,
+    Repository, SELF_CHECKOUT_ALIAS,
 };
 use crate::allowed_hosts::{CORE_ALLOWED_HOSTS, mcp_required_hosts};
 use crate::compile::types::McpConfig;
@@ -534,15 +535,24 @@ pub fn build_parameters(
 // Compact `repos:` lowering
 // ──────────────────────────────────────────────────────────────────────────────
 
-/// Lower a `repos:` list into the internal `(Vec<Repository>, Vec<String>)` pair
-/// consumed by the rest of the compiler. Also validates aliases for collisions.
-pub fn lower_repos(items: &[ReposItem]) -> Result<(Vec<Repository>, Vec<String>)> {
+/// The result of lowering a `repos:` list: the ADO repository resources, the
+/// checkout-alias list, and per-checkout fetch tuning keyed by alias (plus
+/// [`SELF_CHECKOUT_ALIAS`] for the trigger repo).
+pub type LoweredRepos = (Vec<Repository>, Vec<String>, HashMap<String, CheckoutFetchOpts>);
+
+/// Lower a `repos:` list into the internal [`LoweredRepos`] triple consumed by
+/// the rest of the compiler. A reserved `self` entry (an entry whose *name* is
+/// exactly `self`) contributes only fetch tuning under the
+/// [`SELF_CHECKOUT_ALIAS`] key and emits neither a repository resource nor a
+/// checkout alias. Also validates aliases for collisions.
+pub fn lower_repos(items: &[ReposItem]) -> Result<LoweredRepos> {
     let mut repositories: Vec<Repository> = Vec::new();
     let mut checkout: Vec<String> = Vec::new();
+    let mut fetch: HashMap<String, CheckoutFetchOpts> = HashMap::new();
     let mut seen_aliases: HashSet<String> = HashSet::new();
 
     for item in items {
-        let (name, alias, repo_type, repo_ref, do_checkout) = match item {
+        let (name, alias, repo_type, repo_ref, do_checkout, fetch_opts) = match item {
             ReposItem::Shorthand(s) => {
                 let (alias, name) = parse_shorthand(s)?;
                 (
@@ -551,6 +561,7 @@ pub fn lower_repos(items: &[ReposItem]) -> Result<(Vec<Repository>, Vec<String>)
                     "git".to_string(),
                     "refs/heads/main".to_string(),
                     true,
+                    CheckoutFetchOpts::default(),
                 )
             }
             ReposItem::Full(entry) => {
@@ -564,9 +575,31 @@ pub fn lower_repos(items: &[ReposItem]) -> Result<(Vec<Repository>, Vec<String>)
                     entry.repo_type.clone(),
                     entry.repo_ref.clone(),
                     entry.checkout,
+                    CheckoutFetchOpts {
+                        fetch_depth: entry.fetch_depth,
+                        fetch_tags: entry.fetch_tags,
+                    },
                 )
             }
         };
+
+        // Reserved `self` entry: tunes the auto-generated `checkout: self`
+        // rather than declaring an additional repository resource. Detected by
+        // an explicit `self` *name* (not a derived/aliased collision like
+        // `org/self` or `self=org/repo`, which still hit the reserved guard
+        // below so real repos can't be silently swallowed).
+        if name == SELF_CHECKOUT_ALIAS {
+            if fetch
+                .insert(SELF_CHECKOUT_ALIAS.to_string(), fetch_opts)
+                .is_some()
+            {
+                anyhow::bail!(
+                    "Duplicate 'self' entry in repos. Declare the self-checkout \
+                    fetch tuning at most once."
+                );
+            }
+            continue;
+        }
 
         // Reject duplicate aliases
         if !seen_aliases.insert(alias.clone()) {
@@ -595,11 +628,14 @@ pub fn lower_repos(items: &[ReposItem]) -> Result<(Vec<Repository>, Vec<String>)
         });
 
         if do_checkout {
-            checkout.push(alias);
+            checkout.push(alias.clone());
+        }
+        if !fetch_opts.is_empty() {
+            fetch.insert(alias, fetch_opts);
         }
     }
 
-    Ok((repositories, checkout))
+    Ok((repositories, checkout, fetch))
 }
 
 /// Parse a shorthand string: `"org/repo"` → (derived alias, name), or
@@ -637,15 +673,16 @@ fn derive_alias(name: &str) -> Result<String> {
 }
 
 /// Resolve the `repos:` field in a `FrontMatter` into the canonical
-/// `(Vec<Repository>, Vec<String>)` pair consumed by the rest of the compiler.
+/// `(repositories, checkout, checkout_fetch)` triple consumed by the rest of
+/// the compiler.
 ///
 /// The legacy `repositories:` + `checkout:` fields are converted to `repos:`
 /// by the `repos_unified` codemod (`src/compile/codemods/0001_repos_unified.rs`)
 /// before typed deserialization, so by the time this function runs the only
 /// shape it sees is `repos:`.
-pub fn resolve_repos(front_matter: &FrontMatter) -> Result<(Vec<Repository>, Vec<String>)> {
+pub fn resolve_repos(front_matter: &FrontMatter) -> Result<LoweredRepos> {
     if front_matter.repos.is_empty() {
-        return Ok((Vec::new(), Vec::new()));
+        return Ok((Vec::new(), Vec::new(), HashMap::new()));
     }
     lower_repos(&front_matter.repos)
 }
@@ -6271,7 +6308,7 @@ safe-outputs:
     #[test]
     fn test_repos_shorthand_simple() {
         let items = vec![ReposItem::Shorthand("my-org/my-repo".to_string())];
-        let (repos, checkout) = lower_repos(&items).unwrap();
+        let (repos, checkout, _fetch) = lower_repos(&items).unwrap();
         assert_eq!(repos.len(), 1);
         assert_eq!(repos[0].repository, "my-repo");
         assert_eq!(repos[0].name, "my-org/my-repo");
@@ -6285,7 +6322,7 @@ safe-outputs:
         let items = vec![ReposItem::Shorthand(
             "schemas=my-org/internal-schemas".to_string(),
         )];
-        let (repos, checkout) = lower_repos(&items).unwrap();
+        let (repos, checkout, _fetch) = lower_repos(&items).unwrap();
         assert_eq!(repos.len(), 1);
         assert_eq!(repos[0].repository, "schemas");
         assert_eq!(repos[0].name, "my-org/internal-schemas");
@@ -6300,8 +6337,10 @@ safe-outputs:
             repo_type: "git".to_string(),
             repo_ref: "refs/heads/main".to_string(),
             checkout: true,
+            fetch_depth: None,
+            fetch_tags: None,
         })];
-        let (repos, checkout) = lower_repos(&items).unwrap();
+        let (repos, checkout, _fetch) = lower_repos(&items).unwrap();
         assert_eq!(repos[0].repository, "docs");
         assert_eq!(repos[0].name, "my-org/docs");
         assert_eq!(checkout, vec!["docs"]);
@@ -6315,8 +6354,10 @@ safe-outputs:
             repo_type: "git".to_string(),
             repo_ref: "refs/heads/main".to_string(),
             checkout: false,
+            fetch_depth: None,
+            fetch_tags: None,
         })];
-        let (repos, checkout) = lower_repos(&items).unwrap();
+        let (repos, checkout, _fetch) = lower_repos(&items).unwrap();
         assert_eq!(repos.len(), 1);
         assert_eq!(repos[0].repository, "big-monorepo");
         assert!(checkout.is_empty());
@@ -6330,8 +6371,10 @@ safe-outputs:
             repo_type: "git".to_string(),
             repo_ref: "refs/heads/release/2.x".to_string(),
             checkout: true,
+            fetch_depth: None,
+            fetch_tags: None,
         })];
-        let (repos, checkout) = lower_repos(&items).unwrap();
+        let (repos, checkout, _fetch) = lower_repos(&items).unwrap();
         assert_eq!(repos[0].repository, "docs-v2");
         assert_eq!(repos[0].repo_ref, "refs/heads/release/2.x");
         assert_eq!(checkout, vec!["docs-v2"]);
@@ -6373,6 +6416,8 @@ safe-outputs:
             repo_type: "git".to_string(),
             repo_ref: "refs/heads/main".to_string(),
             checkout: true,
+            fetch_depth: None,
+            fetch_tags: None,
         })];
         let err = lower_repos(&items).unwrap_err();
         assert!(err.to_string().contains("reserved"), "{err}");
@@ -6389,12 +6434,87 @@ safe-outputs:
                 repo_type: "git".to_string(),
                 repo_ref: "refs/heads/main".to_string(),
                 checkout: false,
+                fetch_depth: None,
+                fetch_tags: None,
             }),
         ];
-        let (repos, checkout) = lower_repos(&items).unwrap();
+        let (repos, checkout, _fetch) = lower_repos(&items).unwrap();
         assert_eq!(repos.len(), 3);
         assert_eq!(checkout, vec!["tools", "schemas"]);
         assert_eq!(repos[2].repository, "templates");
+    }
+
+    #[test]
+    fn test_repos_self_entry_tunes_self_checkout_only() {
+        let items = vec![
+            ReposItem::Full(RepoEntry {
+                name: "self".to_string(),
+                alias: None,
+                repo_type: "git".to_string(),
+                repo_ref: "refs/heads/main".to_string(),
+                checkout: true,
+                fetch_depth: Some(1),
+                fetch_tags: Some(false),
+            }),
+            ReposItem::Shorthand("my-org/tools".to_string()),
+        ];
+        let (repos, checkout, fetch) = lower_repos(&items).unwrap();
+        // The `self` entry emits no repository resource and no checkout alias.
+        assert_eq!(repos.len(), 1);
+        assert_eq!(repos[0].repository, "tools");
+        assert_eq!(checkout, vec!["tools"]);
+        // Its fetch tuning is captured under the reserved `self` key.
+        let self_opts = fetch.get("self").unwrap();
+        assert_eq!(self_opts.fetch_depth, Some(1));
+        assert_eq!(self_opts.fetch_tags, Some(false));
+        assert!(!fetch.contains_key("tools"));
+    }
+
+    #[test]
+    fn test_repos_named_entry_captures_fetch_opts() {
+        let items = vec![ReposItem::Full(RepoEntry {
+            name: "my-org/monorepo".to_string(),
+            alias: None,
+            repo_type: "git".to_string(),
+            repo_ref: "refs/heads/main".to_string(),
+            checkout: true,
+            fetch_depth: Some(0),
+            fetch_tags: Some(false),
+        })];
+        let (repos, checkout, fetch) = lower_repos(&items).unwrap();
+        assert_eq!(repos.len(), 1);
+        assert_eq!(checkout, vec!["monorepo"]);
+        let opts = fetch.get("monorepo").unwrap();
+        // `0` is preserved as the resolved value; depth_for_emit collapses it.
+        assert_eq!(opts.fetch_depth, Some(0));
+        assert_eq!(opts.depth_for_emit(), None);
+        assert_eq!(opts.fetch_tags, Some(false));
+    }
+
+    #[test]
+    fn test_repos_rejects_duplicate_self_entry() {
+        let items = vec![
+            ReposItem::Full(RepoEntry {
+                name: "self".to_string(),
+                alias: None,
+                repo_type: "git".to_string(),
+                repo_ref: "refs/heads/main".to_string(),
+                checkout: true,
+                fetch_depth: Some(1),
+                fetch_tags: None,
+            }),
+            ReposItem::Full(RepoEntry {
+                name: "self".to_string(),
+                alias: None,
+                repo_type: "git".to_string(),
+                repo_ref: "refs/heads/main".to_string(),
+                checkout: true,
+                fetch_depth: None,
+                fetch_tags: Some(true),
+            }),
+        ];
+        let err = lower_repos(&items).unwrap_err();
+        assert!(err.to_string().contains("Duplicate 'self' entry"), "{err}");
     }
 
     #[test]
@@ -6444,7 +6564,7 @@ name: "test"
 description: "test"
 "#;
         let fm: FrontMatter = serde_yaml::from_str(yaml).unwrap();
-        let (repos, checkout) = resolve_repos(&fm).unwrap();
+        let (repos, checkout, _fetch) = resolve_repos(&fm).unwrap();
         assert!(repos.is_empty());
         assert!(checkout.is_empty());
     }
@@ -6463,7 +6583,7 @@ repos:
     checkout: false
 "#;
         let fm: FrontMatter = serde_yaml::from_str(yaml).unwrap();
-        let (repos, checkout) = resolve_repos(&fm).unwrap();
+        let (repos, checkout, _fetch) = resolve_repos(&fm).unwrap();
         assert_eq!(repos.len(), 3);
         assert_eq!(repos[0].repository, "tools");
         assert_eq!(repos[0].name, "my-org/tools");
@@ -6487,7 +6607,7 @@ repos:
                       checkout:\n  - tools\n\
                       ---\nbody\n";
         let (fm, _) = parse_markdown(source).unwrap();
-        let (repos, checkout) = resolve_repos(&fm).unwrap();
+        let (repos, checkout, _fetch) = resolve_repos(&fm).unwrap();
         assert_eq!(repos.len(), 1);
         assert_eq!(repos[0].repository, "tools");
         assert_eq!(checkout, vec!["tools"]);

--- a/src/compile/ir/emit.rs
+++ b/src/compile/ir/emit.rs
@@ -59,6 +59,7 @@ mod tests {
             clean: Some(true),
             submodules: None,
             fetch_depth: None,
+            fetch_tags: None,
             persist_credentials: None,
         }));
         setup.push_step(Step::Bash(BashStep::new("Prep", "echo prep")));

--- a/src/compile/ir/job.rs
+++ b/src/compile/ir/job.rs
@@ -272,6 +272,7 @@ mod tests {
             clean: None,
             submodules: None,
             fetch_depth: None,
+            fetch_tags: None,
             persist_credentials: None,
         }));
         assert_eq!(j.steps.len(), 1);

--- a/src/compile/ir/lower.rs
+++ b/src/compile/ir/lower.rs
@@ -998,6 +998,9 @@ fn lower_checkout(c: &CheckoutStep) -> Value {
     if let Some(fd) = c.fetch_depth {
         m.insert(s("fetchDepth"), Value::from(fd));
     }
+    if let Some(ft) = c.fetch_tags {
+        m.insert(s("fetchTags"), Value::Bool(ft));
+    }
     if let Some(pc) = c.persist_credentials {
         m.insert(s("persistCredentials"), Value::Bool(pc));
     }
@@ -2747,5 +2750,38 @@ mod tests {
             merge_condition_with_template_param("succeeded()", "condition"),
             "and(succeeded(), ${{ parameters.condition }})"
         );
+    }
+
+    #[test]
+    fn lower_checkout_emits_fetch_depth_and_tags_when_set() {
+        let c = CheckoutStep {
+            repository: CheckoutRepo::Self_,
+            clean: None,
+            submodules: None,
+            fetch_depth: Some(1),
+            fetch_tags: Some(false),
+            persist_credentials: None,
+        };
+        let v = lower_checkout(&c);
+        let m = v.as_mapping().unwrap();
+        assert_eq!(m.get(s("checkout")).unwrap(), &s("self"));
+        assert_eq!(m.get(s("fetchDepth")).unwrap(), &Value::from(1u32));
+        assert_eq!(m.get(s("fetchTags")).unwrap(), &Value::Bool(false));
+    }
+
+    #[test]
+    fn lower_checkout_omits_fetch_keys_when_none() {
+        let c = CheckoutStep {
+            repository: CheckoutRepo::Self_,
+            clean: None,
+            submodules: None,
+            fetch_depth: None,
+            fetch_tags: None,
+            persist_credentials: None,
+        };
+        let v = lower_checkout(&c);
+        let m = v.as_mapping().unwrap();
+        assert!(m.get(s("fetchDepth")).is_none());
+        assert!(m.get(s("fetchTags")).is_none());
     }
 }

--- a/src/compile/ir/step.rs
+++ b/src/compile/ir/step.rs
@@ -186,6 +186,7 @@ pub struct CheckoutStep {
     pub clean: Option<bool>,
     pub submodules: Option<SubmodulesOpt>,
     pub fetch_depth: Option<u32>,
+    pub fetch_tags: Option<bool>,
     pub persist_credentials: Option<bool>,
 }
 
@@ -255,6 +256,7 @@ mod tests {
             clean: None,
             submodules: None,
             fetch_depth: None,
+            fetch_tags: None,
             persist_credentials: None,
         });
         assert!(chk.id().is_none());

--- a/src/compile/mod.rs
+++ b/src/compile/mod.rs
@@ -158,9 +158,11 @@ async fn compile_pipeline_inner(
     front_matter.sanitize_config_fields();
 
     // Resolve repos: new compact syntax or legacy repositories: + checkout:
-    let (resolved_repos, resolved_checkout) = common::resolve_repos(&front_matter)?;
+    let (resolved_repos, resolved_checkout, resolved_checkout_fetch) =
+        common::resolve_repos(&front_matter)?;
     front_matter.repositories = resolved_repos;
     front_matter.checkout = resolved_checkout;
+    front_matter.checkout_fetch = resolved_checkout_fetch;
 
     // Validate checkout list against repositories
     common::validate_checkout_list(&front_matter.repositories, &front_matter.checkout)?;
@@ -594,9 +596,11 @@ pub async fn check_pipeline(pipeline_path: &str) -> Result<()> {
     front_matter.sanitize_config_fields();
 
     // Resolve repos (compact or legacy)
-    let (resolved_repos, resolved_checkout) = common::resolve_repos(&front_matter)?;
+    let (resolved_repos, resolved_checkout, resolved_checkout_fetch) =
+        common::resolve_repos(&front_matter)?;
     front_matter.repositories = resolved_repos;
     front_matter.checkout = resolved_checkout;
+    front_matter.checkout_fetch = resolved_checkout_fetch;
 
     common::validate_checkout_list(&front_matter.repositories, &front_matter.checkout)?;
 
@@ -902,9 +906,11 @@ pub async fn build_pipeline_ir(input_path: &Path) -> Result<(FrontMatter, ir::Pi
     use crate::sanitize::SanitizeConfig;
     front_matter.sanitize_config_fields();
 
-    let (resolved_repos, resolved_checkout) = common::resolve_repos(&front_matter)?;
+    let (resolved_repos, resolved_checkout, resolved_checkout_fetch) =
+        common::resolve_repos(&front_matter)?;
     front_matter.repositories = resolved_repos;
     front_matter.checkout = resolved_checkout;
+    front_matter.checkout_fetch = resolved_checkout_fetch;
     common::validate_checkout_list(&front_matter.repositories, &front_matter.checkout)?;
 
     // Inferred output path for the marker step. Defaults to

--- a/src/compile/path_layout_check.rs
+++ b/src/compile/path_layout_check.rs
@@ -210,10 +210,11 @@ mod tests {
         let mut fm: FrontMatter = serde_yaml::from_str(yaml).expect("parse front matter");
         // Lower repos the way the compile pipeline does.
         if !fm.repos.is_empty() {
-            let (repositories, checkout) =
+            let (repositories, checkout, checkout_fetch) =
                 crate::compile::common::lower_repos(&fm.repos).expect("lower repos");
             fm.repositories = repositories;
             fm.checkout = checkout;
+            fm.checkout_fetch = checkout_fetch;
         }
         fm
     }

--- a/src/compile/types.rs
+++ b/src/compile/types.rs
@@ -664,6 +664,11 @@ pub struct FrontMatter {
     /// YAML directly.
     #[serde(skip)]
     pub checkout: Vec<String>,
+    /// Lowered per-checkout fetch tuning, populated by `lower_repos()`. Keyed by
+    /// alias, plus [`SELF_CHECKOUT_ALIAS`] for the trigger repo. Not
+    /// deserialized from YAML directly.
+    #[serde(skip)]
+    pub checkout_fetch: HashMap<String, CheckoutFetchOpts>,
     /// MCP server configurations
     #[serde(default, rename = "mcp-servers")]
     pub mcp_servers: HashMap<String, McpConfig>,
@@ -1327,6 +1332,17 @@ pub struct RepoEntry {
     /// Whether the agent job checks out this repository. Defaults to `true`.
     #[serde(default = "default_checkout")]
     pub checkout: bool,
+    /// Shallow-clone depth for this repository's checkout step. Maps to ADO
+    /// `fetchDepth`. `0` means full history (no `fetchDepth` emitted). When
+    /// omitted, the ADO default applies. Also settable on a reserved `self`
+    /// entry to tune the auto-generated `checkout: self`.
+    #[serde(default, rename = "fetch-depth")]
+    pub fetch_depth: Option<u32>,
+    /// Whether to fetch git tags during this repository's checkout step. Maps
+    /// to ADO `fetchTags`. When omitted, the ADO default applies. Also settable
+    /// on a reserved `self` entry.
+    #[serde(default, rename = "fetch-tags")]
+    pub fetch_tags: Option<bool>,
 }
 
 fn default_repo_type() -> String {
@@ -1335,6 +1351,34 @@ fn default_repo_type() -> String {
 
 fn default_checkout() -> bool {
     true
+}
+
+/// Reserved `repos:` alias that tunes the auto-generated `checkout: self`
+/// step rather than declaring an additional repository resource.
+pub const SELF_CHECKOUT_ALIAS: &str = "self";
+
+/// Resolved fetch tuning for a single checkout step (`self` or a named
+/// repository). Populated by `lower_repos()` from `repos:` entries and keyed by
+/// alias (with [`SELF_CHECKOUT_ALIAS`] for the trigger repo).
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct CheckoutFetchOpts {
+    /// ADO `fetchDepth`. `Some(0)` means full history.
+    pub fetch_depth: Option<u32>,
+    /// ADO `fetchTags`.
+    pub fetch_tags: Option<bool>,
+}
+
+impl CheckoutFetchOpts {
+    /// `true` when no tuning is set (a no-op, e.g. a bare `self` entry).
+    pub fn is_empty(&self) -> bool {
+        self.fetch_depth.is_none() && self.fetch_tags.is_none()
+    }
+
+    /// The `fetchDepth` value to emit: `Some(0)` (full history) collapses to
+    /// `None` so no `fetchDepth` key is written.
+    pub fn depth_for_emit(&self) -> Option<u32> {
+        self.fetch_depth.filter(|d| *d != 0)
+    }
 }
 
 /// A single item in the `repos:` list — either a string shorthand or an object.

--- a/src/main.rs
+++ b/src/main.rs
@@ -741,10 +741,12 @@ async fn run_execute(
     front_matter.sanitize_config_fields();
 
     // Resolve compact repos: syntax into the legacy fields for execution
-    let (resolved_repos, resolved_checkout) = compile::resolve_repos(&front_matter)
-        .with_context(|| "Failed to resolve repository configuration")?;
+    let (resolved_repos, resolved_checkout, resolved_checkout_fetch) =
+        compile::resolve_repos(&front_matter)
+            .with_context(|| "Failed to resolve repository configuration")?;
     front_matter.repositories = resolved_repos;
     front_matter.checkout = resolved_checkout;
+    front_matter.checkout_fetch = resolved_checkout_fetch;
 
     println!("Loaded tool configs from: {}", source.display());
 

--- a/tests/compiler_tests.rs
+++ b/tests/compiler_tests.rs
@@ -7078,3 +7078,108 @@ fn invalid_task_input_compiles_silently_and_preserves_passthrough() {
     );
 }
 
+/// A reserved `self` entry in `repos:` tunes the auto-generated
+/// `checkout: self` step in every job (fetchDepth + fetchTags) without emitting
+/// a repository resource or an extra checkout.
+#[test]
+fn test_repos_self_entry_tunes_all_self_checkouts() {
+    let source = r#"---
+name: "Self Checkout Tuning"
+description: "shallow, no tags on self"
+repos:
+  - name: self
+    fetch-depth: 1
+    fetch-tags: false
+---
+
+## Body
+"#;
+    let (ok, compiled, stderr) = compile_inline_source("self-checkout-tuning", source);
+    assert!(ok, "self-checkout tuning should compile: {stderr}");
+
+    let self_checkouts = compiled.matches("- checkout: self").count();
+    assert!(
+        self_checkouts >= 2,
+        "expected multiple `checkout: self` steps, found {self_checkouts}:\n{compiled}"
+    );
+    // Every self checkout carries the tuned fetch options.
+    assert_eq!(
+        compiled.matches("fetchDepth: 1").count(),
+        self_checkouts,
+        "each `checkout: self` must carry fetchDepth: 1:\n{compiled}"
+    );
+    assert_eq!(
+        compiled.matches("fetchTags: false").count(),
+        self_checkouts,
+        "each `checkout: self` must carry fetchTags: false:\n{compiled}"
+    );
+    // `self` must NOT add an extra repository resource — only the canonical
+    // `SelfRepo` (always emitted) should be present.
+    assert_eq!(
+        compiled.matches("repository: self").count(),
+        1,
+        "the reserved `self` entry must not emit an extra repository resource:\n{compiled}"
+    );
+}
+
+/// `fetch-depth` / `fetch-tags` on a named `repos:` entry tune that
+/// repository's checkout step (which lands in the Agent job).
+#[test]
+fn test_repos_named_entry_fetch_tuning_emitted() {
+    let source = r#"---
+name: "Named Checkout Tuning"
+description: "shallow named repo"
+repos:
+  - name: my-org/monorepo
+    fetch-depth: 1
+    fetch-tags: false
+---
+
+## Body
+"#;
+    let (ok, compiled, stderr) = compile_inline_source("named-checkout-tuning", source);
+    assert!(ok, "named checkout tuning should compile: {stderr}");
+
+    let agent = job_block(&compiled, "Agent");
+    assert!(
+        agent.contains("- checkout: monorepo"),
+        "the named repo must be checked out in the Agent job:\n{agent}"
+    );
+    assert!(
+        agent.contains("fetchDepth: 1") && agent.contains("fetchTags: false"),
+        "the named checkout must carry the tuned fetch options:\n{agent}"
+    );
+    // Without a `self` entry, `checkout: self` stays at ADO defaults.
+    assert!(
+        !agent.contains("- checkout: self\n  fetchDepth"),
+        "checkout: self must stay untuned when only a named repo is tuned:\n{agent}"
+    );
+}
+
+/// Regression: with no `repos:` fetch tuning, checkout steps stay bare (ADO
+/// defaults), so existing agents compile byte-for-byte unchanged.
+#[test]
+fn test_no_repos_fetch_tuning_emits_bare_checkout() {
+    let source = r#"---
+name: "Bare Checkout"
+description: "no fetch tuning"
+---
+
+## Body
+"#;
+    let (ok, compiled, stderr) = compile_inline_source("bare-checkout", source);
+    assert!(ok, "bare agent should compile: {stderr}");
+    assert!(
+        compiled.contains("- checkout: self"),
+        "the self checkout must still be emitted:\n{compiled}"
+    );
+    assert!(
+        !compiled.contains("fetchDepth"),
+        "no fetchDepth key without tuning:\n{compiled}"
+    );
+    assert!(
+        !compiled.contains("fetchTags"),
+        "no fetchTags key without tuning:\n{compiled}"
+    );
+}
+


### PR DESCRIPTION
## Summary

Closes #1318.

On large Azure DevOps monorepos the auto-generated `checkout` step can dominate the run: ADO's default performs a full-history clone **and** `git fetch --tags`, which can take tens of minutes. Until now there was no front-matter knob to tune this, so the only workaround was hand-editing the compiled `.lock.yml` — which then fails the runtime "Verify pipeline integrity" step and forces `ado-aw-debug.skip-integrity: true`.

This adds first-class fetch tuning to the `repos:` object, applied to **every** checkout step:

```yaml
repos:
  - name: my-org/monorepo   # named repo
    fetch-depth: 1
    fetch-tags: false
  - name: self              # reserved entry: tunes checkout: self only
    fetch-depth: 1
    fetch-tags: false
```

- `fetch-depth: 0` means full history (no `fetchDepth` emitted).
- A reserved `self` entry contributes **only** fetch tuning — no extra repository resource or checkout — and applies to the `checkout: self` step in every job (Setup/Agent/Detection/SafeOutputs/Teardown), across all targets (standalone/1es/job/stage).
- Omitted fields keep ADO defaults, so agents that don't opt in compile **byte-for-byte unchanged**.
- Because the tuning comes from source, the compiled lock stays in sync and the runtime integrity check keeps passing — no `skip-integrity` workaround.
- `persistCredentials` is intentionally not exposed (trust boundary).

### Key changes

- **`ir/step.rs` + `ir/lower.rs`** — new `CheckoutStep.fetch_tags` field; emits `fetchTags` beside `fetchDepth`.
- **`types.rs`** — `fetch-depth`/`fetch-tags` on `RepoEntry`; `CheckoutFetchOpts` (with `depth_for_emit()` collapsing `0` → full history); `SELF_CHECKOUT_ALIAS`; `FrontMatter.checkout_fetch`.
- **`common.rs::lower_repos`** — returns a `LoweredRepos` triple; a `self`-named entry is special-cased **before** the reserved-name guard, so `org/self`, `self=org/repo`, and aliased collisions still error.
- **`agentic_pipeline.rs`** — `StandaloneCtx.self_checkout_fetch` threaded into `checkout_self_step()`; the additional-repo loop applies per-alias opts.
- **`docs/front-matter.md`** — documents the new fields and the `self` entry.

## Test plan

- `cargo clippy --all-targets --all-features` — clean.
- `cargo test` — green (2464 unit + all integration tests, 0 failed).
- Added 5 unit tests (`lower_checkout` emission; `lower_repos` self/named/duplicate-self handling) and 3 compile-level integration tests (self tuning applied to every `checkout: self`; named-repo tuning in the Agent job; regression that non-configured agents emit bare checkout steps).
