### PR TITLE
chore: add repository inventory metadata

### DIFF
--- a/es-metadata.yml
+++ b/es-metadata.yml
@@ -1,0 +1,8 @@
+schemaVersion: 0.0.1
+isProduction: false
+accountableOwners:
+  service: ba908dea-38f6-4994-86e9-9e34eae8d29d
+routing:
+  defaultAreaPath:
+    org: msazuresphere
+    path: 4x4\Gen1\Incoming


### PR DESCRIPTION
## Summary

Adds the root `es-metadata.yml` required by AgentPlayground inventory
automation.

- Marks the repository as non-production.
- Assigns accountable service
  `ba908dea-38f6-4994-86e9-9e34eae8d29d`.
- Routes inventory work to `msazuresphere` area
  `4x4\Gen1\Incoming`.

Without this file, AgentPlayground inventory automation disables test
repositories, including the ado-aw mirror used by deterministic trigger E2E.

The same metadata is being applied to the other AgentPlayground repositories.
