### PR TITLE
fix(trigger-e2e): preserve mirror push diagnostics

### DIFF
--- a/scripts/ado-script/src/trigger-e2e/__tests__/mirror.test.ts
+++ b/scripts/ado-script/src/trigger-e2e/__tests__/mirror.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it, vi } from "vitest";
 
 import {
   loadMirrorSyncConfig,
+  mirrorGitEnv,
   mirrorRepoUrl,
   runMirrorSyncPreflight,
   type MirrorGitRequest,
@@ -41,6 +42,25 @@ function successRunner(calls: MirrorGitRequest[]): MirrorGitRunner {
 }
 
 describe("trigger mirror sync", () => {
+  it("removes ambient git tracing while preserving bearer auth", () => {
+    expect(
+      mirrorGitEnv(
+        { GIT_CONFIG_COUNT: "1", GIT_CONFIG_VALUE_0: "Authorization: bearer secret" },
+        {
+          PATH: "/bin",
+          GIT_TRACE: "1",
+          GIT_TRACE_CURL: "true",
+          GIT_CURL_VERBOSE: "1",
+        },
+      ),
+    ).toEqual({
+      PATH: "/bin",
+      GIT_CONFIG_COUNT: "1",
+      GIT_CONFIG_VALUE_0: "Authorization: bearer secret",
+      GIT_TERMINAL_PROMPT: "0",
+    });
+  });
+
   it("is disabled unless explicitly opted in", async () => {
     const runner = vi.fn<MirrorGitRunner>();
     const result = await runMirrorSyncPreflight({}, () => {}, runner);
@@ -121,6 +141,27 @@ describe("trigger mirror sync", () => {
     expect(result?.ok).toBe(false);
     expect(result?.message).toContain("non-fast-forward");
     expect(calls.some((call) => call.args[0] === "ls-remote")).toBe(false);
+  });
+
+  it("reports the actionable error tail and redacts the bearer", async () => {
+    const runner: MirrorGitRunner = async (request) => {
+      if (request.args[0] === "rev-parse" && request.args[1] === "--is-shallow-repository") {
+        return { status: 0, stdout: "false\n", stderr: "" };
+      }
+      if (request.args[0] === "rev-parse") {
+        return { status: 0, stdout: `${HEAD}\n`, stderr: "" };
+      }
+      return {
+        status: 1,
+        stdout: "",
+        stderr: `${"trace noise\n".repeat(300)}Authorization: bearer secret-token\nfatal: non-fast-forward`,
+      };
+    };
+
+    const result = await runMirrorSyncPreflight(baseEnv(), () => {}, runner);
+    expect(result?.ok).toBe(false);
+    expect(result?.message).toContain("fatal: non-fast-forward");
+    expect(result?.message).not.toContain("secret-token");
   });
 
   it("fails when the verified remote SHA differs", async () => {

--- a/scripts/ado-script/src/trigger-e2e/mirror.ts
+++ b/scripts/ado-script/src/trigger-e2e/mirror.ts
@@ -33,6 +33,24 @@ export interface MirrorGitResult {
 
 export type MirrorGitRunner = (request: MirrorGitRequest) => Promise<MirrorGitResult>;
 
+export function mirrorGitEnv(
+  requestEnv: Record<string, string>,
+  baseEnv: NodeJS.ProcessEnv = process.env,
+): NodeJS.ProcessEnv {
+  const env: NodeJS.ProcessEnv = {
+    ...baseEnv,
+    ...requestEnv,
+    GIT_TERMINAL_PROMPT: "0",
+  };
+  // Git treats any non-empty trace value — including "0" — as enabled.
+  // Remove ambient tracing completely so bearer-bearing HTTP headers cannot
+  // enter captured stderr or displace the actionable error tail.
+  delete env.GIT_TRACE;
+  delete env.GIT_TRACE_CURL;
+  delete env.GIT_CURL_VERBOSE;
+  return env;
+}
+
 function cleanVar(raw: string | undefined): string | undefined {
   const value = raw?.trim();
   if (!value || /^\$\(.*\)$/.test(value)) return undefined;
@@ -84,14 +102,7 @@ function runGit(request: MirrorGitRequest): Promise<MirrorGitResult> {
   return new Promise((resolve, reject) => {
     const child = spawn("git", request.args, {
       cwd: request.cwd,
-      env: {
-        ...process.env,
-        ...request.env,
-        GIT_TERMINAL_PROMPT: "0",
-        GIT_TRACE: "0",
-        GIT_TRACE_CURL: "0",
-        GIT_CURL_VERBOSE: "0",
-      },
+      env: mirrorGitEnv(request.env),
     });
     let stdout = "";
     let stderr = "";
@@ -142,7 +153,7 @@ function diagnostic(result: MirrorGitResult, secret: string): string {
   if (!text) return "(no output)";
   return text.length <= MAX_DIAGNOSTIC_CHARS
     ? text
-    : `${text.slice(0, MAX_DIAGNOSTIC_CHARS)}…`;
+    : `…${text.slice(-MAX_DIAGNOSTIC_CHARS)}`;
 }
 
 async function git(


### PR DESCRIPTION
## Summary

Makes trigger mirror-sync failures quiet and actionable.

- Removes inherited `GIT_TRACE`, `GIT_TRACE_CURL`, and `GIT_CURL_VERBOSE`
  variables from the git child environment.
- Preserves the environment-only bearer auth configuration.
- Keeps the redacted error **tail** when diagnostics exceed the cap, where git
  writes the final `fatal:` reason.

Git treats any non-empty trace value, including `"0"`, as enabled. The prior
implementation therefore emitted enough HTTP trace noise to hide the actual
mirror push error in the bounded failure report.

## Validation

- `npm run typecheck`
- Mirror tests: 10 passed
- `npm run build:trigger-e2e`
- Independent review found no bearer, environment, truncation, or spawn
  handling defects.
