### PR TITLE
fix(trigger-e2e): mint victim cancellation token

### DIFF
--- a/tests/trigger-e2e/README.md
+++ b/tests/trigger-e2e/README.md
@@ -173,14 +173,18 @@ In `https://dev.azure.com/msazuresphere/AgentPlayground`:
    orchestrator:
    - `TRIGGER_E2E_VICTIM_DEFINITION_ID=<victim-pipeline-id>`
    - `TRIGGER_E2E_VICTIM_REPO=ado-aw-mirror`
-5. **Grant the VICTIM build identity** Code (read) on the repo, Build (add
-   tags / edit build quality), and permission to cancel builds (gate
-   self-cancel). See [`docs/safe-output-permissions.md`](../../docs/safe-output-permissions.md)
-   if it hits 401/403.
+5. **Grant the VICTIM build identity** Code Read on `ado-aw-mirror` for
+   checkout and synth PR lookups.
 6. **Grant the principal behind `agent-playground-write`** Contribute, Create
    branch, delete refs, and Contribute to PRs on `ado-aw-mirror`, plus Queue
-   builds on the victim definition. This same principal performs mirror sync
-   and creates the transient PR context.
+   builds on the victim definition. Grant it project-level **Stop builds**:
+   current-build cancellation is checked against a build-instance token and
+   does not inherit a definition-scoped Stop permission. Authorize the
+   `agent-playground-write` service connection for both the orchestrator and
+   victim definitions. This same identity performs mirror sync, creates the
+   transient PR context, and supplies the gate's short-lived bearer.
+   See [`docs/safe-output-permissions.md`](../../docs/safe-output-permissions.md)
+   if either identity hits 401/403.
 7. **Set the GitHub PAT secret** on the orchestrator only:
    ```powershell
    ado-aw secrets set TRIGGER_E2E_GITHUB_TOKEN `

--- a/tests/trigger-e2e/victim-pipeline.yml
+++ b/tests/trigger-e2e/victim-pipeline.yml
@@ -17,9 +17,10 @@
 #     Register it against the ado-aw Azure Repos mirror so the `self` checkout
 #     also carries `scripts/ado-script/` to build the bundles from source.
 #   - The build identity ($(System.AccessToken)) needs: Code (read) on the repo
-#     (PR/label/iteration lookups), Build (edit build quality / add tags) and
-#     the ability to cancel builds (gate self-cancel). See
-#     docs/safe-output-permissions.md if it hits 401/403.
+#     for checkout and synth PR lookups. Gate evaluation uses a short-lived ADO
+#     token minted from `agent-playground-write`; that dedicated identity needs
+#     repo Read plus project-level Stop builds for gate self-cancel. See
+#     docs/safe-output-permissions.md if either path hits 401/403.
 #
 # ## Observable build tags
 #   - trig.synth.promoted | trig.synth.skipped | trig.synth.real-pr
@@ -82,6 +83,20 @@ jobs:
         workingDirectory: scripts/ado-script
         displayName: Build gate + synth bundles from checkout
 
+      - task: AzureCLI@2
+        displayName: Acquire ADO token for gate self-cancel
+        inputs:
+          azureSubscription: agent-playground-write
+          scriptType: bash
+          scriptLocation: inlineScript
+          inlineScript: |
+            set -euo pipefail
+            ADO_TOKEN=$(az account get-access-token \
+              --resource 499b84ac-1321-427f-aa17-267ca6975798 \
+              --query accessToken -o tsv)
+            test -n "$ADO_TOKEN"
+            echo "##vso[task.setvariable variable=SC_WRITE_TOKEN;issecret=true]$ADO_TOKEN"
+
       - script: |
           set -euo pipefail
           node scripts/ado-script/exec-context-pr-synth.js
@@ -140,8 +155,9 @@ jobs:
           ADO_SOURCE_BRANCH: ${{ parameters.sourceBranchFact }}
           ADO_TARGET_BRANCH: ${{ parameters.targetBranchFact }}
           ADO_COMMIT_MESSAGE: ${{ parameters.commitMessage }}
-          # REST auth for API facts (labels, changed files) + self-cancel.
-          SYSTEM_ACCESSTOKEN: $(System.AccessToken)
+          # Dedicated short-lived write identity for API facts + self-cancel.
+          # The token is mapped only into this gate step.
+          SYSTEM_ACCESSTOKEN: $(SC_WRITE_TOKEN)
 
       - script: |
           set -euo pipefail


### PR DESCRIPTION
## Summary

Uses the dedicated `agent-playground-write` workload identity for trigger
victim gate evaluation and self-cancellation.

- Mints a short-lived ADO token inside the victim through `AzureCLI@2`.
- Maps that token only into the gate step as `SYSTEM_ACCESSTOKEN`.
- Retains `$(System.AccessToken)` for synth PR reads, preserving coverage of
  the normal build-token path.
- Fails closed if token acquisition returns an error or an empty token.
- Avoids exposing the WIF assertion to the script through
  `addSpnToEnvironment`.

## Why

ADO checks cancellation of a current build against a build-instance security
token. A definition-scoped `Stop builds` grant to the shared Build Service does
not inherit to those instances. Granting project-wide Stop to the dedicated
write identity is preferable to widening the shared Build Service.

## Validation

- Parsed `tests/trigger-e2e/victim-pipeline.yml`.
- Asserted the mint step is fail-closed and the gate maps
  `$(SC_WRITE_TOKEN)`.
- Independent review findings about shell failure handling and unnecessary WIF
  environment exposure were incorporated.
