### PR TITLE
fix(executor-e2e): let definition variable override issue-filing repo

### DIFF
--- a/scripts/ado-script/src/executor-e2e/__tests__/github-issue.test.ts
+++ b/scripts/ado-script/src/executor-e2e/__tests__/github-issue.test.ts
@@ -68,6 +68,20 @@ describe("loadIssueEnv", () => {
     const env = loadIssueEnv({ ADO_AW_DEBUG_GITHUB_TOKEN: "fallback" } as NodeJS.ProcessEnv);
     expect(env.token).toBe("fallback");
   });
+
+  it("honors an explicit EXECUTOR_E2E_ISSUE_REPO override", () => {
+    const env = loadIssueEnv({
+      EXECUTOR_E2E_ISSUE_REPO: "jamesadevine/ado-aw-issues",
+    } as NodeJS.ProcessEnv);
+    expect(env.repo).toBe("jamesadevine/ado-aw-issues");
+  });
+
+  it("treats an unexpanded ADO macro as unset and falls back to the default", () => {
+    const env = loadIssueEnv({
+      EXECUTOR_E2E_ISSUE_REPO: "$(EXECUTOR_E2E_ISSUE_REPO)",
+    } as NodeJS.ProcessEnv);
+    expect(env.repo).toBe("githubnext/ado-aw");
+  });
 });
 
 describe("fileFailureIssue", () => {

--- a/scripts/ado-script/src/executor-e2e/github-issue.ts
+++ b/scripts/ado-script/src/executor-e2e/github-issue.ts
@@ -37,7 +37,7 @@ export function loadIssueEnv(env: NodeJS.ProcessEnv = process.env): IssueEnv {
   }
   return {
     token: env.EXECUTOR_E2E_GITHUB_TOKEN?.trim() || env.ADO_AW_DEBUG_GITHUB_TOKEN?.trim(),
-    repo: env.EXECUTOR_E2E_ISSUE_REPO?.trim() || DEFAULT_REPO,
+    repo: cleanVar(env.EXECUTOR_E2E_ISSUE_REPO) || DEFAULT_REPO,
     labels,
     buildId: env.BUILD_BUILDID?.trim(),
     buildUrl:
@@ -47,6 +47,19 @@ export function loadIssueEnv(env: NodeJS.ProcessEnv = process.env): IssueEnv {
         : undefined),
     project: env.SYSTEM_TEAMPROJECT?.trim(),
   };
+}
+
+/**
+ * Trim a pipeline env value, treating an UNEXPANDED ADO macro (e.g. the literal
+ * `$(EXECUTOR_E2E_ISSUE_REPO)`) as absent. ADO passes a `$(VAR)` reference
+ * through verbatim when VAR is undefined, so without this guard an unset
+ * override would be used as a bogus repo slug instead of falling back to the
+ * default.
+ */
+function cleanVar(raw: string | undefined): string | undefined {
+  const value = raw?.trim();
+  if (!value || /^\$\(.*\)$/.test(value)) return undefined;
+  return value;
 }
 
 /**

--- a/tests/executor-e2e/azure-pipelines.yml
+++ b/tests/executor-e2e/azure-pipelines.yml
@@ -30,8 +30,12 @@ variables:
   # ADO Git repo (with an initialised main branch) used by the PR/git/
   # create-pull-request scenarios.
   EXECUTOR_E2E_ADO_REPO: agent-definitions
-  # GitHub repo that failure issues are filed against.
-  EXECUTOR_E2E_ISSUE_REPO: githubnext/ado-aw
+  # GitHub repo that failure issues are filed against. NOT defined here on
+  # purpose: a YAML `variables:` entry SHADOWS a same-named pipeline (definition)
+  # variable, so hardcoding it would block per-pipeline overrides. Set
+  # EXECUTOR_E2E_ISSUE_REPO as a pipeline/definition variable to redirect issue
+  # filing (e.g. to a fork you can write to); the harness defaults to
+  # githubnext/ado-aw when it is unset.
   # Optional-precondition scenarios: empty by default so queue-build / wiki
   # skip gracefully. Override at queue time (or via a variable group) to enable.
   E2E_QUEUE_PIPELINE_ID: ""


### PR DESCRIPTION
## Problem

A live pipeline run confirmed failure issues were still filed to `githubnext/ado-aw` **even though the pipeline's `EXECUTOR_E2E_ISSUE_REPO` definition variable was set to a personal fork**. The newly-merged diagnostic (#1401) surfaced it directly:

```
GitHub token diagnosis: authenticated as 'jamesadevine' but got HTTP 403 filing to 'githubnext/ado-aw'.
```

Root cause: a YAML `variables:` entry **shadows** a same-named ADO pipeline (definition) variable — contrary to the common "UI overrides YAML" belief. The hardcoded `EXECUTOR_E2E_ISSUE_REPO: githubnext/ado-aw` in the pipeline YAML meant the definition-variable override was silently ignored.

## Change

- **Remove** the `EXECUTOR_E2E_ISSUE_REPO` hardcode from `tests/executor-e2e/azure-pipelines.yml` so a definition variable can take effect. Production behaviour is unchanged: the harness still defaults to `githubnext/ado-aw` (`DEFAULT_REPO`) when the variable is unset.
- **Harden** `loadIssueEnv` to treat an unexpanded ADO macro (the literal `$(EXECUTOR_E2E_ISSUE_REPO)`) as unset, so an undefined override falls back to the default instead of being used as a bogus repo slug.

## Tests

Adds coverage for the explicit-override and unexpanded-macro paths. Full `src/executor-e2e` suite: 24 passing; `tsc --noEmit` clean; bundle builds.
