### PR TITLE
fix(smoke): audit SELF under the rule matching how the orchestrator is triggered

### DIFF
--- a/scripts/ado-script/src/compiler-smoke-e2e/__tests__/pipeline-policy.test.ts
+++ b/scripts/ado-script/src/compiler-smoke-e2e/__tests__/pipeline-policy.test.ts
@@ -149,7 +149,6 @@ describe("candidate orchestrator trigger policy", () => {
     expect(audit?.script).toContain("jq_error_begin");
     expect(audit?.script).toContain('head -c 16384 "$body"');
     expect(audit?.script).toContain("response_sample_begin");
-
     const publish = steps.find(
       (step) => step.displayName === "Publish smoke diagnostics",
     );
@@ -162,6 +161,30 @@ describe("candidate orchestrator trigger policy", () => {
       },
       task: "PublishPipelineArtifact@1",
     });
+  });
+
+  it("audits SELF under the rule matching how the orchestrator is triggered", () => {
+    // Regression: SELF_ID was unconditionally appended to the PR-definition
+    // list, so the released orchestrator - scheduled-only by design - was
+    // required to carry a pullRequest trigger it must never have, and failed
+    // its own audit. Caught by the first live released run (build 629514).
+    const audit = steps.find(
+      (step) => step.displayName === "Audit AgentPlayground trigger policy",
+    );
+    expect(audit?.script).toContain(
+      "SELF_IS_PR_DEFINITION=${{ eq(parameters.compilerSource, 'candidate') }}",
+    );
+    // SELF must land in exactly one list, never unconditionally in PR_IDS.
+    expect(audit?.script).not.toMatch(/\.pr_definition_ids\[\]\s*'\s*"\$POLICY"\s*\)\s*\$SELF_ID"/);
+    expect(audit?.script).toContain('PR_IDS="$PR_IDS $SELF_ID"');
+    expect(audit?.script).toContain(
+      'SCHEDULED_ONLY_IDS="$SCHEDULED_ONLY_IDS $SELF_ID"',
+    );
+    // The comment-gate assertion is PR-only; in released mode there is no PR
+    // trigger to carry a comment gate.
+    expect(audit?.script).toMatch(
+      /if \[ "\$SELF_IS_PR_DEFINITION" = "True" \]; then[\s\S]*was not included in the PR policy audit/,
+    );
   });
 });
 

--- a/tests/smoke/orchestrator-steps.yml
+++ b/tests/smoke/orchestrator-steps.yml
@@ -356,18 +356,39 @@ steps:
         return 1
       }
 
+      # Which list SELF belongs in depends on how this orchestrator is
+      # triggered, and the two are mutually exclusive:
+      #
+      #   candidate - PR-triggered, so it MUST carry the fork hardening and
+      #               the collaborator comment gate (it runs PR-authored code
+      #               against credentialed resources).
+      #   released  - scheduled-only by design, so it must carry NO CI and NO
+      #               PR trigger at all.
+      #
+      # Auditing self as a PR definition in released mode would demand a
+      # pullRequest trigger that must not exist. Keyed off the compile mode
+      # rather than off the definition's own triggers, so a definition that
+      # LOST its PR trigger still fails closed instead of quietly reclassifying
+      # itself into the weaker rule.
+      SELF_IS_PR_DEFINITION=${{ eq(parameters.compilerSource, 'candidate') }}
+
       PR_IDS="$(
         jq -er '
           select(.schema == "ado-aw/agentplayground-trigger-policy/1")
           | .pr_definition_ids[]
         ' "$POLICY"
-      ) $SELF_ID"
+      )"
       SCHEDULED_ONLY_IDS="$(
         jq -er '
           select(.schema == "ado-aw/agentplayground-trigger-policy/1")
           | .scheduled_only_definition_ids[]
         ' "$POLICY"
       )"
+      if [ "$SELF_IS_PR_DEFINITION" = "True" ]; then
+        PR_IDS="$PR_IDS $SELF_ID"
+      else
+        SCHEDULED_ONLY_IDS="$SCHEDULED_ONLY_IDS $SELF_ID"
+      fi
 
       SELF_JSON=""
       for id in $PR_IDS; do
@@ -395,23 +416,25 @@ steps:
         fi
       done
 
-      if [ -z "$SELF_JSON" ]; then
-        echo "Candidate definition $SELF_ID was not included in the PR policy audit." >&2
-        exit 1
-      fi
-      if ! printf '%s' "$SELF_JSON" | jq -e '
-        any(
-          .triggers[]?;
-          .triggerType == "pullRequest"
-          and .isCommentRequiredForPullRequest == true
-          and .requireCommentsForNonTeamMembersOnly == false
-          and .requireCommentsForNonTeamMemberAndNonContributors == false
-          and .isCommentRequiredForInternalRepoPRs == true
-          and .commentOptionInternalRepos == "all"
-        )' >/dev/null; then
-        echo "Candidate compiler PR comment-gate policy drift detected for definition $SELF_ID." >&2
-        printf '%s' "$SELF_JSON" | jq '{id, name, revision, triggers}' >&2
-        exit 1
+      if [ "$SELF_IS_PR_DEFINITION" = "True" ]; then
+        if [ -z "$SELF_JSON" ]; then
+          echo "Candidate definition $SELF_ID was not included in the PR policy audit." >&2
+          exit 1
+        fi
+        if ! printf '%s' "$SELF_JSON" | jq -e '
+          any(
+            .triggers[]?;
+            .triggerType == "pullRequest"
+            and .isCommentRequiredForPullRequest == true
+            and .requireCommentsForNonTeamMembersOnly == false
+            and .requireCommentsForNonTeamMemberAndNonContributors == false
+            and .isCommentRequiredForInternalRepoPRs == true
+            and .commentOptionInternalRepos == "all"
+          )' >/dev/null; then
+          echo "Candidate compiler PR comment-gate policy drift detected for definition $SELF_ID." >&2
+          printf '%s' "$SELF_JSON" | jq '{id, name, revision, triggers}' >&2
+          exit 1
+        fi
       fi
 
       for id in $SCHEDULED_ONLY_IDS; do


### PR DESCRIPTION
The trigger-policy audit unconditionally appended \SELF_ID\ to the PR-definition list, which requires fork hardening **and** a \pullRequest\ trigger with a collaborator comment gate.

That held while the candidate orchestrator was the only one. The released orchestrator (2568) is **scheduled-only by design**, so it failed its own audit before running a single case:

\\\
PR trigger policy drift detected for definition 2568 (ado-aw released smoke).
\\\

Found by the first live released run (build 629514), which reached the audit and stopped there — the guard working correctly, on the wrong rule.

## Fix

\SELF\ now joins whichever list matches its trigger model: \PR_IDS\ in candidate mode, \SCHEDULED_ONLY_IDS\ in released mode. The comment-gate assertion is likewise PR-only.

**Keyed off the compile mode, not the definition's own triggers.** Reading the triggers would be fail-*open*: a candidate definition that lost its PR trigger would silently reclassify into the weaker scheduled-only rule and pass. Keying off the mode keeps both directions fail-closed.

## Validation

- \
px vitest run src/compiler-smoke-e2e\ green, incl. a new regression test
- Mutation-checked: pinning \SELF_IS_PR_DEFINITION=True\ fails the new test
- \cargo test --test bash_lint_tests\ green (shellcheck over the modified body)