### PR TITLE
fix(safe-outputs): create build attachments via DistributedTask timeline attachment API

### DIFF
--- a/docs/codemods.md
+++ b/docs/codemods.md
@@ -111,7 +111,8 @@ src/compile/codemods/
 ├── 0001_repos_unified.rs   # Legacy repositories: + checkout: → repos: codemod
 ├── 0002_pool_object_form.rs # Legacy scalar pool → explicit object form codemod
 ├── 0003_flatten_work_item_config.rs # Legacy work-item config flatten codemod
-└── 0004_legacy_path_markers.rs # {{ workspace }} / {{ working_directory }} / {{ trigger_repo_directory }} → explicit ADO path exprs
+├── 0004_legacy_path_markers.rs # {{ workspace }} / {{ working_directory }} / {{ trigger_repo_directory }} → explicit ADO path exprs
+└── 0005_drop_build_attachment_allowed_build_ids.rs # remove no-op upload-build-attachment.allowed-build-ids
 ```
 
 (New codemods are appended as `<NNNN>_<id>.rs` files.)
@@ -391,6 +392,21 @@ in the body, plus checkout-aware path mistakes such as a
 declared-but-not-checked-out repo, or the multi-checkout self subfolder
 form used under a single checkout. These are advisory and never fail
 the compile.
+
+## `upload-build-attachment.allowed-build-ids` removal (`0005_drop_build_attachment_allowed_build_ids`)
+
+A build attachment is a DistributedTask **timeline attachment** on the current
+job's record (the same object `##vso[task.addattachment]` creates), so it can
+only ever be added to the **current** run. The historical
+`safe-outputs.upload-build-attachment.allowed-build-ids` allow-list — which gated
+*which other* build the agent could attach to — is therefore inert: no other
+build is reachable.
+
+This codemod removes the key from `safe-outputs.upload-build-attachment`, and the
+standard codemod compile warning tells the author it was auto-removed. It does
+**not** touch `safe-outputs.upload-pipeline-artifact.allowed-build-ids`, which
+stays meaningful (pipeline artifacts use the Build Artifacts `Create` API, which
+can target an arbitrary build).
 
 ## Tests
 

--- a/docs/safe-outputs.md
+++ b/docs/safe-outputs.md
@@ -581,28 +581,36 @@ safe-outputs:
 
 ### upload-build-attachment
 
-Attaches a workspace file to an Azure DevOps build as a **build attachment** via
-the ADO build attachments REST API
-(`PUT /_apis/build/builds/{buildId}/attachments/{type}/{name}`).
+Attaches a workspace file to the **current** Azure DevOps build as a **build
+attachment**.
 
-> **Important:** Build attachments are **not visible** in the standard Azure
-> DevOps build summary UI. They are only accessible via the REST API or through
-> a custom Azure DevOps extension that registers a tab matching the
-> `attachment-type` value. For artifacts that should appear in the **Artifacts
-> tab**, use [`upload-pipeline-artifact`](#upload-pipeline-artifact) instead.
+Build attachments are created via the **DistributedTask timeline attachment**
+API — the same mechanism as the `##vso[task.addattachment type=…;name=…]<path>`
+logging command. The resulting object *is* a build attachment: it is stored once
+by `{type}`/`{name}` and read back through the Build ▸ Attachments **Get/List**
+API (and by ADO extensions that register for a given attachment `type`). The
+executor calls the REST endpoint directly (rather than emitting the `##vso`
+command) so it can report a deterministic success/failure and surface the
+attachment URL.
 
-**Omit `build_id` to target the current pipeline run** — the executor resolves
-the build ID from the `BUILD_BUILDID` environment variable automatically. When
-`build_id` is provided, the file is attached to that specific build — useful for
-posthumously decorating a finished build with a generated report, screenshot, or
-log bundle.
+> **Current run only.** A timeline attachment can only be added to the job that
+> is executing, so this tool always targets the **current** build. There is no
+> ADO API to attach to an arbitrary other build. (The tool previously advertised
+> a `PUT /_apis/build/builds/{id}/attachments/…` route to attach to any build —
+> that route never existed; the Build ▸ Attachments API is read-only.)
+
+> **Not visible in the standard UI.** Build attachments do not appear in the
+> build summary UI; they are read via the REST API or a custom Azure DevOps
+> extension that registers a tab matching the `attachment-type` value. For
+> artifacts that should appear in the **Artifacts tab**, use
+> [`upload-pipeline-artifact`](#upload-pipeline-artifact) instead.
 
 The tool stages the file during Stage 1 (MCP) by copying it into the
-safe-outputs directory; Stage 3 reads the staged copy and uploads it via the REST
-API.
+safe-outputs directory; Stage 3 reads the staged copy and PUTs it to the current
+job's timeline record.
 
 **Agent parameters:**
-- `build_id` *(optional)* - Target build ID. Omit to attach to the current pipeline run. Must be positive when specified.
+- `build_id` *(optional)* - **Omit** to attach to the current run (recommended). If set, it must equal the current build id; any other value is rejected.
 - `artifact_name` - Attachment name (1–100 chars, alphanumeric / `-` / `_` / `.`, no leading `.`)
 - `file_path` - Relative path to the file in the workspace (no directory traversal)
 
@@ -613,24 +621,28 @@ safe-outputs:
     max-file-size: 52428800              # Maximum file size in bytes (default: 50 MB)
     allowed-extensions: []               # Optional — restrict file types (e.g., [".png", ".pdf", ".log"])
     allowed-artifact-names: []           # Optional — restrict names (suffix `*` = prefix match)
-    allowed-build-ids: []                # Optional — restrict target builds (skipped when targeting current build)
     name-prefix: ""                      # Optional — prepended to the agent-supplied artifact name
-    attachment-type: "agent-artifact"    # Optional — {type} segment in the attachments URL (default: "agent-artifact")
+    attachment-type: "agent-artifact"    # Optional — {type} segment in the attachment path (default: "agent-artifact")
     max: 3                               # Maximum per run (default: 3)
 ```
 
+> **Removed:** `allowed-build-ids` is no longer supported here — since a build
+> attachment can only target the current run, the allow-list was meaningless. A
+> [codemod](codemods.md) auto-removes it from source (with a compile warning) on
+> the next `ado-aw compile`. (`allowed-build-ids` remains valid for
+> [`upload-pipeline-artifact`](#upload-pipeline-artifact).)
+
 **Notes:**
 - Single-file only; directory uploads are not supported.
-- When `build_id` is omitted and `allowed-build-ids` is configured, the allow-list check is skipped — the current build is implicitly trusted.
 
-**About `attachment-type`:** This is the `{type}` segment in the ADO build
-attachments URL (`PUT .../attachments/{type}/{name}`). It acts as a category
-label. Azure DevOps extensions can register to display attachments of a specific
-type — for example, the built-in code coverage extension displays attachments
-with type `CodeCoverageSummary`. The default `agent-artifact` is a custom type;
-without a matching ADO extension installed, attachments with this type are only
-accessible via the REST API. Change this only if you have a custom extension
-that displays attachments of a specific type. Most users should use
+**About `attachment-type`:** This is the `{type}` segment in the attachment path
+(`.../attachments/{type}/{name}`). It acts as a category label. Azure DevOps
+extensions can register to display attachments of a specific type — for example,
+the built-in code coverage extension displays attachments with type
+`CodeCoverageSummary`. The default `agent-artifact` is a custom type; without a
+matching ADO extension installed, attachments with this type are only accessible
+via the REST API. Change this only if you have a custom extension that displays
+attachments of a specific type. Most users should use
 [`upload-pipeline-artifact`](#upload-pipeline-artifact) for user-visible
 artifacts instead.
 

--- a/src/compile/codemods/0005_drop_build_attachment_allowed_build_ids.rs
+++ b/src/compile/codemods/0005_drop_build_attachment_allowed_build_ids.rs
@@ -1,0 +1,152 @@
+//! `safe-outputs.upload-build-attachment.allowed-build-ids:` -> removed
+//!
+//! A build attachment is a DistributedTask **timeline attachment** on the
+//! current job's record (the same object `##vso[task.addattachment]` creates),
+//! so it can only ever be added to the **current** run. The historical
+//! `allowed-build-ids` allow-list — which gated *which other* build the agent
+//! could attach to — is therefore meaningless: no other build is reachable.
+//!
+//! This codemod strips the now-inert key from
+//! `safe-outputs.upload-build-attachment` and lets the compile warning tell the
+//! author it was auto-removed. It deliberately does **not** touch
+//! `safe-outputs.upload-pipeline-artifact.allowed-build-ids`, which remains
+//! meaningful (pipeline artifacts use the Build Artifacts `Create` API, which
+//! can target an arbitrary build).
+//!
+//! Before:
+//!
+//! ```yaml
+//! safe-outputs:
+//!   upload-build-attachment:
+//!     allowed-build-ids:
+//!       - 12345
+//!     max-file-size: 1048576
+//! ```
+//!
+//! After:
+//!
+//! ```yaml
+//! safe-outputs:
+//!   upload-build-attachment:
+//!     max-file-size: 1048576
+//! ```
+
+use anyhow::Result;
+use serde_yaml::{Mapping, Value};
+
+use super::{Codemod, CodemodContext};
+
+const INTRODUCED_IN: &str = "0.42.0";
+
+pub static CODEMOD: Codemod = Codemod {
+    id: "drop_build_attachment_allowed_build_ids",
+    summary: "safe-outputs.upload-build-attachment.allowed-build-ids removed \
+              (build attachments are current-run only)",
+    introduced_in: INTRODUCED_IN,
+    apply: apply_codemod,
+};
+
+fn apply_codemod(fm: &mut Mapping, _ctx: &CodemodContext) -> Result<bool> {
+    let so_key = Value::String("safe-outputs".to_string());
+    let Some(so_val) = fm.get_mut(&so_key) else {
+        return Ok(false);
+    };
+    let Some(so_map) = so_val.as_mapping_mut() else {
+        return Ok(false);
+    };
+
+    let tool_key = Value::String("upload-build-attachment".to_string());
+    let Some(tool_val) = so_map.get_mut(&tool_key) else {
+        return Ok(false);
+    };
+    let Some(tool_map) = tool_val.as_mapping_mut() else {
+        return Ok(false);
+    };
+
+    let removed = tool_map
+        .remove(Value::String("allowed-build-ids".to_string()))
+        .is_some();
+    Ok(removed)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::compile::codemods::CodemodContext;
+
+    fn ctx() -> CodemodContext {
+        CodemodContext {
+            compiler_version: INTRODUCED_IN,
+        }
+    }
+
+    fn map(yaml: &str) -> Mapping {
+        serde_yaml::from_str(yaml).unwrap()
+    }
+
+    #[test]
+    fn removes_allowed_build_ids_from_upload_build_attachment() {
+        let mut m = map(
+            "safe-outputs:\n  upload-build-attachment:\n    allowed-build-ids:\n      - 12345\n      - 67890\n    max-file-size: 1048576\n",
+        );
+        assert!(apply_codemod(&mut m, &ctx()).unwrap());
+        let so = m
+            .get(Value::String("safe-outputs".into()))
+            .unwrap()
+            .as_mapping()
+            .unwrap();
+        let tool = so
+            .get(Value::String("upload-build-attachment".into()))
+            .unwrap()
+            .as_mapping()
+            .unwrap();
+        assert!(!tool.contains_key(Value::String("allowed-build-ids".into())));
+        // Sibling config is preserved.
+        assert!(tool.contains_key(Value::String("max-file-size".into())));
+    }
+
+    #[test]
+    fn leaves_upload_pipeline_artifact_untouched() {
+        let mut m = map(
+            "safe-outputs:\n  upload-pipeline-artifact:\n    allowed-build-ids:\n      - 12345\n",
+        );
+        assert!(!apply_codemod(&mut m, &ctx()).unwrap());
+        let so = m
+            .get(Value::String("safe-outputs".into()))
+            .unwrap()
+            .as_mapping()
+            .unwrap();
+        let tool = so
+            .get(Value::String("upload-pipeline-artifact".into()))
+            .unwrap()
+            .as_mapping()
+            .unwrap();
+        assert!(
+            tool.contains_key(Value::String("allowed-build-ids".into())),
+            "upload-pipeline-artifact.allowed-build-ids must be preserved"
+        );
+    }
+
+    #[test]
+    fn noop_when_key_absent() {
+        let mut m = map("safe-outputs:\n  upload-build-attachment:\n    max-file-size: 1024\n");
+        assert!(!apply_codemod(&mut m, &ctx()).unwrap());
+    }
+
+    #[test]
+    fn noop_when_no_safe_outputs() {
+        let mut m = map("name: x\ndescription: y\n");
+        assert!(!apply_codemod(&mut m, &ctx()).unwrap());
+    }
+
+    #[test]
+    fn idempotent() {
+        let mut m = map(
+            "safe-outputs:\n  upload-build-attachment:\n    allowed-build-ids:\n      - 1\n",
+        );
+        assert!(apply_codemod(&mut m, &ctx()).unwrap());
+        let snapshot = m.clone();
+        assert!(!apply_codemod(&mut m, &ctx()).unwrap());
+        assert_eq!(m, snapshot, "second run must not mutate the mapping");
+    }
+}

--- a/src/compile/codemods/mod.rs
+++ b/src/compile/codemods/mod.rs
@@ -41,6 +41,8 @@ mod m0002_pool_object_form;
 mod m0003_flatten_work_item_config;
 #[path = "0004_legacy_path_markers.rs"]
 mod m0004_legacy_path_markers;
+#[path = "0005_drop_build_attachment_allowed_build_ids.rs"]
+mod m0005_drop_build_attachment_allowed_build_ids;
 
 #[allow(unused_imports)] // Re-exported for future codemods; only `take_key` is in-tree use.
 pub use helpers::{ConflictPolicy, insert_no_overwrite, rename_key, take_key};
@@ -108,6 +110,7 @@ pub static CODEMODS: &[&Codemod] = &[
     &m0002_pool_object_form::CODEMOD,
     &m0003_flatten_work_item_config::CODEMOD,
     &m0004_legacy_path_markers::CODEMOD,
+    &m0005_drop_build_attachment_allowed_build_ids::CODEMOD,
 ];
 
 /// Result of running the codemod registry on a single front-matter

--- a/src/execute.rs
+++ b/src/execute.rs
@@ -1217,7 +1217,13 @@ mod tests {
         };
 
         let result = execute_safe_output(&entry, &ctx).await;
-        assert!(result.is_err());
+        // Missing BUILD_BUILDID / ADO context must not succeed. Depending on
+        // whether the test host has BUILD_BUILDID set, this surfaces either as
+        // a hard error (missing staged file / ADO context) or as a clean
+        // unsuccessful ExecutionResult (current run undeterminable).
+        if let Ok(r) = result {
+            assert!(!r.1.success, "expected non-success, got: {:?}", r);
+        }
     }
 
     #[tokio::test]

--- a/src/mcp.rs
+++ b/src/mcp.rs
@@ -1140,14 +1140,15 @@ uploaded and linked during safe output processing. File size and type restrictio
 
     #[tool(
         name = "upload-build-attachment",
-        description = "Attach a workspace file to an Azure DevOps build as a build attachment via \
-the ADO build attachments REST API. Build attachments are NOT visible in the standard ADO UI — \
-they are only accessible via the REST API or a custom Azure DevOps extension. For files that \
-should appear in the Artifacts tab, use upload-pipeline-artifact instead. \
-Omit `build_id` to target the current pipeline run. When `build_id` is provided, the file is \
-attached to that specific build — useful for posthumously decorating a finished build with a \
-generated report or log bundle. File size, extension, artifact-name and build-id restrictions \
-may apply per the workflow's safe-outputs config."
+        description = "Attach a workspace file to the CURRENT Azure DevOps build as a build \
+attachment. This uses the DistributedTask timeline attachment API — the same mechanism as the \
+`##vso[task.addattachment]` command — so the file can only be attached to the run that is \
+currently executing. Build attachments are NOT visible in the standard ADO UI; they are read \
+back via the REST API or a custom Azure DevOps extension registered for the attachment type. For \
+files that should appear in the Artifacts tab, use upload-pipeline-artifact instead. \
+Omit `build_id` (recommended) to target the current run; if you set it, it MUST equal the current \
+build id — any other value is rejected. File size, extension and artifact-name restrictions may \
+apply per the workflow's safe-outputs config."
     )]
     async fn upload_build_attachment(
         &self,

--- a/src/safe_outputs/create_pull_request.rs
+++ b/src/safe_outputs/create_pull_request.rs
@@ -2961,6 +2961,9 @@ index 0000000..abcdefg
             pull_request_source_branch: None,
             pull_request_target_branch: None,
             build_container_id: None,
+            plan_id: None,
+            timeline_id: None,
+            job_id: None,
             uploaded_pipeline_artifact_keys: std::sync::Arc::new(std::sync::Mutex::new(
                 std::collections::HashSet::new(),
             )),

--- a/src/safe_outputs/result.rs
+++ b/src/safe_outputs/result.rs
@@ -95,6 +95,19 @@ pub struct ExecutionContext {
     /// all artifacts in the build share this container, differentiated by item path.
     /// Required by `upload-pipeline-artifact` to know where to upload bytes.
     pub build_container_id: Option<u64>,
+    /// Orchestration **plan ID** (`SYSTEM_PLANID`) for the current run. Together
+    /// with [`Self::timeline_id`] and [`Self::job_id`] this addresses the
+    /// current job's timeline record, which is the only target for a
+    /// DistributedTask **attachment** create — the API `upload-build-attachment`
+    /// uses (the same mechanism as `##vso[task.addattachment]`). Present only
+    /// while a job is running; there is no equivalent for an arbitrary build.
+    pub plan_id: Option<String>,
+    /// Timeline ID (`SYSTEM_TIMELINEID`) for the current run. See
+    /// [`Self::plan_id`].
+    pub timeline_id: Option<String>,
+    /// Timeline **record ID** of the current job (`SYSTEM_JOBID`) — the record a
+    /// build attachment is attached to. See [`Self::plan_id`].
+    pub job_id: Option<String>,
     /// Human-readable build number (`BUILD_BUILDNUMBER`)
     #[allow(dead_code)]
     pub build_number: Option<String>,
@@ -241,6 +254,9 @@ impl ExecutionContext {
             // Build identification
             build_id: env("BUILD_BUILDID").and_then(|s| s.parse().ok()),
             build_container_id: env("BUILD_CONTAINERID").and_then(|s| s.parse().ok()),
+            plan_id: env("SYSTEM_PLANID"),
+            timeline_id: env("SYSTEM_TIMELINEID"),
+            job_id: env("SYSTEM_JOBID"),
             build_number: env("BUILD_BUILDNUMBER"),
             build_reason: env("BUILD_REASON"),
             definition_name: env("BUILD_DEFINITIONNAME"),
@@ -906,6 +922,37 @@ mod tests {
     fn test_from_env_lookup_build_container_id_none_when_unset() {
         let ctx = ExecutionContext::from_env_lookup(env_from(&[]));
         assert!(ctx.build_container_id.is_none());
+    }
+
+    #[test]
+    fn test_from_env_lookup_timeline_coordinates() {
+        // SYSTEM_PLANID / SYSTEM_TIMELINEID / SYSTEM_JOBID address the current
+        // job's timeline record — the target for a build attachment.
+        let ctx = ExecutionContext::from_env_lookup(env_from(&[
+            ("SYSTEM_PLANID", "11111111-1111-1111-1111-111111111111"),
+            ("SYSTEM_TIMELINEID", "22222222-2222-2222-2222-222222222222"),
+            ("SYSTEM_JOBID", "33333333-3333-3333-3333-333333333333"),
+        ]));
+        assert_eq!(
+            ctx.plan_id.as_deref(),
+            Some("11111111-1111-1111-1111-111111111111")
+        );
+        assert_eq!(
+            ctx.timeline_id.as_deref(),
+            Some("22222222-2222-2222-2222-222222222222")
+        );
+        assert_eq!(
+            ctx.job_id.as_deref(),
+            Some("33333333-3333-3333-3333-333333333333")
+        );
+    }
+
+    #[test]
+    fn test_from_env_lookup_timeline_coordinates_none_when_unset() {
+        let ctx = ExecutionContext::from_env_lookup(env_from(&[]));
+        assert!(ctx.plan_id.is_none());
+        assert!(ctx.timeline_id.is_none());
+        assert!(ctx.job_id.is_none());
     }
 
     #[test]

--- a/src/safe_outputs/upload_build_attachment.rs
+++ b/src/safe_outputs/upload_build_attachment.rs
@@ -1,12 +1,36 @@
 //! Upload build attachment safe output tool.
 //!
-//! Lets an agent propose attaching a workspace file to an Azure DevOps build
-//! via the **build attachments** REST API
-//! (`PUT /_apis/build/builds/{buildId}/attachments/{type}/{name}`).
+//! Lets an agent propose attaching a workspace file to the **current** Azure
+//! DevOps build as a build attachment.
 //!
-//! When `build_id` is omitted the executor targets the **current** pipeline run
-//! by resolving `BUILD_BUILDID` from the environment — so the same tool covers
-//! both "attach to the run I'm part of" and "attach to a different build".
+//! ## Which API this uses
+//!
+//! A "build attachment" is created via the **DistributedTask timeline
+//! attachment** API — the same mechanism the agent's
+//! `##vso[task.addattachment type=…;name=…]<path>` logging command uses under
+//! the hood:
+//!
+//! ```text
+//! PUT {collectionUri}_apis/distributedtask/hubs/build
+//!     /plans/{planId}/timelines/{timelineId}/records/{recordId}
+//!     /attachments/{type}/{name}?api-version=7.1-preview
+//! ```
+//!
+//! The resulting object *is* a build attachment: it is stored once by
+//! `{type}`/`{name}` and is read back through the Build ▸ Attachments
+//! **Get/List** API (and rendered by ADO extensions that register for a given
+//! attachment `type`). We call the REST endpoint directly (rather than printing
+//! the `##vso` command) so the executor gets a response body — it can surface
+//! `attachment_url` and report a deterministic success/failure instead of the
+//! fire-and-forget `##vso` behaviour.
+//!
+//! **Current-run only.** `planId` / `timelineId` / `recordId` exist only for the
+//! job that is executing, so a build attachment can only be added to the
+//! **current** run. There is no ADO API to attach to an arbitrary other build.
+//! The `build_id` param is therefore accepted only when it is omitted or equals
+//! the current run's `BUILD_BUILDID`; any other value is rejected. (The old
+//! `/_apis/build/builds/{id}/attachments/…` PUT route this tool used never
+//! existed — the Build ▸ Attachments API is read-only.)
 //!
 //! The flow mirrors `create-pull-request`:
 //!
@@ -19,8 +43,8 @@
 //! * **Stage 3 (executor, outside the sandbox):** reads the staged file from
 //!   `ctx.working_directory.join(staged_file)`, applies operator-supplied
 //!   limits (`max-file-size`, `allowed-extensions`, `allowed-artifact-names`,
-//!   `allowed-build-ids`, `name-prefix`, `attachment-type`), resolves the
-//!   target build ID, and PUTs the bytes to the ADO build attachments endpoint.
+//!   `name-prefix`, `attachment-type`), and PUTs the bytes to the timeline
+//!   attachment endpoint for the current job's record.
 
 use ado_aw_derive::SanitizeConfig;
 use log::{debug, info, warn};
@@ -39,14 +63,15 @@ use anyhow::{Context, ensure};
 /// Parameters for attaching a workspace file to an ADO build.
 #[derive(Deserialize, JsonSchema)]
 pub struct UploadBuildAttachmentParams {
-    /// The build ID to attach the file to.  **Omit to target the current
-    /// pipeline run** — the executor resolves the build ID from the
-    /// `BUILD_BUILDID` environment variable automatically.  When provided,
-    /// must be a positive integer.
+    /// Build ID to attach the file to. **Omit to target the current pipeline
+    /// run** (recommended) — the executor resolves it from `BUILD_BUILDID`.
+    /// Build attachments can only be added to the current run, so if you set
+    /// this it MUST equal the current build id; any other (still positive)
+    /// value is rejected at execution time.
     pub build_id: Option<i64>,
 
     /// The artifact name to attach the file under. Used as the `{name}`
-    /// segment of the ADO build attachments URL. ADO requires a non-empty
+    /// segment of the attachment path. ADO requires a non-empty
     /// name made of alphanumerics, `-`, `_`, or `.`. Must be 1-100 characters
     /// and must not start with `.`. Validated at deserialization time via
     /// [`ArtifactName`].
@@ -165,9 +190,6 @@ const DEFAULT_ATTACHMENT_TYPE: &str = "agent-artifact";
 ///       - .log
 ///     allowed-artifact-names:
 ///       - agent-*
-///     allowed-build-ids:
-///       - 12345
-///       - 67890
 ///     name-prefix: "agent-"
 ///     attachment-type: "agent-artifact"
 ///     max: 5
@@ -188,12 +210,6 @@ pub struct UploadBuildAttachmentConfig {
     /// by prefix; otherwise the comparison is exact.
     #[serde(default, rename = "allowed-artifact-names")]
     pub allowed_artifact_names: Vec<String>,
-
-    /// Restrict which build IDs the agent may attach to. Empty means any
-    /// build ID accessible to the executor's token is allowed. This check
-    /// is skipped when `build_id` is omitted (targeting the current build).
-    #[serde(default, rename = "allowed-build-ids")]
-    pub allowed_build_ids: Vec<i64>,
 
     /// Prefix prepended to the agent-supplied artifact name before publishing.
     #[serde(default, rename = "name-prefix")]
@@ -216,7 +232,6 @@ impl Default for UploadBuildAttachmentConfig {
             max_file_size: DEFAULT_MAX_FILE_SIZE,
             allowed_extensions: Vec::new(),
             allowed_artifact_names: Vec::new(),
-            allowed_build_ids: Vec::new(),
             name_prefix: None,
             attachment_type: None,
         }
@@ -239,29 +254,48 @@ impl Executor for UploadBuildAttachmentResult {
     }
 
     async fn execute_impl(&self, ctx: &ExecutionContext) -> anyhow::Result<ExecutionResult> {
-        // Resolve the effective build ID: explicit value from the agent, or
-        // fall back to the current pipeline's BUILD_BUILDID.
-        let effective_build_id: i64 = match self.build_id {
-            Some(id) => id,
-            None => {
-                let current = ctx.build_id.context(
-                    "build_id was not specified and BUILD_BUILDID is not set — \
-                     cannot determine which build to attach the artifact to",
-                )?;
-                i64::try_from(current).context("BUILD_BUILDID value overflows i64")?
+        // Resolve the current run's build ID. A build attachment can only ever
+        // be added to the *current* job's timeline record (see module docs), so
+        // `build_id`, when the agent supplies it, must match the current run.
+        let current_build_id: Option<i64> = match ctx.build_id {
+            Some(current) => {
+                Some(i64::try_from(current).context("BUILD_BUILDID value overflows i64")?)
+            }
+            None => None,
+        };
+        let effective_build_id: i64 = match (self.build_id, current_build_id) {
+            // Agent supplied a build_id that differs from the current run — not
+            // possible for a build attachment; fail with a clear message.
+            (Some(requested), Some(current)) if requested != current => {
+                return Ok(ExecutionResult::failure(format!(
+                    "build_id {requested} does not match the current build ({current}). Build \
+                     attachments can only be added to the current run — omit build_id (or set it \
+                     to {current}) to attach to this build."
+                )));
+            }
+            (Some(requested), Some(_current)) => requested,
+            // Agent supplied a build_id but the current build is unknown; we
+            // cannot prove it targets the current run, so refuse.
+            (Some(requested), None) => {
+                return Ok(ExecutionResult::failure(format!(
+                    "build_id {requested} was specified but the current build id (BUILD_BUILDID) \
+                     is not set, so it cannot be confirmed to target the current run. Build \
+                     attachments can only be added to the current run — omit build_id."
+                )));
+            }
+            (None, Some(current)) => current,
+            (None, None) => {
+                return Ok(ExecutionResult::failure(
+                    "Cannot attach a build attachment: BUILD_BUILDID is not set, so the current \
+                     run cannot be determined."
+                        .to_string(),
+                ));
             }
         };
 
         info!(
-            "Attaching '{}' as artifact '{}' to build #{}{}",
-            self.file_path,
-            self.artifact_name,
-            effective_build_id,
-            if self.build_id.is_none() {
-                " (current build)"
-            } else {
-                ""
-            }
+            "Attaching '{}' as artifact '{}' to the current build #{}",
+            self.file_path, self.artifact_name, effective_build_id,
         );
         debug!(
             "upload-build-attachment: build_id={}, artifact_name='{}', file_path='{}'",
@@ -275,21 +309,6 @@ impl Executor for UploadBuildAttachmentResult {
             "Allowed artifact names: {:?}",
             config.allowed_artifact_names
         );
-        debug!("Allowed build IDs: {:?}", config.allowed_build_ids);
-
-        // Check build-id allow-list (if configured).  When the agent omitted
-        // build_id (targeting the current build), skip this check — the
-        // current build is implicitly trusted because the operator chose to
-        // run this pipeline.
-        if self.build_id.is_some()
-            && !config.allowed_build_ids.is_empty()
-            && !config.allowed_build_ids.contains(&effective_build_id)
-        {
-            return Ok(ExecutionResult::failure(format!(
-                "Build ID {} is not in the allowed-build-ids list",
-                effective_build_id
-            )));
-        }
 
         // Validate name-prefix length before applying. A long prefix would
         // be caught later by the final_name.len() > 100 check, but rejecting
@@ -432,16 +451,8 @@ impl Executor for UploadBuildAttachmentResult {
 
         if ctx.dry_run {
             return Ok(ExecutionResult::success(format!(
-                "[dry-run] would attach '{}' ({} bytes) as artifact '{}' to build #{}{}",
-                self.file_path,
-                file_size,
-                final_name,
-                effective_build_id,
-                if self.build_id.is_none() {
-                    " (current build)"
-                } else {
-                    ""
-                }
+                "[dry-run] would attach '{}' ({} bytes) as artifact '{}' to the current build #{}",
+                self.file_path, file_size, final_name, effective_build_id,
             )));
         }
 
@@ -464,7 +475,12 @@ impl Executor for UploadBuildAttachmentResult {
             )));
         }
 
-        // Resolve the ADO API context (org URL, project, token).
+        // Resolve the ADO API context (collection URL, token) and the current
+        // job's timeline coordinates. A build attachment is a DistributedTask
+        // **timeline attachment** on the running job's record (the same object
+        // `##vso[task.addattachment]` creates), so we need the plan / timeline /
+        // record IDs of the current run — these come from the auto-injected
+        // SYSTEM_* predefined variables and only exist for the current job.
         let org_url = ctx
             .ado_org_url
             .as_ref()
@@ -477,15 +493,33 @@ impl Executor for UploadBuildAttachmentResult {
             .access_token
             .as_ref()
             .context("No access token available (SYSTEM_ACCESSTOKEN or AZURE_DEVOPS_EXT_PAT)")?;
+        let plan_id = ctx.plan_id.as_ref().context(
+            "SYSTEM_PLANID is not set — required to attach to the current build (build attachments \
+             are written to the current job's timeline record)",
+        )?;
+        let timeline_id = ctx.timeline_id.as_ref().context(
+            "SYSTEM_TIMELINEID is not set — required to attach to the current build (build \
+             attachments are written to the current job's timeline record)",
+        )?;
+        let record_id = ctx.job_id.as_ref().context(
+            "SYSTEM_JOBID is not set — required to attach to the current build (build attachments \
+             are written to the current job's timeline record)",
+        )?;
         debug!("ADO org: {}, project: {}", org_url, project);
 
-        // Build the build-attachments URL.
-        // PUT {org_url}/{project}/_apis/build/builds/{buildId}/attachments/{type}/{name}?api-version=7.1-preview.1
+        // Build the DistributedTask timeline-attachment URL (collection-scoped;
+        // the `build` hub covers build/YAML pipelines). This is the write side
+        // of a build attachment — the object is read back via the Build ▸
+        // Attachments Get/List API by `{type}`/`{name}`.
+        // PUT {collectionUri}_apis/distributedtask/hubs/build/plans/{planId}
+        //     /timelines/{timelineId}/records/{recordId}
+        //     /attachments/{type}/{name}?api-version=7.1-preview.1
         let url = format!(
-            "{}/{}/_apis/build/builds/{}/attachments/{}/{}?api-version=7.1-preview.1",
+            "{}/_apis/distributedtask/hubs/build/plans/{}/timelines/{}/records/{}/attachments/{}/{}?api-version=7.1-preview.1",
             org_url.trim_end_matches('/'),
-            utf8_percent_encode(project, PATH_SEGMENT),
-            effective_build_id,
+            utf8_percent_encode(plan_id, PATH_SEGMENT),
+            utf8_percent_encode(timeline_id, PATH_SEGMENT),
+            utf8_percent_encode(record_id, PATH_SEGMENT),
             utf8_percent_encode(attachment_type, PATH_SEGMENT),
             utf8_percent_encode(&final_name, PATH_SEGMENT),
         );
@@ -786,7 +820,6 @@ mod tests {
         assert_eq!(config.max_file_size, 50 * 1024 * 1024);
         assert!(config.allowed_extensions.is_empty());
         assert!(config.allowed_artifact_names.is_empty());
-        assert!(config.allowed_build_ids.is_empty());
         assert!(config.name_prefix.is_none());
         assert!(config.attachment_type.is_none());
     }
@@ -801,9 +834,6 @@ allowed-extensions:
 allowed-artifact-names:
   - agent-*
   - report
-allowed-build-ids:
-  - 100
-  - 200
 name-prefix: "agent-"
 attachment-type: "agent-artifact"
 "#;
@@ -811,9 +841,17 @@ attachment-type: "agent-artifact"
         assert_eq!(config.max_file_size, 1_048_576);
         assert_eq!(config.allowed_extensions, vec![".png", ".pdf"]);
         assert_eq!(config.allowed_artifact_names, vec!["agent-*", "report"]);
-        assert_eq!(config.allowed_build_ids, vec![100, 200]);
         assert_eq!(config.name_prefix, Some("agent-".to_string()));
         assert_eq!(config.attachment_type, Some("agent-artifact".to_string()));
+    }
+
+    /// A stray `allowed-build-ids` key (e.g. from a pre-migration lock the
+    /// codemod hasn't rewritten) must be tolerated and ignored, not error.
+    #[test]
+    fn test_config_ignores_stray_allowed_build_ids() {
+        let yaml = "allowed-build-ids:\n  - 100\n  - 200\n";
+        let config: UploadBuildAttachmentConfig = serde_yaml::from_str(yaml).unwrap();
+        assert_eq!(config.max_file_size, DEFAULT_MAX_FILE_SIZE);
     }
 
     fn make_ctx(working_directory: std::path::PathBuf, dry_run: bool) -> ExecutionContext {
@@ -833,7 +871,7 @@ attachment-type: "agent-artifact"
             allowed_repositories: std::collections::HashMap::new(),
             agent_stats: None,
             dry_run,
-            build_id: None,
+            build_id: Some(1234),
             build_number: None,
             build_reason: None,
             definition_name: None,
@@ -848,6 +886,9 @@ attachment-type: "agent-artifact"
             pull_request_source_branch: None,
             pull_request_target_branch: None,
             build_container_id: None,
+            plan_id: None,
+            timeline_id: None,
+            job_id: None,
             uploaded_pipeline_artifact_keys: std::sync::Arc::new(std::sync::Mutex::new(
                 std::collections::HashSet::new(),
             )),
@@ -856,11 +897,12 @@ attachment-type: "agent-artifact"
     }
 
     #[tokio::test]
-    async fn test_executor_reads_staged_file_with_explicit_build_id() {
+    async fn test_executor_reads_staged_file_with_matching_build_id() {
         let dir = tempfile::tempdir().unwrap();
         let staged = "upload-build-attachment-agent-report-deadbeef.pdf";
         std::fs::write(dir.path().join(staged), b"%PDF-1.4 hello").unwrap();
 
+        // Explicit build_id equal to the current run (make_ctx sets 1234) — OK.
         let result = UploadBuildAttachmentResult::new(
             Some(1234),
             "agent-report".to_string(),
@@ -897,7 +939,33 @@ attachment-type: "agent-artifact"
         assert!(outcome.success, "expected success, got: {:?}", outcome);
         assert!(outcome.message.contains("[dry-run]"));
         assert!(outcome.message.contains("#5678"));
-        assert!(outcome.message.contains("(current build)"));
+        assert!(outcome.message.contains("current build"));
+    }
+
+    #[tokio::test]
+    async fn test_executor_rejects_build_id_mismatch() {
+        let dir = tempfile::tempdir().unwrap();
+        let staged = "upload-build-attachment-agent-report-cafef00d.pdf";
+        std::fs::write(dir.path().join(staged), b"hello").unwrap();
+
+        // Explicit build_id 999 while the current run is 1234 — impossible for
+        // a build attachment, so it must fail with a clear message.
+        let result = UploadBuildAttachmentResult::new(
+            Some(999),
+            "agent-report".to_string(),
+            "out/report.pdf".to_string(),
+            staged.to_string(),
+            5,
+            DUMMY_HASH.to_string(),
+        );
+        let ctx = make_ctx(dir.path().to_path_buf(), true);
+        let outcome = result.execute_impl(&ctx).await.unwrap();
+        assert!(!outcome.success);
+        assert!(
+            outcome.message.contains("does not match the current build"),
+            "expected current-build mismatch rejection, got: {}",
+            outcome.message
+        );
     }
 
     #[tokio::test]
@@ -914,12 +982,48 @@ attachment-type: "agent-artifact"
             5,
             DUMMY_HASH.to_string(),
         );
-        let ctx = make_ctx(dir.path().to_path_buf(), true);
-        // ctx.build_id is None — no BUILD_BUILDID
+        let mut ctx = make_ctx(dir.path().to_path_buf(), true);
+        ctx.build_id = None; // no BUILD_BUILDID
+        let outcome = result.execute_impl(&ctx).await.unwrap();
+        assert!(!outcome.success);
+        assert!(
+            outcome.message.contains("BUILD_BUILDID"),
+            "expected BUILD_BUILDID failure, got: {}",
+            outcome.message
+        );
+    }
+
+    #[tokio::test]
+    async fn test_executor_fails_when_plan_id_missing() {
+        // SHA-256 of b"hello" so the non-dry-run integrity check passes and we
+        // reach the timeline-coordinate resolution.
+        const HELLO_SHA: &str =
+            "2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824";
+        let dir = tempfile::tempdir().unwrap();
+        let staged = "upload-build-attachment-agent-report-0badf00d.txt";
+        std::fs::write(dir.path().join(staged), b"hello").unwrap();
+
+        let result = UploadBuildAttachmentResult::new(
+            None,
+            "agent-report".to_string(),
+            "out/report.txt".to_string(),
+            staged.to_string(),
+            5,
+            HELLO_SHA.to_string(),
+        );
+        // Non-dry-run with org/token set but SYSTEM_PLANID absent — must fail
+        // before any HTTP call, naming the missing variable.
+        let mut ctx = make_ctx(dir.path().to_path_buf(), false);
+        ctx.ado_org_url = Some("https://dev.azure.com/org".to_string());
+        ctx.ado_project = Some("Proj".to_string());
+        ctx.access_token = Some("token".to_string());
+        ctx.timeline_id = Some("00000000-0000-0000-0000-000000000001".to_string());
+        ctx.job_id = Some("00000000-0000-0000-0000-000000000002".to_string());
+        // plan_id intentionally left None.
         let err = result.execute_impl(&ctx).await.unwrap_err();
         assert!(
-            err.to_string().contains("BUILD_BUILDID"),
-            "expected BUILD_BUILDID error, got: {}",
+            err.to_string().contains("SYSTEM_PLANID"),
+            "expected SYSTEM_PLANID error, got: {}",
             err
         );
     }
@@ -945,92 +1049,13 @@ attachment-type: "agent-artifact"
     }
 
     #[tokio::test]
-    async fn test_executor_rejects_disallowed_build_id() {
-        let dir = tempfile::tempdir().unwrap();
-        let staged = "upload-build-attachment-agent-report-cafef00d.pdf";
-        std::fs::write(dir.path().join(staged), b"hello").unwrap();
-
-        let result = UploadBuildAttachmentResult::new(
-            Some(999),
-            "agent-report".to_string(),
-            "out/report.pdf".to_string(),
-            staged.to_string(),
-            5,
-            DUMMY_HASH.to_string(),
-        );
-        let mut ctx = make_ctx(dir.path().to_path_buf(), true);
-        ctx.tool_configs.insert(
-            "upload-build-attachment".to_string(),
-            serde_json::json!({ "allowed-build-ids": [100, 200] }),
-        );
-        let outcome = result.execute_impl(&ctx).await.unwrap();
-        assert!(!outcome.success);
-        assert!(
-            outcome.message.contains("allowed-build-ids"),
-            "expected allowed-build-ids rejection, got: {}",
-            outcome.message
-        );
-    }
-
-    #[tokio::test]
-    async fn test_executor_skips_build_id_allowlist_for_current_build() {
-        let dir = tempfile::tempdir().unwrap();
-        let staged = "upload-build-attachment-agent-report-aabbccdd.pdf";
-        std::fs::write(dir.path().join(staged), b"hello").unwrap();
-
-        let result = UploadBuildAttachmentResult::new(
-            None, // targeting current build
-            "agent-report".to_string(),
-            "out/report.pdf".to_string(),
-            staged.to_string(),
-            5,
-            DUMMY_HASH.to_string(),
-        );
-        let mut ctx = make_ctx(dir.path().to_path_buf(), true);
-        ctx.build_id = Some(999); // current build not in allowed list
-        ctx.tool_configs.insert(
-            "upload-build-attachment".to_string(),
-            serde_json::json!({ "allowed-build-ids": [100, 200] }),
-        );
-        let outcome = result.execute_impl(&ctx).await.unwrap();
-        assert!(
-            outcome.success,
-            "current build should bypass allowed-build-ids, got: {:?}",
-            outcome
-        );
-    }
-
-    #[tokio::test]
-    async fn test_executor_accepts_allowed_build_id() {
-        let dir = tempfile::tempdir().unwrap();
-        let staged = "upload-build-attachment-agent-report-feedf00d.pdf";
-        std::fs::write(dir.path().join(staged), b"hello").unwrap();
-
-        let result = UploadBuildAttachmentResult::new(
-            Some(100),
-            "agent-report".to_string(),
-            "out/report.pdf".to_string(),
-            staged.to_string(),
-            5,
-            DUMMY_HASH.to_string(),
-        );
-        let mut ctx = make_ctx(dir.path().to_path_buf(), true);
-        ctx.tool_configs.insert(
-            "upload-build-attachment".to_string(),
-            serde_json::json!({ "allowed-build-ids": [100, 200] }),
-        );
-        let outcome = result.execute_impl(&ctx).await.unwrap();
-        assert!(outcome.success, "expected success, got: {:?}", outcome);
-    }
-
-    #[tokio::test]
     async fn test_executor_rejects_oversized_file() {
         let dir = tempfile::tempdir().unwrap();
         let staged = "upload-build-attachment-agent-big-deadbeef.bin";
         std::fs::write(dir.path().join(staged), vec![0u8; 1024]).unwrap();
 
         let result = UploadBuildAttachmentResult::new(
-            Some(1),
+            None,
             "agent-big".to_string(),
             "out/big.bin".to_string(),
             staged.to_string(),
@@ -1058,7 +1083,7 @@ attachment-type: "agent-artifact"
         std::fs::write(dir.path().join(staged), b"MZ hello").unwrap();
 
         let result = UploadBuildAttachmentResult::new(
-            Some(1),
+            None,
             "agent-report".to_string(),
             "out/report.exe".to_string(),
             staged.to_string(),
@@ -1088,7 +1113,7 @@ attachment-type: "agent-artifact"
         std::fs::write(dir.path().join(staged), b"hello").unwrap();
 
         let result = UploadBuildAttachmentResult::new(
-            Some(1),
+            None,
             "evil-report".to_string(),
             "out/report.pdf".to_string(),
             staged.to_string(),
@@ -1116,7 +1141,7 @@ attachment-type: "agent-artifact"
         std::fs::write(dir.path().join(staged), b"hello").unwrap();
 
         let result = UploadBuildAttachmentResult::new(
-            Some(1),
+            None,
             "report".to_string(),
             "out/report.pdf".to_string(),
             staged.to_string(),
@@ -1146,7 +1171,7 @@ attachment-type: "agent-artifact"
         std::fs::write(dir.path().join(staged), vec![0u8; 100]).unwrap();
 
         let result = UploadBuildAttachmentResult::new(
-            Some(1),
+            None,
             "agent-report".to_string(),
             "out/report.pdf".to_string(),
             staged.to_string(),

--- a/src/safe_outputs/upload_build_attachment.rs
+++ b/src/safe_outputs/upload_build_attachment.rs
@@ -11,7 +11,7 @@
 //! the hood:
 //!
 //! ```text
-//! PUT {collectionUri}_apis/distributedtask/hubs/build
+//! PUT {org}/{project}/_apis/distributedtask/hubs/build
 //!     /plans/{planId}/timelines/{timelineId}/records/{recordId}
 //!     /attachments/{type}/{name}?api-version=7.1-preview
 //! ```
@@ -507,16 +507,18 @@ impl Executor for UploadBuildAttachmentResult {
         )?;
         debug!("ADO org: {}, project: {}", org_url, project);
 
-        // Build the DistributedTask timeline-attachment URL (collection-scoped;
-        // the `build` hub covers build/YAML pipelines). This is the write side
-        // of a build attachment — the object is read back via the Build ▸
-        // Attachments Get/List API by `{type}`/`{name}`.
-        // PUT {collectionUri}_apis/distributedtask/hubs/build/plans/{planId}
+        // Build the DistributedTask timeline-attachment URL. This is the write
+        // side of a build attachment — the object is read back via the Build ▸
+        // Attachments Get/List API by `{type}`/`{name}`. The `build` hub covers
+        // build/YAML pipelines; the route is project-scoped (like the Build
+        // area), unlike the collection-scoped `resources/Containers` upload.
+        // PUT {org}/{project}/_apis/distributedtask/hubs/build/plans/{planId}
         //     /timelines/{timelineId}/records/{recordId}
         //     /attachments/{type}/{name}?api-version=7.1-preview.1
         let url = format!(
-            "{}/_apis/distributedtask/hubs/build/plans/{}/timelines/{}/records/{}/attachments/{}/{}?api-version=7.1-preview.1",
+            "{}/{}/_apis/distributedtask/hubs/build/plans/{}/timelines/{}/records/{}/attachments/{}/{}?api-version=7.1-preview.1",
             org_url.trim_end_matches('/'),
+            utf8_percent_encode(project, PATH_SEGMENT),
             utf8_percent_encode(plan_id, PATH_SEGMENT),
             utf8_percent_encode(timeline_id, PATH_SEGMENT),
             utf8_percent_encode(record_id, PATH_SEGMENT),

--- a/src/safe_outputs/upload_build_attachment.rs
+++ b/src/safe_outputs/upload_build_attachment.rs
@@ -1045,6 +1045,43 @@ attachment-type: "agent-artifact"
     }
 
     #[tokio::test]
+    async fn test_executor_fails_when_project_id_missing() {
+        // SHA-256 of b"hello" so the integrity check passes and we reach the
+        // scope-identifier resolution.
+        const HELLO_SHA: &str =
+            "2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824";
+        let dir = tempfile::tempdir().unwrap();
+        let staged = "upload-build-attachment-agent-report-1badf00d.txt";
+        std::fs::write(dir.path().join(staged), b"hello").unwrap();
+
+        let result = UploadBuildAttachmentResult::new(
+            None,
+            "agent-report".to_string(),
+            "out/report.txt".to_string(),
+            staged.to_string(),
+            5,
+            HELLO_SHA.to_string(),
+        );
+        // Non-dry-run with org/token/plan/timeline/job set but
+        // SYSTEM_TEAMPROJECTID absent — must fail before any HTTP call, naming
+        // the missing variable (it is the route's scope identifier).
+        let mut ctx = make_ctx(dir.path().to_path_buf(), false);
+        ctx.ado_org_url = Some("https://dev.azure.com/org".to_string());
+        ctx.ado_project = Some("Proj".to_string());
+        ctx.access_token = Some("token".to_string());
+        ctx.plan_id = Some("00000000-0000-0000-0000-000000000001".to_string());
+        ctx.timeline_id = Some("00000000-0000-0000-0000-000000000002".to_string());
+        ctx.job_id = Some("00000000-0000-0000-0000-000000000003".to_string());
+        // ado_project_id intentionally left None.
+        let err = result.execute_impl(&ctx).await.unwrap_err();
+        assert!(
+            err.to_string().contains("SYSTEM_TEAMPROJECTID"),
+            "expected SYSTEM_TEAMPROJECTID error, got: {}",
+            err
+        );
+    }
+
+    #[tokio::test]
     async fn test_executor_rejects_missing_staged_file() {
         let dir = tempfile::tempdir().unwrap();
         let result = UploadBuildAttachmentResult::new(
@@ -1211,8 +1248,9 @@ attachment-type: "agent-artifact"
         let content = b"real file content";
         std::fs::write(dir.path().join(staged), content).unwrap();
 
-        // Record the hash of different content — same size but wrong hash.
-        let wrong_hash = crate::hash::sha256_hex(b"wrong file content");
+        // Record the hash of different content of the SAME length (17 bytes),
+        // so the size check passes and the SHA-256 check is what fires.
+        let wrong_hash = crate::hash::sha256_hex(b"fake file content");
 
         let result = UploadBuildAttachmentResult::new(
             Some(1),

--- a/src/safe_outputs/upload_build_attachment.rs
+++ b/src/safe_outputs/upload_build_attachment.rs
@@ -11,9 +11,9 @@
 //! the hood:
 //!
 //! ```text
-//! PUT {org}/{project}/_apis/distributedtask/hubs/build
+//! PUT {org}/{projectId}/_apis/distributedtask/hubs/build
 //!     /plans/{planId}/timelines/{timelineId}/records/{recordId}
-//!     /attachments/{type}/{name}?api-version=7.1-preview
+//!     /attachments/{type}/{name}?api-version=7.1
 //! ```
 //!
 //! The resulting object *is* a build attachment: it is stored once by
@@ -493,6 +493,13 @@ impl Executor for UploadBuildAttachmentResult {
             .access_token
             .as_ref()
             .context("No access token available (SYSTEM_ACCESSTOKEN or AZURE_DEVOPS_EXT_PAT)")?;
+        // The DistributedTask hub route's `{scopeIdentifier}` is the **project
+        // GUID** (SYSTEM_TEAMPROJECTID), not the project name — the name routes
+        // but is rejected with HTTP 400.
+        let project_id = ctx.ado_project_id.as_ref().context(
+            "SYSTEM_TEAMPROJECTID is not set — required as the scope identifier for the build \
+             attachment (timeline attachment) API",
+        )?;
         let plan_id = ctx.plan_id.as_ref().context(
             "SYSTEM_PLANID is not set — required to attach to the current build (build attachments \
              are written to the current job's timeline record)",
@@ -505,20 +512,20 @@ impl Executor for UploadBuildAttachmentResult {
             "SYSTEM_JOBID is not set — required to attach to the current build (build attachments \
              are written to the current job's timeline record)",
         )?;
-        debug!("ADO org: {}, project: {}", org_url, project);
+        debug!("ADO org: {}, project: {} ({})", org_url, project, project_id);
 
         // Build the DistributedTask timeline-attachment URL. This is the write
         // side of a build attachment — the object is read back via the Build ▸
         // Attachments Get/List API by `{type}`/`{name}`. The `build` hub covers
-        // build/YAML pipelines; the route is project-scoped (like the Build
-        // area), unlike the collection-scoped `resources/Containers` upload.
-        // PUT {org}/{project}/_apis/distributedtask/hubs/build/plans/{planId}
+        // build/YAML pipelines. The route's `{scopeIdentifier}` is the project
+        // **GUID**; released api-version is 7.1.
+        // PUT {org}/{projectId}/_apis/distributedtask/hubs/build/plans/{planId}
         //     /timelines/{timelineId}/records/{recordId}
-        //     /attachments/{type}/{name}?api-version=7.1-preview.1
+        //     /attachments/{type}/{name}?api-version=7.1
         let url = format!(
-            "{}/{}/_apis/distributedtask/hubs/build/plans/{}/timelines/{}/records/{}/attachments/{}/{}?api-version=7.1-preview.1",
+            "{}/{}/_apis/distributedtask/hubs/build/plans/{}/timelines/{}/records/{}/attachments/{}/{}?api-version=7.1",
             org_url.trim_end_matches('/'),
-            utf8_percent_encode(project, PATH_SEGMENT),
+            utf8_percent_encode(project_id, PATH_SEGMENT),
             utf8_percent_encode(plan_id, PATH_SEGMENT),
             utf8_percent_encode(timeline_id, PATH_SEGMENT),
             utf8_percent_encode(record_id, PATH_SEGMENT),
@@ -549,9 +556,15 @@ impl Executor for UploadBuildAttachmentResult {
                 );
                 serde_json::Value::Null
             });
+            // The timeline-attachment response carries the attachment URL under
+            // `_links.self.href` (there is no top-level `url` field); fall back
+            // to a top-level `url` defensively for forward compatibility.
             let attachment_url = resp_body
-                .get("url")
+                .get("_links")
+                .and_then(|l| l.get("self"))
+                .and_then(|s| s.get("href"))
                 .and_then(|v| v.as_str())
+                .or_else(|| resp_body.get("url").and_then(|v| v.as_str()))
                 .map(|s| s.to_string());
             info!(
                 "Attached '{}' to build #{} as '{}'",
@@ -1018,6 +1031,7 @@ attachment-type: "agent-artifact"
         let mut ctx = make_ctx(dir.path().to_path_buf(), false);
         ctx.ado_org_url = Some("https://dev.azure.com/org".to_string());
         ctx.ado_project = Some("Proj".to_string());
+        ctx.ado_project_id = Some("00000000-0000-0000-0000-0000000000aa".to_string());
         ctx.access_token = Some("token".to_string());
         ctx.timeline_id = Some("00000000-0000-0000-0000-000000000001".to_string());
         ctx.job_id = Some("00000000-0000-0000-0000-000000000002".to_string());


### PR DESCRIPTION
## Summary

Fixes `upload-build-attachment`, which failed against the live ADO server in the
deterministic executor-e2e pipeline (build **619362**):

```
Failed to attach artifact to build #619362 (HTTP 404 Not Found):
The controller for path '/AgentPlayground/_apis/build/builds/619362/attachments/…'
was not found or does not implement IController.
```

**Root cause:** the executor `PUT`s to
`/_apis/build/builds/{id}/attachments/{type}/{name}`, but ADO's **Build ▸
Attachments** REST API is **read-only** (`Get`/`List` only) — that create route
never existed, so every live upload 404'd as an unmatched route.

## Fix

Build attachments are created via the **DistributedTask timeline attachment**
API — the same mechanism as the `##vso[task.addattachment]` logging command. The
resulting object *is* a build attachment (same `{type}`/`{name}`, read back via
the Build ▸ Attachments Get/List API); only the write endpoint changes. Because a
timeline attachment targets the current job's record, it is **current-run only**.

Verified working endpoint (empirically confirmed):

```
PUT {org}/{SYSTEM_TEAMPROJECTID}/_apis/distributedtask/hubs/build
    /plans/{SYSTEM_PLANID}/timelines/{SYSTEM_TIMELINEID}/records/{SYSTEM_JOBID}
    /attachments/{type}/{name}?api-version=7.1
```

- Scope identifier is the project **GUID** (`SYSTEM_TEAMPROJECTID`) — the project
  *name* routes but is rejected `HTTP 400`; a collection-scoped URL `404`s.
- The attachment URL is read from `_links.self.href` (there is no top-level
  `url` field).

## Changes

- **`result.rs`**: add `plan_id` / `timeline_id` / `job_id` to `ExecutionContext`
  from `SYSTEM_PLANID` / `SYSTEM_TIMELINEID` / `SYSTEM_JOBID` (auto-injected
  predefined vars — no compiler change needed).
- **`upload_build_attachment.rs`**: switch to the timeline-attachment endpoint;
  reject a `build_id` that differs from the current run with a clear message;
  remove the now-meaningless `allowed-build-ids` config; parse
  `_links.self.href`; rewrite the module doc.
- **Codemod `0005_drop_build_attachment_allowed_build_ids`**: auto-strips
  `safe-outputs.upload-build-attachment.allowed-build-ids` (with a compile
  warning). Leaves `upload-pipeline-artifact.allowed-build-ids` untouched.
- **`mcp.rs`** tool description + **`docs/safe-outputs.md`** / **`docs/codemods.md`**.

## Semantic note

There is **no user-facing difference** in the resulting attachment — a timeline
attachment is a build attachment, and it is read back through the same Build ▸
Attachments API. The only behavioural change is that attaching to an *arbitrary
other* build is no longer offered (it was never actually possible).

## Testing

- `cargo test` full suite (2511 unit + all integration), `cargo clippy
  --all-targets --all-features` — clean. (No `cargo fmt`: local rustfmt 1.9.0
  reformats unrelated committed code and CI has no fmt gate.)
- **Live validation:** the deterministic executor-e2e pipeline (def 2541) run on
  this branch (build **619391**) passes: **20 total, 19 passed, 0 failed, 1
  skipped**, with `[PASS] upload-build-attachment`.

Fixes the failure tracked in `jamesadevine/ado-aw-issues#8`.
