### PR TITLE
chore: regenerate committed SKILL.md for v0.44.1

### DIFF
--- a/.github/skills/ado-aw/SKILL.md
+++ b/.github/skills/ado-aw/SKILL.md
@@ -46,7 +46,7 @@ This is a **dispatcher skill** that routes your request to the appropriate speci
 ### Create New Agentic Workflow
 **Load when**: User wants to create a new agentic workflow from scratch
 
-**Prompt file**: https://raw.githubusercontent.com/githubnext/ado-aw/v0.44.0/prompts/create-ado-agentic-workflow.md <!-- x-release-please-version -->
+**Prompt file**: https://raw.githubusercontent.com/githubnext/ado-aw/v0.44.1/prompts/create-ado-agentic-workflow.md <!-- x-release-please-version -->
 
 **Use cases**:
 - "Create an agentic workflow that reviews PRs weekly"
@@ -56,7 +56,7 @@ This is a **dispatcher skill** that routes your request to the appropriate speci
 ### Update Existing Workflow
 **Load when**: User wants to modify an existing agent workflow file
 
-**Prompt file**: https://raw.githubusercontent.com/githubnext/ado-aw/v0.44.0/prompts/update-ado-agentic-workflow.md <!-- x-release-please-version -->
+**Prompt file**: https://raw.githubusercontent.com/githubnext/ado-aw/v0.44.1/prompts/update-ado-agentic-workflow.md <!-- x-release-please-version -->
 
 **Use cases**:
 - "Add the Azure DevOps MCP to my workflow"
@@ -66,7 +66,7 @@ This is a **dispatcher skill** that routes your request to the appropriate speci
 ### Debug Failing Workflow
 **Load when**: User needs to troubleshoot a failing agentic workflow
 
-**Prompt file**: https://raw.githubusercontent.com/githubnext/ado-aw/v0.44.0/prompts/debug-ado-agentic-workflow.md <!-- x-release-please-version -->
+**Prompt file**: https://raw.githubusercontent.com/githubnext/ado-aw/v0.44.1/prompts/debug-ado-agentic-workflow.md <!-- x-release-please-version -->
 
 **Use cases**:
 - "Why is my agentic workflow failing?"
@@ -109,4 +109,4 @@ ado-aw check <pipeline.lock.yml>
 - Agent files must be compiled with `ado-aw compile` after YAML frontmatter changes
 - Markdown body (agent instructions) changes do NOT require recompilation
 - The agent never has direct write access — all mutations go through safe outputs
-- Full reference: https://raw.githubusercontent.com/githubnext/ado-aw/v0.44.0/AGENTS.md <!-- x-release-please-version -->
+- Full reference: https://raw.githubusercontent.com/githubnext/ado-aw/v0.44.1/AGENTS.md <!-- x-release-please-version -->


### PR DESCRIPTION
## Summary

Fixes stale `x-release-please-version` markers in the committed `.github/skills/ado-aw/SKILL.md`.

The skill file was committed in #1499 with `v0.44.0` prompt/AGENTS URLs, but the crate has since been released as `0.44.1`. `tests/init_tests.rs::test_committed_skill_file_matches_template_output` regenerates the skill from `src/data/init-skill.md` (substituting the current crate version) and compares it byte-for-byte against the committed file, so this drift **fails the required `Build & Test` check on `main`** — and therefore on every branch cut from it.

This bumps the three prompt URLs and the AGENTS.md reference from `v0.44.0` → `v0.44.1` to match the template output. No behavior change.

## Test plan

- `cargo test --test init_tests test_committed_skill_file_matches_template_output` — now passes (was failing on `main`).
