### PR TITLE
test(compile): fix named-pool 1ES test on Windows CRLF checkout

### DIFF
--- a/tests/compiler_tests.rs
+++ b/tests/compiler_tests.rs
@@ -3386,6 +3386,12 @@ fn compile_named_pool_demands_fixture_for_target(target: Option<&str>) -> String
         &[],
         &["--skip-integrity"],
         |contents| {
+            // Normalize CRLF → LF so the `target:` injection below matches
+            // regardless of how git checked the fixture out (on Windows,
+            // core.autocrlf rewrites the fixture with CRLF line endings,
+            // which would otherwise defeat the `\n`-anchored replacen and
+            // silently drop the target override).
+            let contents = contents.replace("\r\n", "\n");
             if let Some(target) = target {
                 contents.replacen(
                     "description: \"Fixture that exercises named pool demands\"\n",


### PR DESCRIPTION
## Summary

The Daily Build failed **only on Windows** on 12 & 13 July via the test `test_named_pool_demands_compile_to_1es_shared_pool` (`tests/compiler_tests.rs`), panicking with `1ES output should contain extends.parameters.pool mapping`.

**Root cause** (test bug introduced by #1461 *feat(compile): support named pool demands*):

- On Windows, git checks out the `named-pool-demands-agent.md` fixture with **CRLF** line endings (`core.autocrlf=true`, no `.gitattributes` override for fixtures).
- The test helper `compile_named_pool_demands_fixture_for_target` injected `target: 1es` via `replacen("description: \"...\"\n", ...)` using a bare `\n`.
- Against CRLF content the pattern never matched, so `target: 1es` was silently dropped. The fixture then compiled as the default **standalone** target — which has no `extends.parameters.pool` — tripping the assertion.
- The sibling `job`/`stage` cases passed vacuously (standalone still exposes an `Agent` job with a pool), so only the 1ES case surfaced the bug.

**Fix:** normalize `\r\n` → `\n` in the transform closure before the `replacen`, so the target override applies regardless of checkout line endings. This is purely a test-harness issue; the compiler itself was never broken.

## Test plan

- `cargo test --test compiler_tests named_pool` → 3 passed (previously failed on Windows)
- `cargo test --test compiler_tests` → 184 passed, 0 failed (on Windows)
