### PR TITLE
fix(trigger-e2e): stabilize and parallelize victim scenarios

### DIFF
--- a/docs/filter-ir.md
+++ b/docs/filter-ir.md
@@ -77,7 +77,7 @@ on `PrMetadata` being acquired first.
 |------|--------|-----------|------------|
 | `PrMetadata` | `GET pullRequests/{id}` | `PR_DATA` | — |
 | `PrIsDraft` | `json .isDraft` from `PR_DATA` | `IS_DRAFT` | `PrMetadata` |
-| `PrLabels` | `json .labels[].name` from `PR_DATA` | `PR_LABELS` | `PrMetadata` |
+| `PrLabels` | `GET pullRequests/{id}/labels` | `PR_LABELS` | — |
 
 #### Iteration API-Derived
 
@@ -175,7 +175,7 @@ Maps each field of `PrFilters` to a `FilterCheck`:
 | `source_branch` | `GlobMatch` | `SourceBranch` | `source-branch-mismatch` |
 | `target_branch` | `GlobMatch` | `TargetBranch` | `target-branch-mismatch` |
 | `commit_message` | `GlobMatch` | `CommitMessage` | `commit-message-mismatch` |
-| `labels` | `LabelSetMatch` | `PrLabels` (→ `PrMetadata`) | `labels-mismatch` |
+| `labels` | `LabelSetMatch` | `PrLabels` | `labels-mismatch` |
 | `draft` | `Equality` | `PrIsDraft` (→ `PrMetadata`) | `draft-mismatch` |
 | `changed_files` | `FileGlobMatch` | `ChangedFiles` | `changed-files-mismatch` |
 | `time_window` | `TimeWindow` | `CurrentUtcMinutes` | `time-window-mismatch` |

--- a/scripts/ado-script/src/gate/facts.test.ts
+++ b/scripts/ado-script/src/gate/facts.test.ts
@@ -6,12 +6,14 @@ const {
   mockReadEnvFact,
   mockIsPipelineVarFact,
   mockGetPullRequestById,
+  mockGetPullRequestLabels,
   mockGetPullRequestIterations,
   mockGetIterationChanges,
 } = vi.hoisted(() => ({
   mockReadEnvFact: vi.fn(),
   mockIsPipelineVarFact: vi.fn(),
   mockGetPullRequestById: vi.fn(),
+  mockGetPullRequestLabels: vi.fn(),
   mockGetPullRequestIterations: vi.fn(),
   mockGetIterationChanges: vi.fn(),
 }));
@@ -23,6 +25,7 @@ vi.mock("../shared/env-facts.js", () => ({
 
 vi.mock("../shared/ado-client.js", () => ({
   getPullRequestById: mockGetPullRequestById,
+  getPullRequestLabels: mockGetPullRequestLabels,
   getPullRequestIterations: mockGetPullRequestIterations,
   getIterationChanges: mockGetIterationChanges,
 }));
@@ -72,6 +75,7 @@ describe("acquireFacts", () => {
     mockReadEnvFact.mockReset();
     mockIsPipelineVarFact.mockReset().mockReturnValue(false);
     mockGetPullRequestById.mockReset();
+    mockGetPullRequestLabels.mockReset();
     mockGetPullRequestIterations.mockReset();
     mockGetIterationChanges.mockReset();
   });
@@ -166,11 +170,13 @@ describe("acquireFacts", () => {
     expect(mockGetPullRequestById).not.toHaveBeenCalled();
   });
 
-  it("derives pr_labels from cached pr_metadata", async () => {
-    mockGetPullRequestById.mockResolvedValue({
-      pullRequestId: 42,
-      labels: [{ name: "ready" }, { name: "security" }, {}],
-    });
+  it("acquires pr_labels from the dedicated labels endpoint", async () => {
+    mockGetPullRequestById.mockResolvedValue({ pullRequestId: 42 });
+    mockGetPullRequestLabels.mockResolvedValue([
+      { name: "ready" },
+      { name: "security" },
+      {},
+    ]);
     const { tracker } = makeTracker();
 
     const facts = await acquireFacts(
@@ -178,6 +184,7 @@ describe("acquireFacts", () => {
       tracker,
     );
 
+    expect(mockGetPullRequestLabels).toHaveBeenCalledWith("project", "repo", 42);
     expect(facts.get("pr_labels")).toEqual(["ready", "security", ""]);
   });
 

--- a/scripts/ado-script/src/gate/facts.ts
+++ b/scripts/ado-script/src/gate/facts.ts
@@ -67,10 +67,12 @@ async function acquireOne(
       return md.isDraft ? "true" : "false";
     }
     case "pr_labels": {
-      const md = facts.get("pr_metadata") as
-        | { labels?: { name?: string }[] }
-        | undefined;
-      const labels = md?.labels ?? [];
+      requireAdoCtx(ctx, "pr_labels");
+      const labels = await adoClient.getPullRequestLabels(
+        ctx.project,
+        ctx.repoId,
+        ctx.prId,
+      );
       return labels.map((l) => l.name ?? "");
     }
     case "changed_files": {

--- a/scripts/ado-script/src/shared/__tests__/ado-client.test.ts
+++ b/scripts/ado-script/src/shared/__tests__/ado-client.test.ts
@@ -7,6 +7,7 @@ const { mockGitApi, mockBuildApi, mockWebApi, mockGetWebApi } = vi.hoisted(() =>
     getBranch: vi.fn(),
     getCommitDiffs: vi.fn(),
     getPullRequestById: vi.fn(),
+    getPullRequestLabels: vi.fn(),
     getPullRequestIterations: vi.fn(),
     getPullRequestIterationChanges: vi.fn(),
   };
@@ -29,6 +30,7 @@ vi.mock("../auth.js", () => ({
 import {
   getCommitDiffMetadata,
   getPullRequestById,
+  getPullRequestLabels,
   getPullRequestIterations,
   getIterationChanges,
   cancelBuild,
@@ -40,6 +42,7 @@ describe("ado-client", () => {
     mockGitApi.getBranch.mockReset();
     mockGitApi.getCommitDiffs.mockReset();
     mockGitApi.getPullRequestById.mockReset();
+    mockGitApi.getPullRequestLabels.mockReset();
     mockGitApi.getPullRequestIterations.mockReset();
     mockGitApi.getPullRequestIterationChanges.mockReset();
     mockBuildApi.updateBuild.mockReset();
@@ -55,6 +58,21 @@ describe("ado-client", () => {
     const result = await getPullRequestById("p", "r", 42);
     expect(mockGitApi.getPullRequestById).toHaveBeenCalledWith(42, "p");
     expect(result).toEqual({ pullRequestId: 42 });
+  });
+
+  it("getPullRequestLabels calls the dedicated labels endpoint", async () => {
+    mockGitApi.getPullRequestLabels.mockResolvedValue([
+      { name: "run-agent" },
+      { name: "security" },
+    ]);
+    const result = await getPullRequestLabels("p", "r", 42);
+    expect(mockGitApi.getPullRequestLabels).toHaveBeenCalledWith("r", 42, "p");
+    expect(result).toEqual([{ name: "run-agent" }, { name: "security" }]);
+  });
+
+  it("getPullRequestLabels normalizes an empty SDK response", async () => {
+    mockGitApi.getPullRequestLabels.mockResolvedValue(null);
+    await expect(getPullRequestLabels("p", "r", 42)).resolves.toEqual([]);
   });
 
   it("getCommitDiffMetadata pins the target branch tip and orients the diff correctly", async () => {

--- a/scripts/ado-script/src/shared/__tests__/policy.test.ts
+++ b/scripts/ado-script/src/shared/__tests__/policy.test.ts
@@ -7,7 +7,6 @@ import type { FactSpec } from "../types.gen.js";
 // the call sites (matches how the compiler emits it in production).
 const DEFAULT_DEPS: Record<string, readonly string[]> = {
   pr_is_draft: ["pr_metadata"],
-  pr_labels: ["pr_metadata"],
   changed_file_count: ["changed_files"],
 };
 
@@ -57,15 +56,13 @@ describe("PolicyTracker", () => {
     expect(t.verdictForMissingFacts(["pr_is_draft"])).toBe("skip");
   });
 
-  it("transitive skip: pr_metadata fails skip_dependents → pr_labels skipped", () => {
+  it("pr_metadata failure does not suppress independent pr_labels", () => {
     const t = new PolicyTracker([
       spec("pr_metadata", "skip_dependents"),
       spec("pr_labels", "fail_open"),
     ]);
     t.recordFactFailure("pr_metadata", "API error");
-    // Even though pr_labels is fail_open, the *skip* propagates because
-    // its dep failed with skip_dependents. The skip dominates.
-    expect(t.verdictForMissingFacts(["pr_labels"])).toBe("skip");
+    expect(t.verdictForMissingFacts(["pr_labels"])).toBe("evaluate");
   });
 
   it("transitive skip: changed_files fails skip_dependents → changed_file_count skipped", () => {

--- a/scripts/ado-script/src/shared/ado-client.ts
+++ b/scripts/ado-script/src/shared/ado-client.ts
@@ -172,6 +172,17 @@ export async function getPullRequestById(
   });
 }
 
+export async function getPullRequestLabels(
+  project: string,
+  repoId: string,
+  prId: number,
+): Promise<Array<{ name?: string }>> {
+  return withRetry("getPullRequestLabels", async () => {
+    const git = await (await getWebApi()).getGitApi();
+    return (await git.getPullRequestLabels(repoId, prId, project)) ?? [];
+  });
+}
+
 /**
  * Lists active pull requests whose `sourceRefName` matches the given
  * value. Used by `exec-context-pr-synth` to discover the open PR for

--- a/scripts/ado-script/src/trigger-e2e/__tests__/gate-spec.test.ts
+++ b/scripts/ado-script/src/trigger-e2e/__tests__/gate-spec.test.ts
@@ -28,15 +28,13 @@ describe("buildGateSpec fact derivation", () => {
     expect(spec.context.bypass_label).toBe("PR");
   });
 
-  it("derives pr_metadata (skip_dependents) before pr_labels (fail_open) for a labels check", () => {
+  it("derives independent fail-open pr_labels for a labels check", () => {
     const spec = buildGateSpec("pull-request", [labelsCheck({ anyOf: ["run-agent"] })]);
     const kinds = spec.facts.map((f) => f.kind);
-    expect(kinds).toEqual(["pr_metadata", "pr_labels"]);
+    expect(kinds).toEqual(["pr_labels"]);
     const meta = Object.fromEntries(spec.facts.map((f) => [f.kind, f]));
-    expect(meta.pr_metadata!.failure_policy).toBe("skip_dependents");
-    expect(meta.pr_metadata!.dependencies).toEqual([]);
     expect(meta.pr_labels!.failure_policy).toBe("fail_open");
-    expect(meta.pr_labels!.dependencies).toEqual(["pr_metadata"]);
+    expect(meta.pr_labels!.dependencies).toEqual([]);
   });
 
   it("derives pr_metadata before pr_is_draft (fail_closed) for a draft check", () => {

--- a/scripts/ado-script/src/trigger-e2e/__tests__/runner.test.ts
+++ b/scripts/ado-script/src/trigger-e2e/__tests__/runner.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it, vi } from "vitest";
 
 import type { AdoRest } from "../../executor-e2e/ado-rest.js";
-import { runScenario } from "../runner.js";
+import { runAll, runScenario, scenarioConcurrency } from "../runner.js";
 import { SkipError } from "../scenario.js";
 import type { TriggerContext, TriggerScenario } from "../scenario.js";
 
@@ -140,5 +140,73 @@ describe("runScenario", () => {
     const res = await runScenario(ctx, scenario({ expected: () => ({ result: "succeeded" }) }));
     expect(res.ok).toBe(true);
     expect(rest.cancelBuild).not.toHaveBeenCalled();
+  });
+});
+
+describe("scenarioConcurrency", () => {
+  it("defaults to four, including for an unexpanded ADO macro", () => {
+    expect(scenarioConcurrency({})).toBe(4);
+    expect(scenarioConcurrency({ TRIGGER_E2E_CONCURRENCY: "$(TRIGGER_E2E_CONCURRENCY)" })).toBe(4);
+  });
+
+  it("accepts an explicit bounded integer", () => {
+    expect(scenarioConcurrency({ TRIGGER_E2E_CONCURRENCY: "6" })).toBe(6);
+  });
+
+  it.each(["0", "9", "1.5", "many"])("rejects invalid value %s", (value) => {
+    expect(() => scenarioConcurrency({ TRIGGER_E2E_CONCURRENCY: value })).toThrow(
+      "TRIGGER_E2E_CONCURRENCY",
+    );
+  });
+});
+
+describe("runAll", () => {
+  it("runs scenarios concurrently while preserving declaration order", async () => {
+    const { ctx } = makeCtx({ result: "succeeded" });
+    let active = 0;
+    let maxActive = 0;
+
+    const delayed = (id: string, delayMs: number): TriggerScenario<string> =>
+      scenario({
+        id,
+        setup: async () => {
+          active += 1;
+          maxActive = Math.max(maxActive, active);
+          await new Promise((resolve) => setTimeout(resolve, delayMs));
+          active -= 1;
+          return id;
+        },
+      });
+
+    const results = await runAll(
+      ctx,
+      [delayed("first", 30), delayed("second", 5), delayed("third", 5)],
+      2,
+    );
+
+    expect(maxActive).toBe(2);
+    expect(results.map((result) => result.id)).toEqual(["first", "second", "third"]);
+    expect(results.every((result) => result.ok)).toBe(true);
+  });
+
+  it("never exceeds the requested concurrency", async () => {
+    const { ctx } = makeCtx({ result: "succeeded" });
+    let active = 0;
+    let maxActive = 0;
+    const scenarios = Array.from({ length: 7 }, (_, index) =>
+      scenario({
+        id: `s-${index}`,
+        setup: async () => {
+          active += 1;
+          maxActive = Math.max(maxActive, active);
+          await new Promise((resolve) => setTimeout(resolve, 10));
+          active -= 1;
+          return "state";
+        },
+      }),
+    );
+
+    await runAll(ctx, scenarios, 3);
+    expect(maxActive).toBe(3);
   });
 });

--- a/scripts/ado-script/src/trigger-e2e/fact-catalog.gen.json
+++ b/scripts/ado-script/src/trigger-e2e/fact-catalog.gen.json
@@ -54,9 +54,7 @@
   {
     "kind": "pr_labels",
     "failure_policy": "fail_open",
-    "dependencies": [
-      "pr_metadata"
-    ]
+    "dependencies": []
   },
   {
     "kind": "changed_files",

--- a/scripts/ado-script/src/trigger-e2e/gate-spec.ts
+++ b/scripts/ado-script/src/trigger-e2e/gate-spec.ts
@@ -62,7 +62,7 @@ const FACT_META: ReadonlyMap<string, FactMeta> = new Map<string, FactMeta>([
   ["triggering_branch", { policy: "fail_closed", deps: [] }],
   ["pr_metadata", { policy: "skip_dependents", deps: [] }],
   ["pr_is_draft", { policy: "fail_closed", deps: ["pr_metadata"] }],
-  ["pr_labels", { policy: "fail_open", deps: ["pr_metadata"] }],
+  ["pr_labels", { policy: "fail_open", deps: [] }],
   ["changed_files", { policy: "fail_open", deps: [] }],
   ["changed_file_count", { policy: "fail_open", deps: ["changed_files"] }],
   ["current_utc_minutes", { policy: "fail_closed", deps: [] }],

--- a/scripts/ado-script/src/trigger-e2e/index.ts
+++ b/scripts/ado-script/src/trigger-e2e/index.ts
@@ -20,6 +20,7 @@
  *   - TRIGGER_E2E_GITHUB_TOKEN — scoped PAT for issue filing
  *   - TRIGGER_E2E_ISSUE_REPO — GitHub repo for issues (default githubnext/ado-aw)
  *   - TRIGGER_E2E_BUILD_TIMEOUT_MS / TRIGGER_E2E_BUILD_POLL_MS — poll tuning
+ *   - TRIGGER_E2E_CONCURRENCY — concurrent scenarios (default 4, max 8)
  *
  * Test-harness module; not shipped in `ado-script.zip`.
  */

--- a/scripts/ado-script/src/trigger-e2e/runner.ts
+++ b/scripts/ado-script/src/trigger-e2e/runner.ts
@@ -1,10 +1,10 @@
 /**
  * Scenario runner for the trigger-condition E2E harness.
  *
- * Runs scenarios sequentially (deterministic ordering; queuing many victim
- * builds in parallel would contend for the agent pool). Each scenario is fully
- * isolated: a failure or skip never prevents later scenarios from running, and
- * cleanup always runs once `setup` succeeded.
+ * Runs isolated scenarios with bounded concurrency. Results retain declaration
+ * order even though setup, victim builds, assertions, and cleanup overlap.
+ * A failure or skip never prevents later scenarios from running, and cleanup
+ * always runs once `setup` succeeded.
  *
  * Test-harness module; not shipped in `ado-script.zip`.
  */
@@ -18,8 +18,25 @@ import type {
   TriggerScenario,
 } from "./scenario.js";
 
+const DEFAULT_SCENARIO_CONCURRENCY = 4;
+const MAX_SCENARIO_CONCURRENCY = 8;
+
 function errMessage(err: unknown): string {
   return err instanceof Error ? err.message : String(err);
+}
+
+/** Resolve the bounded victim-build concurrency for this harness run. */
+export function scenarioConcurrency(env: NodeJS.ProcessEnv = process.env): number {
+  const raw = env.TRIGGER_E2E_CONCURRENCY?.trim();
+  if (!raw || /^\$\(.*\)$/.test(raw)) return DEFAULT_SCENARIO_CONCURRENCY;
+
+  const parsed = Number(raw);
+  if (!Number.isInteger(parsed) || parsed < 1 || parsed > MAX_SCENARIO_CONCURRENCY) {
+    throw new Error(
+      `TRIGGER_E2E_CONCURRENCY must be an integer from 1 to ${MAX_SCENARIO_CONCURRENCY} (got '${raw}')`,
+    );
+  }
+  return parsed;
 }
 
 /** Default declarative assertion: build result + required/forbidden tags. */
@@ -127,10 +144,30 @@ export async function runScenario<S>(
 export async function runAll(
   ctx: TriggerContext,
   scenarios: TriggerScenario<unknown>[],
+  concurrency = scenarioConcurrency(),
 ): Promise<ScenarioResult[]> {
-  const results: ScenarioResult[] = [];
-  for (const scenario of scenarios) {
-    results.push(await runScenario(ctx, scenario));
+  if (scenarios.length === 0) return [];
+
+  const workerCount = Math.min(concurrency, scenarios.length);
+  const results = new Array<ScenarioResult>(scenarios.length);
+  let nextIndex = 0;
+
+  ctx.log(
+    `Running ${scenarios.length} trigger scenarios with concurrency ${workerCount}`,
+  );
+
+  const worker = async (): Promise<void> => {
+    while (true) {
+      const index = nextIndex++;
+      if (index >= scenarios.length) return;
+      results[index] = await runScenario(ctx, scenarios[index]!);
+    }
+  };
+
+  await Promise.all(Array.from({ length: workerCount }, () => worker()));
+
+  if (results.some((result) => result === undefined)) {
+    throw new Error("trigger scenario worker completed without recording every result");
   }
   return results;
 }

--- a/site/src/content/docs/reference/filter-ir.mdx
+++ b/site/src/content/docs/reference/filter-ir.mdx
@@ -78,7 +78,7 @@ on `PrMetadata` being acquired first.
 |------|--------|-----------|------------|
 | `PrMetadata` | `GET pullRequests/{id}` | `PR_DATA` | -- |
 | `PrIsDraft` | `json .isDraft` from `PR_DATA` | `IS_DRAFT` | `PrMetadata` |
-| `PrLabels` | `json .labels[].name` from `PR_DATA` | `PR_LABELS` | `PrMetadata` |
+| `PrLabels` | `GET pullRequests/{id}/labels` | `PR_LABELS` | -- |
 
 #### Iteration API-Derived
 
@@ -176,7 +176,7 @@ Maps each field of `PrFilters` to a `FilterCheck`:
 | `source_branch` | `GlobMatch` | `SourceBranch` | `source-branch-mismatch` |
 | `target_branch` | `GlobMatch` | `TargetBranch` | `target-branch-mismatch` |
 | `commit_message` | `GlobMatch` | `CommitMessage` | `commit-message-mismatch` |
-| `labels` | `LabelSetMatch` | `PrLabels` (-> `PrMetadata`) | `labels-mismatch` |
+| `labels` | `LabelSetMatch` | `PrLabels` | `labels-mismatch` |
 | `draft` | `Equality` | `PrIsDraft` (-> `PrMetadata`) | `draft-mismatch` |
 | `changed_files` | `FileGlobMatch` | `ChangedFiles` | `changed-files-mismatch` |
 | `time_window` | `TimeWindow` | `CurrentUtcMinutes` | `time-window-mismatch` |

--- a/src/compile/extensions/ado_script.rs
+++ b/src/compile/extensions/ado_script.rs
@@ -2378,7 +2378,7 @@ mod tests {
 
         // Three checks together cover the three identifiers that
         // read from the synth-emitted `AW_PR_*` variables:
-        //   - LabelSetMatch (PrLabels → PrMetadata) → ADO_PR_ID
+        //   - LabelSetMatch (PrLabels) → ADO_PR_ID
         //   - SourceBranch fact → ADO_SOURCE_BRANCH
         //   - TargetBranch fact → ADO_TARGET_BRANCH
         let checks = vec![

--- a/src/compile/filter_ir.rs
+++ b/src/compile/filter_ir.rs
@@ -75,7 +75,7 @@ pub enum Fact {
     PrMetadata,
     /// PR draft status — extracted from PrMetadata
     PrIsDraft,
-    /// PR labels list — extracted from PrMetadata
+    /// PR labels list from the dedicated labels endpoint
     PrLabels,
 
     // ── Iteration API-derived (separate API call) ───────────────────────
@@ -106,7 +106,7 @@ impl Fact {
             // API-derived facts
             Fact::PrMetadata => &[],
             Fact::PrIsDraft => &[Fact::PrMetadata],
-            Fact::PrLabels => &[Fact::PrMetadata],
+            Fact::PrLabels => &[],
 
             // Iteration API
             Fact::ChangedFiles => &[],
@@ -1689,7 +1689,7 @@ mod tests {
     #[test]
     fn test_api_derived_facts_have_dependencies() {
         assert_eq!(Fact::PrIsDraft.dependencies(), &[Fact::PrMetadata]);
-        assert_eq!(Fact::PrLabels.dependencies(), &[Fact::PrMetadata]);
+        assert!(Fact::PrLabels.dependencies().is_empty());
         // Iteration API: ChangedFileCount depends on ChangedFiles
         assert_eq!(Fact::ChangedFileCount.dependencies(), &[Fact::ChangedFiles]);
     }
@@ -2176,10 +2176,13 @@ mod tests {
         assert_eq!(spec.context.tag_prefix, "pr-gate");
         assert_eq!(spec.context.step_name, "prGate");
         assert_eq!(spec.context.bypass_label, "PR");
-        // Facts should include pr_title, pr_metadata (dep of pr_labels), pr_labels
-        assert_eq!(spec.facts.len(), 3, "exactly 3 facts required for title + labels checks");
+        // Labels use their dedicated endpoint and no longer require PR metadata.
+        assert_eq!(
+            spec.facts.len(),
+            2,
+            "exactly 2 facts required for title + labels checks"
+        );
         assert!(spec.facts.iter().any(|f| f.kind == "pr_title"));
-        assert!(spec.facts.iter().any(|f| f.kind == "pr_metadata"));
         assert!(spec.facts.iter().any(|f| f.kind == "pr_labels"));
         // Checks
         assert_eq!(spec.checks.len(), 2);

--- a/src/compile/pr_filters.rs
+++ b/src/compile/pr_filters.rs
@@ -30,7 +30,7 @@ mod tests {
     // for all filter gate generation.
 
     #[test]
-    fn test_gate_step_includes_api_facts_for_tier2() {
+    fn test_gate_step_includes_dedicated_labels_fact_for_tier2() {
         use crate::compile::filter_ir::{GateContext, build_gate_spec, lower_pr_filters};
         let filters = PrFilters {
             labels: Some(LabelFilter {
@@ -42,8 +42,8 @@ mod tests {
         let checks = lower_pr_filters(&filters);
         let spec = build_gate_spec(GateContext::PullRequest, &checks).unwrap();
         assert!(
-            spec.facts.iter().any(|f| f.kind == "pr_metadata"),
-            "should require pr_metadata fact"
+            !spec.facts.iter().any(|f| f.kind == "pr_metadata"),
+            "labels use the dedicated endpoint and should not require pr_metadata"
         );
         assert!(
             spec.facts.iter().any(|f| f.kind == "pr_labels"),

--- a/tests/trigger-e2e/README.md
+++ b/tests/trigger-e2e/README.md
@@ -109,6 +109,18 @@ the suite before any victim build is queued. No force push is used. When
 `TRIGGER_E2E_VICTIM_REPO` is unset, synchronization is skipped and the
 existing bypass-only baseline still runs.
 
+## Scenario concurrency
+
+Scenarios run with bounded concurrency rather than waiting for every victim
+pipeline to finish before queueing the next one. The default is **4**
+concurrent scenarios, which substantially reduces queue-bound wall time while
+leaving capacity in the 16-agent pool for other validations.
+
+Set `TRIGGER_E2E_CONCURRENCY` on the orchestrator definition to an integer from
+`1` through `8` to tune it. Results remain in declaration order, and each
+scenario still owns its unique branch, PR, victim build, assertion, and
+unconditional cleanup.
+
 ## Running locally
 
 You need a write-capable ADO token (PAT) and a registered victim pipeline id:
@@ -125,6 +137,7 @@ export TRIGGER_E2E_VICTIM_REPO="<ADO Git repo backing the victim's self>"
 # export TRIGGER_E2E_GITHUB_TOKEN="<fine-grained PAT: Issues rw on jamesadevine/ado-aw-issues>"
 # export TRIGGER_E2E_ISSUE_REPO="jamesadevine/ado-aw-issues"
 # export TRIGGER_E2E_SYNC_MIRROR="true" # requires a full main checkout
+# export TRIGGER_E2E_CONCURRENCY=4       # 1..8, default 4
 # export TRIGGER_E2E_BUILD_TIMEOUT_MS=900000   # per victim build (default 900000)
 # export TRIGGER_E2E_BUILD_POLL_MS=10000       # poll interval (default 10000)
 

--- a/tests/trigger-e2e/azure-pipelines.yml
+++ b/tests/trigger-e2e/azure-pipelines.yml
@@ -33,6 +33,7 @@ variables:
   # variables are not shadowed by this block.
   EFFECTIVE_TRIGGER_E2E_VICTIM_DEFINITION_ID: $[ coalesce(variables['TRIGGER_E2E_VICTIM_DEFINITION_ID'], '') ]
   EFFECTIVE_TRIGGER_E2E_VICTIM_REPO: $[ coalesce(variables['TRIGGER_E2E_VICTIM_REPO'], '') ]
+  EFFECTIVE_TRIGGER_E2E_CONCURRENCY: $[ coalesce(variables['TRIGGER_E2E_CONCURRENCY'], '4') ]
   # GitHub repo that failure issues are filed against is intentionally NOT
   # defined here: a YAML `variables:` entry SHADOWS a same-named pipeline
   # (definition) variable. Set TRIGGER_E2E_ISSUE_REPO as a pipeline/definition
@@ -83,6 +84,7 @@ steps:
       SYSTEM_ACCESSTOKEN: $(SC_WRITE_TOKEN)
       TRIGGER_E2E_VICTIM_DEFINITION_ID: $(EFFECTIVE_TRIGGER_E2E_VICTIM_DEFINITION_ID)
       TRIGGER_E2E_VICTIM_REPO: $(EFFECTIVE_TRIGGER_E2E_VICTIM_REPO)
+      TRIGGER_E2E_CONCURRENCY: $(EFFECTIVE_TRIGGER_E2E_CONCURRENCY)
       TRIGGER_E2E_SYNC_MIRROR: "true"
       TRIGGER_E2E_ISSUE_REPO: $(TRIGGER_E2E_ISSUE_REPO)
       # Secret PAT for filing failure issues on the configured repository.

--- a/tests/trigger-e2e/victim-pipeline.yml
+++ b/tests/trigger-e2e/victim-pipeline.yml
@@ -96,8 +96,8 @@ jobs:
           # Classify the synth outcome from the same-job vars synth setVar's.
           # AW_PR_ID is always set (empty on skip); AW_SYNTHETIC_PR is only set
           # to "true" on promotion (else left as the literal macro).
-          SYN="$(AW_SYNTHETIC_PR)"
-          PRID="$(AW_PR_ID)"
+          SYN="${AW_SYNTHETIC_PR}"
+          PRID="${AW_PR_ID}"
           case "$SYN" in '$('*) SYN="" ;; esac
           case "$PRID" in '$('*) PRID="" ;; esac
           if [ "$SYN" = "true" ]; then
@@ -110,6 +110,12 @@ jobs:
           echo "synth state: ${STATE} (AW_PR_ID='${PRID}' AW_SYNTHETIC_PR='${SYN}')"
           echo "##vso[build.addbuildtag]trig.synth.${STATE}"
         displayName: Tag synth outcome
+        env:
+          # Map ADO macros into environment values instead of embedding them
+          # in Bash command substitutions. Undefined macros remain literal
+          # `$(NAME)` strings and are normalized by the case guards above.
+          AW_SYNTHETIC_PR: $(AW_SYNTHETIC_PR)
+          AW_PR_ID: $(AW_PR_ID)
 
       - script: |
           set -euo pipefail


### PR DESCRIPTION
## Summary

Runs deterministic trigger E2E scenarios with bounded concurrency instead of
waiting for each victim pipeline to finish before queueing the next one.

- Defaults to four concurrent scenarios.
- Supports `TRIGGER_E2E_CONCURRENCY=1..8`.
- Preserves declaration-order result and issue reporting.
- Keeps each scenario's unique PR, branch, victim build, and cleanup lifecycle.
- Leaves pool capacity available rather than launching all scenarios at once.

The current sequential validation spends most of its wall time waiting for
individual victim builds to acquire an agent; four workers overlap that queue
latency without changing scenario assertions.

The first live AgentPlayground run also exposed three pre-existing blockers,
fixed here:

- Maps unset synth variables through `env:` instead of accidentally executing
  `$(AW_SYNTHETIC_PR)` as Bash command substitution.
- Fetches PR labels from ADO's dedicated labels endpoint; the PR-by-id endpoint
  does not populate the typed `labels` field.
- Removes the now-stale `PrLabels -> PrMetadata` fact dependency and updates the
  generated catalog, policy tests, and filter-IR docs.

The AgentPlayground victim definition's project-scoped build identity was
separately granted `Stop builds` so the existing self-cancel assertions can
reach a real canceled terminal result.

## Validation

- `npm run typecheck`
- Trigger/shared targeted tests: 76 passed
- `npm run build:trigger-e2e`
- Rust `filter_ir`: 31 passed, 1 ignored
- Rust `ado_script`: 48 passed
- Independent code review found no shared-client, cleanup-race, ordering, or
  configuration defects; follow-up review findings were incorporated.
