### PR TITLE
docs(tests): record AgentPlayground pipeline inventory

### DIFF
--- a/tests/executor-e2e/README.md
+++ b/tests/executor-e2e/README.md
@@ -116,8 +116,11 @@ no current build. The harness exits non-zero if any scenario fails.
 
 In `https://dev.azure.com/msazuresphere/AgentPlayground`:
 
+> Current registration: definition `2550` in `\executor-e2e`, with
+> `E2E_QUEUE_PIPELINE_ID=2547`.
+
 1. **Register the pipeline.** New pipeline → GitHub through the
-   `github.com_githubnext` service connection → existing YAML →
+   `githubnext` service connection → existing YAML →
    `tests/executor-e2e/azure-pipelines.yml`. Place it in a `\executor-e2e`
    folder and skip the first run until variables are configured.
 2. **Grant the principal behind `agent-playground-write` write access** on the

--- a/tests/safe-outputs/REGISTERED.md
+++ b/tests/safe-outputs/REGISTERED.md
@@ -3,20 +3,37 @@
 Contributor-maintained mapping from smoke fixture → registered ADO
 pipeline ID in
 [AgentPlayground](https://dev.azure.com/msazuresphere/AgentPlayground).
-After the manual-handoff registration step is complete, fill in the
-`Pipeline ID` column and open a docs-only PR with the updates.
-
-> ⚠️ `TBD` rows mean the fixture has been authored and committed but
-> the corresponding ADO pipeline has not been registered yet. While any
-> row is `TBD`, that pipeline is **not** exercised in production.
+The table records the active definitions after the July 2026 replacement-first
+cutover.
 
 | Fixture | Schedule | Pipeline ID | Notes |
 | --- | --- | --- | --- |
-| `canary.md` | `daily around 03:00` | `TBD` | Omnibus: noop + create-work-item + add-build-tag in one agentic run. Proves Stage 1 → 2 → 3 end-to-end. |
-| `azure-cli.md` | `daily around 03:00` | `TBD` | Verifies AWF az CLI mount + ADO auth via `AZURE_DEVOPS_EXT_PAT`. |
-| `noop-target.md` | _no schedule_ | `TBD` | Target of the `queue-build` executor-e2e scenario. Its Pipeline ID must be set as `E2E_QUEUE_PIPELINE_ID` on the executor-e2e pipeline. |
-| `janitor.md` | `weekly on monday around 02:00` | `TBD` | Prunes `ado-aw-smoke-*` artifacts older than 30 days. |
-| `smoke-failure-reporter.md` | `daily around 04:30` | `TBD` | Files `[smoke-failure] …` issues on `jamesadevine/ado-aw-issues`. Requires the `ADO_AW_DEBUG_GITHUB_TOKEN` secret pipeline variable, **only on this pipeline**. |
+| `canary.md` | `daily around 03:00` | `2545` | Omnibus: noop + create-work-item + add-build-tag in one agentic run. Proves Stage 1 → 2 → 3 end-to-end. |
+| `azure-cli.md` | `daily around 03:00` | `2546` | Verifies AWF az CLI mount + ADO auth via `AZURE_DEVOPS_EXT_PAT`. |
+| `noop-target.md` | _no schedule_ | `2547` | Target of the `queue-build` executor-e2e scenario. `E2E_QUEUE_PIPELINE_ID=2547` on executor definition `2550`. |
+| `janitor.md` | `weekly on monday around 02:00` | `2548` | Prunes `ado-aw-smoke-*` artifacts older than 30 days. |
+| `smoke-failure-reporter.md` | `daily around 04:30` | `2549` | Files `[smoke-failure] …` issues on `jamesadevine/ado-aw-issues`. Requires the `ADO_AW_DEBUG_GITHUB_TOKEN` secret pipeline variable, **only on this pipeline**. |
+
+## Deterministic E2E definitions
+
+| Pipeline | Folder | Pipeline ID | Notes |
+| --- | --- | ---: | --- |
+| ado-script e2e | `\ado-script-e2e` | `2544` | Azure-native checkout regression suite. |
+| executor e2e | `\executor-e2e` | `2550` | Deterministic Stage 3 coverage for every non-debug safe output. |
+| trigger e2e | `\trigger-e2e` | `2551` | Concurrent gate/synthetic-PR orchestrator. |
+| trigger e2e victim | `\trigger-e2e` | `2552` | Azure Repos-backed victim using `ado-aw-mirror`. |
+
+All GitHub-backed definitions use the `githubnext` service connection. The
+mirror and every AgentPlayground test repository carry root
+`es-metadata.yml` inventory metadata so repository inventory automation keeps
+them enabled.
+
+## Retired definitions
+
+The cutover deleted legacy definitions `2506`, `2513` through `2538`, and
+`2541`. Per-tool agentic coverage is now split between canary `2545` (full
+Agent → Detection → SafeOutputs handoff) and executor E2E `2550`
+(deterministic per-tool execution and effect assertions).
 
 ## Manual-handoff checklist
 
@@ -32,7 +49,7 @@ the following one-time setup in
    ```powershell
    cargo run -- enable `
      --org msazuresphere --project AgentPlayground `
-     --service-connection github.com_githubnext `
+     --service-connection githubnext `
      --also-set-token `
      --folder '\smoke' `
      tests/safe-outputs/

--- a/tests/trigger-e2e/README.md
+++ b/tests/trigger-e2e/README.md
@@ -152,6 +152,10 @@ fails.
 
 In `https://dev.azure.com/msazuresphere/AgentPlayground`:
 
+> Current registration: orchestrator definition `2551`, victim definition
+> `2552`, and Azure Repo `ado-aw-mirror`. The orchestrator uses concurrency
+> `4` and a 30-minute queue-inclusive victim wait budget.
+
 1. **Create and seed `ado-aw-mirror`.** Import or push the merged
    `githubnext/ado-aw` `main` commit into a dedicated Azure Repo. Do not reuse
    `agent-definitions`.
@@ -166,7 +170,7 @@ In `https://dev.azure.com/msazuresphere/AgentPlayground`:
      project uses a different agent pool, edit both files to point at a
      Linux pool with Node.js 20 available before registering.
 3. **Register the ORCHESTRATOR pipeline.** New pipeline → GitHub through
-   `github.com_githubnext` → existing YAML →
+   `githubnext` → existing YAML →
    `tests/trigger-e2e/azure-pipelines.yml`. Place both definitions in a
    `\trigger-e2e` folder and skip the first run until variables are configured.
 4. **Wire the victim id + repo** as non-secret definition variables on the


### PR DESCRIPTION
## Summary

Records the completed AgentPlayground CI cutover.

- Replaces every smoke-suite `TBD` with definitions `2545-2549`.
- Records executor `2550`, trigger orchestrator `2551`, victim `2552`, and
  retained ado-script E2E `2544`.
- Records `E2E_QUEUE_PIPELINE_ID=2547`, trigger concurrency `4`, and the
  30-minute victim wait budget.
- Corrects the proven GitHub service connection name to `githubnext`.
- Records deletion of legacy definitions `2506`, `2513-2538`, and `2541`.
- Documents the split coverage model: canary for the full agentic handoff and
  executor E2E for deterministic per-tool safe-output execution.

All final definitions are enabled, all four AgentPlayground repositories carry
the approved inventory metadata, and the mirror matches GitHub `main`.
