### PR TITLE
feat(compile): support Azure DevOps variable group imports

### DIFF
--- a/docs/engine.md
+++ b/docs/engine.md
@@ -146,6 +146,14 @@ agent pool's normal network — no AWF `network.allowed` entry is required.
   `Warning: engine.github-app-token uses pipeline variable '<name>' … Ensure
   '<name>' is stored as a SECRET …`. It is non-blocking — heed it by setting the
   value with `ado-aw secrets set` (which stores it as a secret).
+- **Project-level keys via variable groups.** To manage the private key once
+  at the project level instead of setting it on every pipeline definition,
+  store it in an Azure DevOps **variable group** and import that group with the
+  top-level [`variable-groups:`](front-matter.md#variable-groups-variable-groups)
+  front-matter field. Point `private-key` at the variable the group supplies
+  (e.g. `private-key: AGENTIC_WORKFLOWS_GITHUB_APP_PRIVATE_KEY`). Remember that
+  in ADO the group must be **both** authorized on the pipeline definition **and**
+  imported in YAML — `variable-groups:` provides the import.
 - **GHEC by default; GHES via `api-url`.** The mint/revoke steps target
   `https://api.github.com` unless you set `api-url` to your GitHub Enterprise
   Server `/api/v3` base URL. This is independent of `engine.api-target`, which

--- a/docs/front-matter.md
+++ b/docs/front-matter.md
@@ -483,12 +483,14 @@ engine:
 
 Group names that contain ADO expressions (`${{`, `$(`, `$[`), pipeline
 commands (`##vso[`, `##[`), the compiler's template marker (`{{`), or
-control characters (including newlines) are rejected at compile time.
+control characters (including newlines) are rejected at compile time. Names
+with leading or trailing whitespace are also rejected — the entry is emitted
+verbatim as `- group: <name>`, so it must match the ADO group name exactly.
 
-Duplicate imports are also rejected. Azure DevOps variable group names are
-case-insensitive, so two entries that differ only by case or surrounding
-whitespace (e.g. `Shared Secrets` and `shared secrets`) are treated as the
-same group and fail compilation — remove the redundant entry.
+Duplicate imports are rejected too. Azure DevOps variable group names are
+case-insensitive, so two entries that differ only by case (e.g.
+`Shared Secrets` and `shared secrets`) are treated as the same group and fail
+compilation — remove the redundant entry.
 
 ### Target support
 

--- a/docs/front-matter.md
+++ b/docs/front-matter.md
@@ -485,6 +485,11 @@ Group names that contain ADO expressions (`${{`, `$(`, `$[`), pipeline
 commands (`##vso[`, `##[`), the compiler's template marker (`{{`), or
 control characters (including newlines) are rejected at compile time.
 
+Duplicate imports are also rejected. Azure DevOps variable group names are
+case-insensitive, so two entries that differ only by case or surrounding
+whitespace (e.g. `Shared Secrets` and `shared secrets`) are treated as the
+same group and fail compilation — remove the redundant entry.
+
 ### Target support
 
 `variable-groups:` is only valid for pipeline-level targets — `standalone`

--- a/docs/front-matter.md
+++ b/docs/front-matter.md
@@ -423,6 +423,77 @@ becomes a `repos:` entry, with `checkout: false` added for entries
 that weren't listed under `checkout:`. Mixing the legacy fields with
 an existing `repos:` block is rejected; pick one shape.
 
+## Variable Groups (`variable-groups:`)
+
+Import one or more Azure DevOps **variable groups** (ADO "Library" groups)
+into the generated pipeline so a source-clean lock can consume secrets that
+are managed once at the project level — for example a GitHub App private key
+shared across many pipelines:
+
+```yaml
+variable-groups:
+  - Agentic Workflows
+  - Shared Secrets
+```
+
+Each entry is the **name** of a variable group. The compiler emits a
+top-level `variables:` block with one `- group:` import per entry, in
+declaration order:
+
+```yaml
+variables:
+  - group: Agentic Workflows
+  - group: Shared Secrets
+```
+
+Groups are evaluated in order, so a later group wins on key collisions.
+
+### Authorization *and* import are both required
+
+In Azure DevOps, two independent things are needed before a group's
+variables are available to a YAML run:
+
+1. **Authorization** — the pipeline *definition* must be granted permission
+   to use the group (done in the ADO Library UI / API, outside ado-aw).
+2. **YAML import** — the pipeline *YAML* must explicitly pull the group in
+   with `variables: - group: <name>`.
+
+Authorization alone is **not** sufficient — without the YAML import the
+variables are unavailable at runtime. `variable-groups:` provides the YAML
+import; you still have to authorize the group on the pipeline definition.
+
+### Names only — never values
+
+Only group **names** belong in `variable-groups:`. ado-aw never resolves,
+prints, logs, or serialises a group's variable values. Steps continue to
+reference secret variables by macro (`$(VAR_NAME)`) exactly as before — for
+instance `engine.github-app-token.private-key` names a variable that a group
+supplies:
+
+```yaml
+variable-groups:
+  - Agentic Workflows
+engine:
+  id: copilot
+  github-app-token:
+    app-id: 1234567
+    owner: octo-org
+    private-key: AGENTIC_WORKFLOWS_GITHUB_APP_PRIVATE_KEY
+```
+
+Group names that contain ADO expressions (`${{`, `$(`, `$[`), pipeline
+commands (`##vso[`, `##[`), control characters, or newlines are rejected at
+compile time.
+
+### Target support
+
+`variable-groups:` is only valid for pipeline-level targets — `standalone`
+(default) and `1es`. Azure DevOps `job` / `stage` **templates** cannot
+declare pipeline-level `variables:` (the parent pipeline that includes the
+template owns them), so `variable-groups:` on `target: job` or
+`target: stage` is a hard compile-time error. Import the group in the parent
+pipeline that includes the template instead.
+
 ## Inlined Imports
 
 The `inlined-imports:` field controls when `{{#runtime-import ...}}`

--- a/docs/front-matter.md
+++ b/docs/front-matter.md
@@ -482,8 +482,8 @@ engine:
 ```
 
 Group names that contain ADO expressions (`${{`, `$(`, `$[`), pipeline
-commands (`##vso[`, `##[`), control characters, or newlines are rejected at
-compile time.
+commands (`##vso[`, `##[`), the compiler's template marker (`{{`), or
+control characters (including newlines) are rejected at compile time.
 
 ### Target support
 

--- a/docs/ir.md
+++ b/docs/ir.md
@@ -47,6 +47,20 @@ pub struct Pipeline {
 }
 ```
 
+`PipelineVar` is the top-level `variables:` entry type. It is an enum so a
+literal `- name: … / value: …` entry and an Azure DevOps variable-group import
+(`- group: …`) share one list:
+
+```rust
+pub enum PipelineVar {
+    /// Literal `- name: <name>` / `value: <value>` entry (optionally `isSecret: true`).
+    NameValue { name: String, value: String, is_secret: bool },
+    /// Variable-group import `- group: <name>` — only the group name is carried;
+    /// ado-aw never resolves, logs, or serialises the group's variable values.
+    Group(String),
+}
+```
+
 `PipelineBody` captures whether the emitted document has a top-level `jobs:` block or a top-level `stages:` block:
 
 ```rust

--- a/docs/targets.md
+++ b/docs/targets.md
@@ -44,6 +44,12 @@ The output contains the same 3-job chain (Agent → Detection → SafeOutputs) a
 - No triggers, pipeline name, or resource declarations (the parent pipeline owns those)
 - Pool baked in from the front matter `pool:` field (`vmImage` or `name`; defaults to `vmImage: ubuntu-22.04`)
 
+> **Variable groups are not supported here.** ADO `job` / `stage` templates
+> cannot declare pipeline-level `variables:` — the parent pipeline owns them.
+> Declaring [`variable-groups:`](front-matter.md#variable-groups-variable-groups)
+> on `target: job` or `target: stage` is a compile-time error; import the group
+> in the parent pipeline that includes this template instead.
+
 Example front matter:
 ```yaml
 target: job

--- a/prompts/create-ado-agentic-workflow.md
+++ b/prompts/create-ado-agentic-workflow.md
@@ -99,6 +99,11 @@ Copilot auth — omit it otherwise. See
 the full field reference (`private-key` override, `api-url` for GHES,
 `skip-token-revocation`).
 
+To manage the private key once at the project level (instead of per pipeline),
+store it in an Azure DevOps **variable group** and import that group with the
+top-level `variable-groups:` field (see Step 17b), pointing `private-key` at the
+variable the group supplies.
+
 **Custom model provider (BYOK).** To route the Copilot engine to an external LLM
 provider (e.g. Azure AI Foundry, OpenAI), use the `engine.provider` block. The
 compiler mints the provider credential in-job and auto-adds the provider hostname
@@ -655,6 +660,33 @@ inlined-imports: true
 **Trade-off**: with `inlined-imports: true`, every change to the agent instructions requires running `ado-aw compile` and committing the updated `.lock.yml`. Omit this field (or set it to `false`) for the typical edit-without-recompile workflow.
 
 You can also reference shared files from the agent body using `{{#runtime-import path/to/file.md}}` markers.
+
+### Step 17b — Variable Groups (advanced, optional)
+
+To consume secrets managed once at the project level (e.g. a shared GitHub App
+private key), import one or more Azure DevOps **variable groups** with the
+top-level `variable-groups:` field:
+
+```yaml
+variable-groups:
+  - Agentic Workflows
+  - Shared Secrets
+```
+
+The compiler emits a top-level `variables:` block with a `- group: <name>`
+import per entry. Notes:
+
+- Put **only group names** here — never secret values. Steps still reference
+  secrets by macro (`$(VAR_NAME)`), e.g. `github-app-token.private-key`.
+- In ADO the group must be **both** authorized on the pipeline definition **and**
+  imported in YAML; this field provides the import (authorization is done in the
+  ADO Library UI).
+- Only valid for `target: standalone` (default) and `target: 1es`. It is a
+  compile-time error on `target: job` / `target: stage` (the parent pipeline
+  owns pipeline-level `variables:`).
+
+See [`docs/front-matter.md`](../docs/front-matter.md#variable-groups-variable-groups)
+for the full reference.
 
 ---
 

--- a/site/src/content/docs/reference/ir.mdx
+++ b/site/src/content/docs/reference/ir.mdx
@@ -49,6 +49,20 @@ pub struct Pipeline {
 }
 ```
 
+`PipelineVar` is the top-level `variables:` entry type. It is an enum so a
+literal `- name: … / value: …` entry and an Azure DevOps variable-group import
+(`- group: …`) share one list:
+
+```rust
+pub enum PipelineVar {
+    /// Literal `- name: <name>` / `value: <value>` entry (optionally `isSecret: true`).
+    NameValue { name: String, value: String, is_secret: bool },
+    /// Variable-group import `- group: <name>` — only the group name is carried;
+    /// ado-aw never resolves, logs, or serialises the group's variable values.
+    Group(String),
+}
+```
+
 `PipelineBody` captures whether the emitted document has a top-level `jobs:` block or a top-level `stages:` block:
 
 ```rust

--- a/src/compile/agentic_pipeline.rs
+++ b/src/compile/agentic_pipeline.rs
@@ -122,6 +122,7 @@ pub(crate) fn build_pipeline_context(
 ) -> Result<BuiltPipelineContext> {
     // ─── Validations (reuse all shared validators) ────────────────
     common::validate_front_matter_identity(front_matter)?;
+    common::validate_variable_groups(front_matter)?;
     common::validate_checkout_self_collision(
         &front_matter.repositories,
         &front_matter.checkout,

--- a/src/compile/common.rs
+++ b/src/compile/common.rs
@@ -2796,9 +2796,9 @@ mod tests {
 
     #[test]
     fn validate_variable_groups_rejects_duplicates() {
-        // Exact duplicate, case-only difference, and whitespace-only difference
-        // are all treated as the same group and rejected.
-        for second in ["Shared Secrets", "shared secrets", " Shared Secrets "] {
+        // Exact duplicate and case-only difference are treated as the same
+        // group (ADO names are case-insensitive) and rejected as duplicates.
+        for second in ["Shared Secrets", "shared secrets"] {
             let src = format!(
                 "---\nname: t\ndescription: d\nvariable-groups:\n  - Shared Secrets\n  - \"{second}\"\n---\n"
             );
@@ -2809,6 +2809,20 @@ mod tests {
                 "duplicate {second:?} must be rejected; err: {err}"
             );
         }
+    }
+
+    #[test]
+    fn validate_variable_groups_rejects_padded_name() {
+        // A single entry with leading/trailing whitespace is rejected at the
+        // name-validation stage (before the duplicate check), because the raw
+        // string is emitted verbatim into the YAML and would not match the ADO
+        // group.
+        let src =
+            "---\nname: t\ndescription: d\nvariable-groups:\n  - \" Shared Secrets \"\n---\n"
+                .to_string();
+        let (fm, _) = parse_markdown(&src).unwrap();
+        let err = validate_variable_groups(&fm).unwrap_err().to_string();
+        assert!(err.contains("is not a valid"), "err: {err}");
     }
 
     fn extension_declarations(extensions: &[Extension], fm: &FrontMatter) -> Vec<Declarations> {

--- a/src/compile/common.rs
+++ b/src/compile/common.rs
@@ -495,6 +495,19 @@ pub fn validate_variable_groups(front_matter: &FrontMatter) -> Result<()> {
     Ok(())
 }
 
+/// Map the validated `variable-groups:` front-matter entries to top-level
+/// [`super::ir::PipelineVar::Group`] imports, preserving declaration order.
+/// Names are already validated by [`validate_variable_groups`] (invoked inside
+/// [`build_pipeline_context`]).
+pub fn variable_group_vars(front_matter: &FrontMatter) -> Vec<super::ir::PipelineVar> {
+    front_matter
+        .variable_groups
+        .iter()
+        .cloned()
+        .map(super::ir::PipelineVar::Group)
+        .collect()
+}
+
 /// Build the final parameters list by combining user-defined parameters
 /// with auto-injected parameters.
 ///

--- a/src/compile/common.rs
+++ b/src/compile/common.rs
@@ -492,18 +492,19 @@ pub fn validate_variable_groups(front_matter: &FrontMatter) -> Result<()> {
             );
         }
 
-        // Reject duplicate imports (case-insensitive, whitespace-trimmed): ADO
-        // variable group names are case-insensitive display names, and importing
-        // the same group twice emits redundant `- group:` entries whose
-        // collision behaviour is unspecified. A duplicate is always an authoring
-        // mistake, so fail closed rather than silently emitting it.
-        let key = group.trim().to_ascii_lowercase();
+        // Reject duplicate imports (case-insensitive): ADO variable group names
+        // are case-insensitive display names, and importing the same group twice
+        // emits redundant `- group:` entries whose collision behaviour is
+        // unspecified. A duplicate is always an authoring mistake, so fail closed
+        // rather than silently emitting it. (Leading/trailing whitespace is
+        // already rejected by is_valid_variable_group_name above, so the key
+        // needs no .trim().)
+        let key = group.to_ascii_lowercase();
         if !seen.insert(key) {
             anyhow::bail!(
                 "variable-groups entry {group:?} is imported more than once — remove the \
                  duplicate. Azure DevOps variable group names are case-insensitive, so entries \
-                 that differ only by case or surrounding whitespace are treated as the same \
-                 group."
+                 that differ only by case are treated as the same group."
             );
         }
     }

--- a/src/compile/common.rs
+++ b/src/compile/common.rs
@@ -480,6 +480,7 @@ pub fn validate_variable_groups(front_matter: &FrontMatter) -> Result<()> {
         );
     }
 
+    let mut seen: std::collections::HashSet<String> = std::collections::HashSet::new();
     for group in &front_matter.variable_groups {
         if !validate::is_valid_variable_group_name(group) {
             anyhow::bail!(
@@ -488,6 +489,21 @@ pub fn validate_variable_groups(front_matter: &FrontMatter) -> Result<()> {
                  characters, newlines, ADO expressions ('${{{{', '$(', '$['), pipeline commands \
                  ('##vso[', '##['), or the template marker ('{{{{'). Only group names belong \
                  here — never secret values."
+            );
+        }
+
+        // Reject duplicate imports (case-insensitive, whitespace-trimmed): ADO
+        // variable group names are case-insensitive display names, and importing
+        // the same group twice emits redundant `- group:` entries whose
+        // collision behaviour is unspecified. A duplicate is always an authoring
+        // mistake, so fail closed rather than silently emitting it.
+        let key = group.trim().to_ascii_lowercase();
+        if !seen.insert(key) {
+            anyhow::bail!(
+                "variable-groups entry {group:?} is imported more than once — remove the \
+                 duplicate. Azure DevOps variable group names are case-insensitive, so entries \
+                 that differ only by case or surrounding whitespace are treated as the same \
+                 group."
             );
         }
     }
@@ -2776,6 +2792,23 @@ mod tests {
             "---\nname: t\ndescription: d\nvariable-groups:\n  - \"$(evil)\"\n---\n".to_string();
         let (fm, _) = parse_markdown(&src).unwrap();
         assert!(validate_variable_groups(&fm).is_err());
+    }
+
+    #[test]
+    fn validate_variable_groups_rejects_duplicates() {
+        // Exact duplicate, case-only difference, and whitespace-only difference
+        // are all treated as the same group and rejected.
+        for second in ["Shared Secrets", "shared secrets", " Shared Secrets "] {
+            let src = format!(
+                "---\nname: t\ndescription: d\nvariable-groups:\n  - Shared Secrets\n  - \"{second}\"\n---\n"
+            );
+            let (fm, _) = parse_markdown(&src).unwrap();
+            let err = validate_variable_groups(&fm).unwrap_err().to_string();
+            assert!(
+                err.contains("imported more than once"),
+                "duplicate {second:?} must be rejected; err: {err}"
+            );
+        }
     }
 
     fn extension_declarations(extensions: &[Extension], fm: &FrontMatter) -> Vec<Declarations> {

--- a/src/compile/common.rs
+++ b/src/compile/common.rs
@@ -448,6 +448,53 @@ pub fn validate_front_matter_identity(front_matter: &FrontMatter) -> Result<()> 
     Ok(())
 }
 
+/// Validate the `variable-groups:` front-matter block (issue #1385).
+///
+/// Enforces two rules before the pipeline is built:
+///
+/// 1. **Target support.** Variable group imports are pipeline-level
+///    `variables:`, which only `standalone` and `1es` pipelines own. An ADO
+///    `job` / `stage` **template** cannot declare pipeline-level `variables:`
+///    (the parent pipeline that includes the template owns them), so a
+///    non-empty `variable-groups:` on those targets is a hard compile-time
+///    error pointing the author at the parent pipeline.
+/// 2. **Name safety.** Each entry must be a safe group-name **reference** (see
+///    [`crate::validate::is_valid_variable_group_name`]). Only group names
+///    belong here — never secret values; ado-aw never resolves, logs, or
+///    serialises a group's variable values.
+pub fn validate_variable_groups(front_matter: &FrontMatter) -> Result<()> {
+    if front_matter.variable_groups.is_empty() {
+        return Ok(());
+    }
+
+    if matches!(
+        front_matter.target,
+        CompileTarget::Job | CompileTarget::Stage
+    ) {
+        anyhow::bail!(
+            "variable-groups: is not supported for target: {target} — an Azure DevOps {target} \
+             template cannot declare pipeline-level `variables:` (the parent pipeline that \
+             includes this template owns them). Import the variable group in that parent \
+             pipeline instead, or compile with target: standalone or target: 1es.",
+            target = front_matter.target.as_str(),
+        );
+    }
+
+    for group in &front_matter.variable_groups {
+        if !validate::is_valid_variable_group_name(group) {
+            anyhow::bail!(
+                "variable-groups entry {group:?} is not a valid Azure DevOps variable group \
+                 name: it must be a non-empty group-name reference and must not contain control \
+                 characters, newlines, ADO expressions ('${{{{', '$(', '$['), pipeline commands \
+                 ('##vso[', '##['), or the template marker ('{{{{'). Only group names belong \
+                 here — never secret values."
+            );
+        }
+    }
+
+    Ok(())
+}
+
 /// Build the final parameters list by combining user-defined parameters
 /// with auto-injected parameters.
 ///
@@ -2675,6 +2722,47 @@ mod tests {
     fn minimal_front_matter() -> FrontMatter {
         let (fm, _) = parse_markdown("---\nname: test-agent\ndescription: test\n---\n").unwrap();
         fm
+    }
+
+    #[test]
+    fn validate_variable_groups_accepts_empty() {
+        let fm = minimal_front_matter();
+        assert!(validate_variable_groups(&fm).is_ok());
+    }
+
+    #[test]
+    fn validate_variable_groups_accepts_standalone_and_onees() {
+        for target in ["standalone", "1es"] {
+            let src = format!(
+                "---\nname: t\ndescription: d\ntarget: {target}\nvariable-groups:\n  - Agentic Workflows\n  - Shared Secrets\n---\n"
+            );
+            let (fm, _) = parse_markdown(&src).unwrap();
+            assert!(
+                validate_variable_groups(&fm).is_ok(),
+                "variable-groups must be accepted for target {target}"
+            );
+        }
+    }
+
+    #[test]
+    fn validate_variable_groups_rejects_job_and_stage_targets() {
+        for target in ["job", "stage"] {
+            let src = format!(
+                "---\nname: t\ndescription: d\ntarget: {target}\nvariable-groups:\n  - Agentic Workflows\n---\n"
+            );
+            let (fm, _) = parse_markdown(&src).unwrap();
+            let err = validate_variable_groups(&fm).unwrap_err().to_string();
+            assert!(err.contains("variable-groups"), "err: {err}");
+            assert!(err.contains(&format!("target: {target}")), "err: {err}");
+        }
+    }
+
+    #[test]
+    fn validate_variable_groups_rejects_unsafe_name() {
+        let src =
+            "---\nname: t\ndescription: d\nvariable-groups:\n  - \"$(evil)\"\n---\n".to_string();
+        let (fm, _) = parse_markdown(&src).unwrap();
+        assert!(validate_variable_groups(&fm).is_err());
     }
 
     fn extension_declarations(extensions: &[Extension], fm: &FrontMatter) -> Vec<Declarations> {

--- a/src/compile/ir/lower.rs
+++ b/src/compile/ir/lower.rs
@@ -466,10 +466,21 @@ fn lower_variables(vars: &[PipelineVar]) -> Value {
     let mut seq = Vec::with_capacity(vars.len());
     for v in vars {
         let mut m = Mapping::new();
-        m.insert(s("name"), s(&v.name));
-        m.insert(s("value"), s(&v.value));
-        if v.is_secret {
-            m.insert(s("isSecret"), Value::Bool(true));
+        match v {
+            PipelineVar::NameValue {
+                name,
+                value,
+                is_secret,
+            } => {
+                m.insert(s("name"), s(name));
+                m.insert(s("value"), s(value));
+                if *is_secret {
+                    m.insert(s("isSecret"), Value::Bool(true));
+                }
+            }
+            PipelineVar::Group(group) => {
+                m.insert(s("group"), s(group));
+            }
         }
         seq.push(Value::Mapping(m));
     }
@@ -2475,12 +2486,12 @@ mod tests {
             resources: Resources::default(),
             triggers: Triggers::default(),
             variables: vec![
-                PipelineVar {
+                PipelineVar::NameValue {
                     name: "PLAIN_VAR".into(),
                     value: "hello".into(),
                     is_secret: false,
                 },
-                PipelineVar {
+                PipelineVar::NameValue {
                     name: "SECRET_VAR".into(),
                     value: "$(SC_TOKEN)".into(),
                     is_secret: true,
@@ -2496,6 +2507,36 @@ mod tests {
         assert!(yaml.contains("value: hello"));
         assert!(yaml.contains("name: SECRET_VAR"));
         assert!(yaml.contains("isSecret: true"));
+    }
+
+    /// A `PipelineVar::Group` lowers to a `- group: <name>` entry, and
+    /// multiple groups preserve declaration order. No `name:`/`value:` keys
+    /// are emitted for a group import (only the group name is carried).
+    #[test]
+    fn lower_variables_emits_group_imports_in_order() {
+        let p = Pipeline {
+            name: "P".into(),
+            parameters: Vec::new(),
+            resources: Resources::default(),
+            triggers: Triggers::default(),
+            variables: vec![
+                PipelineVar::Group("Agentic Workflows".into()),
+                PipelineVar::Group("Shared Secrets".into()),
+            ],
+            body: PipelineBody::Jobs(Vec::new()),
+            shape: PipelineShape::Standalone,
+        };
+        let g = Graph::default();
+        let v = lower_with_graph(&p, &g).unwrap();
+        let yaml = serde_yaml::to_string(&v).unwrap();
+        assert!(yaml.contains("group: Agentic Workflows"));
+        assert!(yaml.contains("group: Shared Secrets"));
+        // Order preserved: first group appears before the second.
+        let first = yaml.find("Agentic Workflows").unwrap();
+        let second = yaml.find("Shared Secrets").unwrap();
+        assert!(first < second, "group imports must preserve source order");
+        // Group entries carry no name/value keys.
+        assert!(!yaml.contains("value:"));
     }
 
     // ─── Template shape wrapping ──────────────────────────────────

--- a/src/compile/ir/lower.rs
+++ b/src/compile/ir/lower.rs
@@ -2535,8 +2535,12 @@ mod tests {
         let first = yaml.find("Agentic Workflows").unwrap();
         let second = yaml.find("Shared Secrets").unwrap();
         assert!(first < second, "group imports must preserve source order");
-        // Group entries carry no name/value keys.
+        // Group entries carry no name/value keys. (A literal variable would
+        // emit `- name:` / `value:` sequence items; the top-level pipeline
+        // `name: P` mapping key is unrelated, so match the `- name:` item form
+        // to avoid a false collision.)
         assert!(!yaml.contains("value:"));
+        assert!(!yaml.contains("- name:"));
     }
 
     // ─── Template shape wrapping ──────────────────────────────────

--- a/src/compile/ir/mod.rs
+++ b/src/compile/ir/mod.rs
@@ -311,11 +311,26 @@ pub struct CiTrigger {
 }
 
 /// A pipeline-level `variables:` entry.
+///
+/// ADO's top-level `variables:` sequence mixes two entry shapes: literal
+/// `- name: X / value: Y` pairs and variable-group imports (`- group: G`).
+/// This enum models both so the lowering pass can emit the correct YAML for
+/// each; group imports carry only the group **name** — never any variable
+/// value (see issue #1385).
 #[derive(Debug, Clone)]
-pub struct PipelineVar {
-    pub name: String,
-    pub value: String,
-    pub is_secret: bool,
+pub enum PipelineVar {
+    /// A literal `- name: <name>` / `value: <value>` entry, optionally
+    /// flagged `isSecret: true`.
+    NameValue {
+        name: String,
+        value: String,
+        is_secret: bool,
+    },
+    /// A variable-group import: `- group: <name>`. Brings the (project-level,
+    /// often Key Vault-backed) group's variables into the run. Only the group
+    /// name is carried — ado-aw never resolves, logs, or serialises the
+    /// group's variable values.
+    Group(String),
 }
 
 #[cfg(test)]

--- a/src/compile/onees_ir.rs
+++ b/src/compile/onees_ir.rs
@@ -115,7 +115,12 @@ pub fn build_onees_pipeline(
         parameters: built.parameters,
         resources,
         triggers: built.triggers,
-        variables: Vec::new(),
+        variables: front_matter
+            .variable_groups
+            .iter()
+            .cloned()
+            .map(super::ir::PipelineVar::Group)
+            .collect(),
         body: PipelineBody::Jobs(jobs),
         shape: PipelineShape::OneEs {
             sdl: OneEsSdlConfig::default(),

--- a/src/compile/onees_ir.rs
+++ b/src/compile/onees_ir.rs
@@ -115,12 +115,7 @@ pub fn build_onees_pipeline(
         parameters: built.parameters,
         resources,
         triggers: built.triggers,
-        variables: front_matter
-            .variable_groups
-            .iter()
-            .cloned()
-            .map(super::ir::PipelineVar::Group)
-            .collect(),
+        variables: common::variable_group_vars(front_matter),
         body: PipelineBody::Jobs(jobs),
         shape: PipelineShape::OneEs {
             sdl: OneEsSdlConfig::default(),

--- a/src/compile/standalone_ir.rs
+++ b/src/compile/standalone_ir.rs
@@ -17,6 +17,7 @@ use anyhow::Result;
 use std::path::Path;
 
 use super::agentic_pipeline::build_pipeline_context;
+use super::common::variable_group_vars;
 use super::extensions::{CompileContext, Extension};
 use super::ir::{Pipeline, PipelineBody, PipelineShape};
 use super::types::FrontMatter;
@@ -62,16 +63,3 @@ pub fn build_standalone_pipeline(
     })
 }
 
-/// Map the validated `variable-groups:` front-matter entries to top-level
-/// [`super::ir::PipelineVar::Group`] imports (issue #1385), preserving
-/// declaration order. Names are already validated by
-/// [`crate::compile::common::validate_variable_groups`] (invoked inside
-/// [`build_pipeline_context`]).
-fn variable_group_vars(front_matter: &FrontMatter) -> Vec<super::ir::PipelineVar> {
-    front_matter
-        .variable_groups
-        .iter()
-        .cloned()
-        .map(super::ir::PipelineVar::Group)
-        .collect()
-}

--- a/src/compile/standalone_ir.rs
+++ b/src/compile/standalone_ir.rs
@@ -56,8 +56,22 @@ pub fn build_standalone_pipeline(
         parameters: built.parameters,
         resources: built.resources,
         triggers: built.triggers,
-        variables: Vec::new(),
+        variables: variable_group_vars(front_matter),
         body: PipelineBody::Jobs(built.jobs),
         shape: PipelineShape::Standalone,
     })
+}
+
+/// Map the validated `variable-groups:` front-matter entries to top-level
+/// [`super::ir::PipelineVar::Group`] imports (issue #1385), preserving
+/// declaration order. Names are already validated by
+/// [`crate::compile::common::validate_variable_groups`] (invoked inside
+/// [`build_pipeline_context`]).
+fn variable_group_vars(front_matter: &FrontMatter) -> Vec<super::ir::PipelineVar> {
+    front_matter
+        .variable_groups
+        .iter()
+        .cloned()
+        .map(super::ir::PipelineVar::Group)
+        .collect()
 }

--- a/src/compile/types.rs
+++ b/src/compile/types.rs
@@ -1085,6 +1085,25 @@ pub struct FrontMatter {
     /// Network policy for standalone target (ignored in 1ES)
     #[serde(default)]
     pub network: Option<NetworkConfig>,
+    /// Azure DevOps variable group imports (issue #1385).
+    ///
+    /// Each entry is the **name** of a project-level ADO Library variable
+    /// group whose variables should be pulled into the run. The compiler emits
+    /// a top-level `variables:\n  - group: <name>` import for each entry, in
+    /// declaration order (ADO evaluates later groups after earlier ones, so a
+    /// later group wins on key collisions).
+    ///
+    /// Only group **names** belong here — never secret values. ado-aw never
+    /// resolves, prints, logs, or serialises a group's variable values; steps
+    /// still reference secrets by macro (`$(VAR_NAME)`) exactly as before.
+    ///
+    /// In Azure DevOps a group must be **both** authorized for the pipeline
+    /// definition **and** imported in YAML; this field provides the YAML
+    /// import. Not representable in `target: job` / `target: stage` templates
+    /// (the parent pipeline owns pipeline-level `variables:`) — declaring it
+    /// there is a compile-time error.
+    #[serde(default, rename = "variable-groups")]
+    pub variable_groups: Vec<String>,
     /// Custom steps before agent runs (same job)
     #[serde(default)]
     pub steps: Vec<serde_yaml::Value>,

--- a/src/validate.rs
+++ b/src/validate.rs
@@ -244,12 +244,16 @@ pub fn is_safe_tool_name(name: &str) -> bool {
 /// break out of the emitted YAML scalar or inject pipeline logic:
 ///
 /// - empty or whitespace-only names,
+/// - names with leading or trailing whitespace (must be pre-trimmed by the
+///   author so the emitted `- group: <name>` scalar matches the ADO group
+///   exactly),
 /// - control characters (including `\n` / `\r`),
 /// - ADO template / macro / runtime expressions (`${{`, `$(`, `$[`),
 /// - ADO pipeline commands (`##vso[`, `##[`),
 /// - the compiler's own template marker (`{{`).
 pub fn is_valid_variable_group_name(name: &str) -> bool {
     !name.trim().is_empty()
+        && name == name.trim()
         && !name.chars().any(|c| c.is_control())
         && !contains_ado_expression(name)
         && !contains_pipeline_command(name)
@@ -946,10 +950,17 @@ mod tests {
         // character set are allowed.
         assert!(is_valid_variable_group_name("Agentic Workflows"));
         assert!(is_valid_variable_group_name("Shared Secrets"));
+        // Inner spaces are fine; internal single spaces are part of the name.
         assert!(is_valid_variable_group_name("kv-backed.group_1"));
         // Rejected: empty / whitespace-only.
         assert!(!is_valid_variable_group_name(""));
         assert!(!is_valid_variable_group_name("   "));
+        // Rejected: leading / trailing whitespace (name must match the ADO
+        // group exactly; the raw string is emitted verbatim into the YAML).
+        assert!(!is_valid_variable_group_name(" Shared Secrets"));
+        assert!(!is_valid_variable_group_name("Shared Secrets "));
+        assert!(!is_valid_variable_group_name(" Shared Secrets "));
+        assert!(!is_valid_variable_group_name("\tShared Secrets"));
         // Rejected: ADO expressions / macros / runtime expressions.
         assert!(!is_valid_variable_group_name("$(evil)"));
         assert!(!is_valid_variable_group_name("${{ variables.x }}"));

--- a/src/validate.rs
+++ b/src/validate.rs
@@ -244,14 +244,13 @@ pub fn is_safe_tool_name(name: &str) -> bool {
 /// break out of the emitted YAML scalar or inject pipeline logic:
 ///
 /// - empty or whitespace-only names,
-/// - control characters and newlines (`\n` / `\r`),
+/// - control characters (including `\n` / `\r`),
 /// - ADO template / macro / runtime expressions (`${{`, `$(`, `$[`),
 /// - ADO pipeline commands (`##vso[`, `##[`),
 /// - the compiler's own template marker (`{{`).
 pub fn is_valid_variable_group_name(name: &str) -> bool {
     !name.trim().is_empty()
         && !name.chars().any(|c| c.is_control())
-        && !contains_newline(name)
         && !contains_ado_expression(name)
         && !contains_pipeline_command(name)
         && !contains_template_marker(name)

--- a/src/validate.rs
+++ b/src/validate.rs
@@ -233,6 +233,30 @@ pub fn is_safe_tool_name(name: &str) -> bool {
     !name.is_empty() && name.chars().all(|c| c.is_ascii_alphanumeric() || c == '-')
 }
 
+/// Validate an Azure DevOps **variable group** name for a `- group: <name>`
+/// import (issue #1385).
+///
+/// A variable group name is a **reference/identifier**, never a value: ado-aw
+/// emits it verbatim as a top-level `variables:` import and never resolves,
+/// prints, logs, or serialises the group's secret variable values. ADO group
+/// names are human-friendly display names (they may contain spaces), so this
+/// validator is permissive on the character set but rejects anything that could
+/// break out of the emitted YAML scalar or inject pipeline logic:
+///
+/// - empty or whitespace-only names,
+/// - control characters and newlines (`\n` / `\r`),
+/// - ADO template / macro / runtime expressions (`${{`, `$(`, `$[`),
+/// - ADO pipeline commands (`##vso[`, `##[`),
+/// - the compiler's own template marker (`{{`).
+pub fn is_valid_variable_group_name(name: &str) -> bool {
+    !name.trim().is_empty()
+        && !name.chars().any(|c| c.is_control())
+        && !contains_newline(name)
+        && !contains_ado_expression(name)
+        && !contains_pipeline_command(name)
+        && !contains_template_marker(name)
+}
+
 // ── Injection detectors ─────────────────────────────────────────────────────
 
 /// Returns true if the string contains an ADO template expression (`${{`),
@@ -915,6 +939,29 @@ mod tests {
         assert!(!is_safe_tool_name("foo; rm -rf /"));
         assert!(!is_safe_tool_name("tool name"));
         assert!(!is_safe_tool_name("tool\ttab"));
+    }
+
+    #[test]
+    fn test_is_valid_variable_group_name() {
+        // ADO group names are human-friendly display names; spaces and a broad
+        // character set are allowed.
+        assert!(is_valid_variable_group_name("Agentic Workflows"));
+        assert!(is_valid_variable_group_name("Shared Secrets"));
+        assert!(is_valid_variable_group_name("kv-backed.group_1"));
+        // Rejected: empty / whitespace-only.
+        assert!(!is_valid_variable_group_name(""));
+        assert!(!is_valid_variable_group_name("   "));
+        // Rejected: ADO expressions / macros / runtime expressions.
+        assert!(!is_valid_variable_group_name("$(evil)"));
+        assert!(!is_valid_variable_group_name("${{ variables.x }}"));
+        assert!(!is_valid_variable_group_name("$[ something ]"));
+        // Rejected: pipeline commands.
+        assert!(!is_valid_variable_group_name("##vso[task.setvariable]x"));
+        assert!(!is_valid_variable_group_name("##[warning]x"));
+        // Rejected: compiler template marker and control characters.
+        assert!(!is_valid_variable_group_name("{{ agent }}"));
+        assert!(!is_valid_variable_group_name("line\nbreak"));
+        assert!(!is_valid_variable_group_name("tab\there"));
     }
 
     // ── Injection detectors ─────────────────────────────────────────────

--- a/tests/compiler_tests.rs
+++ b/tests/compiler_tests.rs
@@ -7725,3 +7725,91 @@ fn test_github_app_token_reuses_staged_bundle_in_agent() {
         count_downloads(&with),
     );
 }
+
+// ─── Variable group imports (issue #1385) ────────────────────────────────
+
+/// A standalone pipeline with `variable-groups:` emits a top-level
+/// `variables:` block containing one `- group: <name>` import per entry, in
+/// declaration order. Only group names appear — never any variable values.
+#[test]
+fn variable_groups_standalone_emits_group_imports_in_order() {
+    let (ok, compiled, stderr) = compile_inline_source(
+        "vg-standalone",
+        "---\nname: vg-standalone\ndescription: variable group import test\nvariable-groups:\n  - Agentic Workflows\n  - Shared Secrets\n---\n\n## Agent\n\nDo work.\n",
+    );
+    assert!(ok, "standalone compile with variable-groups should succeed.\nstderr: {stderr}");
+    assert!(compiled.contains("variables:"), "top-level variables: block must be present:\n{compiled}");
+    assert!(compiled.contains("- group: Agentic Workflows"), "first group import missing:\n{compiled}");
+    assert!(compiled.contains("- group: Shared Secrets"), "second group import missing:\n{compiled}");
+    let first = compiled.find("Agentic Workflows").unwrap();
+    let second = compiled.find("Shared Secrets").unwrap();
+    assert!(first < second, "group imports must preserve declaration order");
+}
+
+/// A 1ES pipeline (`target: 1es`) also emits the `variables:` group import at
+/// the pipeline root, alongside the `extends:` block.
+#[test]
+fn variable_groups_onees_emits_group_imports() {
+    let (ok, compiled, stderr) = compile_inline_source(
+        "vg-onees",
+        "---\nname: vg-onees\ndescription: variable group import test\ntarget: 1es\nvariable-groups:\n  - Agentic Workflows\n---\n\n## Agent\n\nDo work.\n",
+    );
+    assert!(ok, "1es compile with variable-groups should succeed.\nstderr: {stderr}");
+    assert!(compiled.contains("extends:"), "1ES pipeline must still emit extends:\n{compiled}");
+    assert!(compiled.contains("variables:"), "top-level variables: block must be present:\n{compiled}");
+    assert!(compiled.contains("- group: Agentic Workflows"), "group import missing:\n{compiled}");
+}
+
+/// `target: job` cannot carry pipeline-level `variables:`, so a non-empty
+/// `variable-groups:` there is a hard compile-time error naming the target.
+#[test]
+fn variable_groups_rejected_for_job_target() {
+    let (ok, _compiled, stderr) = compile_inline_source(
+        "vg-job",
+        "---\nname: vg-job\ndescription: variable group import test\ntarget: job\nvariable-groups:\n  - Agentic Workflows\n---\n\n## Agent\n\nDo work.\n",
+    );
+    assert!(!ok, "job target with variable-groups must fail to compile");
+    assert!(stderr.contains("variable-groups"), "error must mention variable-groups:\n{stderr}");
+    assert!(stderr.contains("target: job"), "error must name the job target:\n{stderr}");
+}
+
+/// `target: stage` is rejected for the same reason as `target: job`.
+#[test]
+fn variable_groups_rejected_for_stage_target() {
+    let (ok, _compiled, stderr) = compile_inline_source(
+        "vg-stage",
+        "---\nname: vg-stage\ndescription: variable group import test\ntarget: stage\nvariable-groups:\n  - Agentic Workflows\n---\n\n## Agent\n\nDo work.\n",
+    );
+    assert!(!ok, "stage target with variable-groups must fail to compile");
+    assert!(stderr.contains("variable-groups"), "error must mention variable-groups:\n{stderr}");
+    assert!(stderr.contains("target: stage"), "error must name the stage target:\n{stderr}");
+}
+
+/// A group name that carries an ADO macro expression is rejected as an unsafe
+/// reference (defense in depth — only literal group names belong here).
+#[test]
+fn variable_groups_rejects_injection_name() {
+    let (ok, _compiled, stderr) = compile_inline_source(
+        "vg-inject",
+        "---\nname: vg-inject\ndescription: variable group import test\nvariable-groups:\n  - \"$(evil)\"\n---\n\n## Agent\n\nDo work.\n",
+    );
+    assert!(!ok, "an injection-bearing group name must fail to compile");
+    assert!(stderr.contains("variable group name") || stderr.contains("variable-groups entry"),
+        "error must explain the invalid group name:\n{stderr}");
+}
+
+/// A workflow that references a GitHub App private key held in a project-level
+/// variable group can import that group AND mint the token from the same
+/// source — no generated-lock hand-patching required. The compiled lock
+/// contains both the `- group:` import and the `$(...)` macro reference.
+#[test]
+fn variable_groups_with_github_app_token_compiles_without_patch() {
+    let (ok, compiled, stderr) = compile_inline_source(
+        "vg-ghapp",
+        "---\nname: vg-ghapp\ndescription: variable group + github app token\nvariable-groups:\n  - Agentic Workflows\nengine:\n  id: copilot\n  github-app-token:\n    app-id: 1234567\n    owner: octo-org\n    repositories: [octo-repo]\n    private-key: AGENTIC_WORKFLOWS_GITHUB_APP_PRIVATE_KEY\n---\n\n## Agent\n\nDo work.\n",
+    );
+    assert!(ok, "compile with variable-groups + github-app-token should succeed.\nstderr: {stderr}");
+    assert!(compiled.contains("- group: Agentic Workflows"), "group import missing:\n{compiled}");
+    assert!(compiled.contains("$(AGENTIC_WORKFLOWS_GITHUB_APP_PRIVATE_KEY)"),
+        "private-key macro reference missing:\n{compiled}");
+}


### PR DESCRIPTION
## Summary

Adds source-level support for **Azure DevOps variable group imports** so generated pipeline locks can consume project-level (often Key Vault-backed) secrets — such as a shared GitHub App private key — without hand-editing the generated YAML.

A new front-matter list declares the imports:

```yaml
variable-groups:
  - Agentic Workflows
  - Shared Secrets
```

which compiles to a top-level import per entry, in declaration order:

```yaml
variables:
  - group: Agentic Workflows
  - group: Shared Secrets
```

### Why

In Azure DevOps, a variable group being authorized for a pipeline **definition** is not enough — the YAML must also explicitly import the group. ado-aw already lets `engine.github-app-token.private-key` reference an ADO secret variable and emits `$(NAME)` macros, but never imported the group, so a source-clean lock could not consume a project-level secret without hand-patching (which breaks lock integrity). This PR provides the missing YAML import.

## Changes

- **IR** (`compile/ir/mod.rs`, `compile/ir/lower.rs`): `PipelineVar` is now an enum modelling `- group:` imports alongside literal `- name/value` entries, with matching lowering.
- **Front matter** (`compile/types.rs`): new `variable-groups: Vec<String>` field.
- **Validation** (`compile/common.rs` + `validate.rs`, wired at the shared `build_pipeline_context` chokepoint): group names are validated as safe **references** (reject `$(`, `$[`, `${{`, `##vso[`, `##[`, control characters, newlines); a non-empty `variable-groups:` on `target: job` / `target: stage` is a **hard compile-time error** (ADO templates cannot carry pipeline-level `variables:` — the parent pipeline owns them). Names with leading/trailing whitespace, and duplicate imports (case-insensitive), are also rejected — padded names are emitted verbatim, and ADO group names are case-insensitive and a repeated `- group:` has unspecified collision behaviour.
- **Builders** (`compile/standalone_ir.rs`, `compile/onees_ir.rs`): emit the imports at the pipeline root (valid alongside the 1ES `extends:` block).
- **Docs**: `docs/front-matter.md`, `docs/engine.md`, `docs/targets.md`, and the authoring prompt `prompts/create-ado-agentic-workflow.md`.

## Security

- Source carries only group **names** — never secret values.
- ado-aw never resolves, prints, logs, or serialises a group's variable values.
- Existing secret handling is unchanged: steps still reference secrets by macro (`$(VAR_NAME)`).

## Design decisions

- **Shape:** ado-aw-specific `variable-groups:` list (rather than ADO-native `variables: - group:`), to avoid a future collision with literal name/value `variables:` support. The list handles multiple groups natively.
- **job/stage targets:** fail fast with a clear compile-time error pointing at the parent pipeline, rather than silently emitting nothing.

## Testing

- `cargo check` ✓, `cargo clippy --all-targets --all-features` ✓ (clean)
- Full suite: **2506 unit + all integration tests pass, 0 failures**
- New coverage: IR lowering (single/multiple/ordered group imports), front-matter validation (accept standalone/1es; reject job/stage; reject unsafe names), and end-to-end compile tests (standalone + 1ES output shape, job/stage errors, injection rejection, and `github-app-token` + variable group compiling without a lock patch)
- Lock round-trip tests confirm existing pipelines are byte-unchanged

## Follow-up

- #1416 tracks accepting hyphenated `private-key` names (Key Vault-backed groups commonly expose hyphenated secret names), recommending a dedicated ADO-variable-name validator.

Closes #1385


