### PR TITLE
fix(mcpg): plumb custom MCP pipeline variables

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -87,6 +87,7 @@ fail-closed and only pauses when the agent actually proposed a reviewed output.
 │   │   ├── pr_filters.rs # PR trigger filter generation (native ADO + gate steps)
 │   │   ├── path_layout_check.rs # Warning-only checkout-aware path validation: $(Build.SourcesDirectory)/<seg> refs in steps, runtime-import targets, deprecated directory markers in the body
 │   │   ├── custom_tools.rs # Typed custom safe-output job model, closed MCP schemas, resolved execution config, and shared argument validation
+│   │   ├── mcpg.rs        # Typed MCPG compilation result + deterministic launch env shared by BashStep env and Docker passthrough
 │   │   ├── imports/      # Reusable component imports: ADO-first source/ref resolution, bounded nested graph + SHA-keyed cache, import-schema substitution, and field-specific merge semantics
 │   │   │   ├── mod.rs    # Resolution entry point: source/ref parsing, nested import graph, SHA-keyed `.ado-aw/imports/` cache
 │   │   │   ├── schema.rs # import-schema input substitution
@@ -120,6 +121,7 @@ fail-closed and only pauses when the agent actually proposed a reviewed output.
 │   │   │   ├── 0005_drop_build_attachment_allowed_build_ids.rs # Remove inert safe-outputs.upload-build-attachment.allowed-build-ids key (build attachments are current-run only)
 │   │   │   ├── 0006_explicit_push_trigger.rs # Pin the legacy implicit all-branches push trigger for sources whose committed lock predates 0.49.0
 │   │   │   ├── 0007_promote_debug_create_github_issue.rs # Move legacy ado-aw-debug.create-issue into public safe-outputs.create-github-issue with auth bridge
+│   │   │   ├── 0008_explicit_mcp_pipeline_env.rs # Rewrite empty MCP env passthrough to explicit pipeline-variable objects
 │   │   │   └── helpers.rs # take_key, insert_no_overwrite, rename_key, ConflictPolicy
 │   │   ├── codemod_integration_test.rs # White-box rewrite-path tests (stub registry injection)
 │   │   ├── types.rs      # Front matter grammar and types

--- a/docs/codemods.md
+++ b/docs/codemods.md
@@ -137,7 +137,8 @@ src/compile/codemods/
 ├── 0004_legacy_path_markers.rs # {{ workspace }} / {{ working_directory }} / {{ trigger_repo_directory }} → explicit ADO path exprs
 ├── 0005_drop_build_attachment_allowed_build_ids.rs # remove no-op upload-build-attachment.allowed-build-ids
 ├── 0006_explicit_push_trigger.rs # pin legacy implicit all-branches push trigger for pre-0.49.0 sources
-└── 0007_promote_debug_create_github_issue.rs # move debug GitHub issue filing to regular safe-outputs
+├── 0007_promote_debug_create_github_issue.rs # move debug GitHub issue filing to regular safe-outputs
+└── 0008_explicit_mcp_pipeline_env.rs # replace empty MCP env passthrough with pipeline-variable objects
 ```
 
 (New codemods are appended as `<NNNN>_<id>.rs` files.)
@@ -491,6 +492,28 @@ legacy `ado-aw-debug.create-issue` and the new
 `safe-outputs.create-github-issue` keys exist, the codemod fails with a
 manual-migration error rather than overwriting either value.
 
+## Explicit MCP pipeline variables (`0008_explicit_mcp_pipeline_env`)
+
+Custom container MCP env values previously used an empty string as an implicit
+same-name pipeline-variable passthrough:
+
+```yaml
+env:
+  MCP_TOKEN: ""
+```
+
+The codemod rewrites that unambiguous legacy shape to:
+
+```yaml
+env:
+  MCP_TOKEN:
+    pipeline-variable: MCP_TOKEN
+```
+
+Non-empty literals and already-explicit mappings are unchanged. The new object
+form also supports remapping a container variable from a differently named ADO
+pipeline or variable-group variable.
+
 ## Tests
 
 The codemod framework is covered by three layers of tests:
@@ -504,9 +527,8 @@ The codemod framework is covered by three layers of tests:
   rewrite → lock-file write) using a stub codemod registry
   injected via the crate-private `compile_pipeline_with_registry`
   and `parse_markdown_detailed_with_registry` hooks. They live
-  inside `src/` because the production registry is empty and
-  integration tests in `tests/` cannot link against crate
-  internals.
+  inside `src/` because integration tests in `tests/` cannot link
+  against crate internals or inject a custom registry.
 - **Black-box CLI tests** in `tests/codemod_tests.rs` spawn the
   compiled `ado-aw` binary as a subprocess and assert on the
   user-visible behavior of `compile` and `check`.

--- a/docs/extending.md
+++ b/docs/extending.md
@@ -106,6 +106,15 @@ pub struct Declarations {
 
 Return `Declarations::default()` and fill only the fields your feature owns. The three fields marked "reserved for future use" (`agent_finalize_steps`, `detection_prepare_steps`, `safe_outputs_steps`) exist in the struct but are not currently read by any compile target — steps placed in them will be silently dropped. Do not add target-specific special cases when the same information can be declared here.
 
+`pipeline_env` entries must be constructed with
+`PipelineEnvMapping::new(container_name, pipeline_variable)`. The destination
+name is validated as a process environment variable and the source as an ADO
+pipeline-variable name. These mappings join user `mcp-servers.*.env`
+`pipeline-variable` entries in one `McpgLaunchEnvironment`; identical mappings
+deduplicate and conflicting sources for the same destination fail compilation.
+The resulting values are attached to the MCPG `BashStep` through typed
+`EnvValue::PipelineVar` entries rather than generated YAML strings.
+
 ## Building typed steps
 
 Compiler-owned steps should be `Step` variants from `src/compile/ir/step.rs`.

--- a/docs/front-matter.md
+++ b/docs/front-matter.md
@@ -92,7 +92,9 @@ mcp-servers:
     args: ["--pull=always"]     # Docker runtime args inserted before the image
     mounts: ["$(Build.SourcesDirectory):/workspace:ro"]
     env:
-      CUSTOM_TOKEN: ""          # empty string = pass through from pipeline env
+      CUSTOM_TOKEN:
+        pipeline-variable: CUSTOM_TOKEN  # ADO pipeline/variable-group/same-job source
+      STATIC_CONFIG: "value"    # literal value embedded in MCPG config
     allowed:
       - custom_function_1
       - custom_function_2

--- a/docs/ir.md
+++ b/docs/ir.md
@@ -24,6 +24,11 @@ Those wrappers are the only place per-target shape (top-level `PipelineShape`, t
 - `job.rs` — `Job`, `Pool`, job variables, 1ES `templateContext` support, and target-job external `dependsOn` / `condition` wrapping.
 - `stage.rs` — `Stage` plus target-stage external `dependsOn` / `condition` wrapping.
 - `env.rs` — typed environment values (`EnvValue`) including ADO macros, pipeline variables, secrets, `OutputRef`s, `Coalesce`, macro-form `Concat`, and `RuntimeExpression` (a `$[ ... ]` ADO runtime expression that the lowering pass auto-hoists to a job-level `variables:` entry — ADO does not evaluate `$[ ... ]` inside step `env:`). `RuntimeExpression` is only valid at the top level of a step `env:` value: nesting it inside `Concat` or `Coalesce` is rejected at lower time (the hoist pass walks only the top level, so a nested occurrence would emit a dangling `$(AwRtExpr_…)` macro). A `Literal` or `RawYamlScalar(String)` smuggling a raw `$[ ... ]` into a step `env:` value (whether at the top level or nested inside a `Concat`) is likewise rejected at lower time — ADO passes such scalars verbatim, so the typed `RuntimeExpression` variant must be used instead.
+- `../mcpg.rs` — the typed MCPG host-launch environment. It maps validated
+  destination env names to `EnvValue`s once, then the canonical MCPG
+  `BashStep` uses the same map for ADO step env and Docker passthrough names.
+  User `pipeline-variable` sources lower through `EnvValue::PipelineVar`; they
+  are never converted to compiler-generated YAML env strings.
 - `condition.rs` — the `Condition` / `Expr` AST and code generation to ADO condition syntax.
 - `output.rs` — `OutputDecl`, `OutputRef`, and the output-reference lowering rules.
 - `graph.rs` — graph construction, `dependsOn` derivation, output validation, `isOutput=true` promotion, and cycle detection.

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -17,7 +17,8 @@ mcp-servers:
     entrypoint: "npx"
     entrypoint-args: ["-y", "@azure-devops/mcp", "myorg", "-d", "core", "work-items"]
     env:
-      AZURE_DEVOPS_EXT_PAT: ""
+      AZURE_DEVOPS_EXT_PAT:
+        pipeline-variable: AZURE_DEVOPS_EXT_PAT
     allowed:
       - core_list_projects
       - wit_get_work_item
@@ -48,7 +49,9 @@ mcp-servers:
 - `entrypoint-args:` - Arguments passed to the container entrypoint
 - `args:` - Additional Docker runtime arguments (inserted before the image in `docker run`). **Security note**: dangerous flags like `--privileged`, `--network host` will trigger compile-time warnings.
 - `mounts:` - Volume mounts in `"source:dest:mode"` format (e.g., `["/host/data:/app/data:ro"]`)
-- `env:` - Environment variables for the MCP server process. Use `""` (empty string) for passthrough from the pipeline environment.
+- `env:` - Environment variables for the MCP server process. Use a string for
+  a static value or `{ pipeline-variable: NAME }` to read an ADO pipeline,
+  variable-group, queue-time, or earlier-same-job variable at runtime.
 
 **HTTP servers:**
 - `url:` - HTTP endpoint URL for the remote MCP server
@@ -62,13 +65,23 @@ HTTP MCPs ignore `env:`; use `headers:` for HTTP authentication instead.
 
 ## Environment Variable Passthrough
 
-MCP containers may need secrets from the pipeline (e.g., ADO tokens). The `env:` field supports passthrough:
+MCP containers may need secrets from the pipeline (e.g., ADO tokens). The
+`env:` field uses an explicit pipeline-variable source:
 
 ```yaml
 env:
-  AZURE_DEVOPS_EXT_PAT: ""        # Passthrough from pipeline environment
+  MCP_AUTH_TOKEN:                 # Name visible inside the MCP container
+    pipeline-variable: ADO_TOKEN  # ADO variable/variable-group source
   STATIC_CONFIG: "some-value"     # Literal value embedded in config
 ```
+
+The compiler emits `MCP_AUTH_TOKEN: $(ADO_TOKEN)` on the MCPG pipeline step,
+then Docker forwards the resulting process value with `-e MCP_AUTH_TOKEN`.
+Secret values remain runtime-only and are never written into compiled YAML.
+The source variable must exist before the MCPG step runs: pipeline,
+variable-group, and queue-time variables exist from job start; a
+`task.setvariable` source must be published by an earlier step in the same job.
+Cross-job/stage output expressions are not accepted by `pipeline-variable`.
 
 The first-party `tools.azure-devops` integration is deliberately different:
 it gives the MCP a non-secret sentinel in `ADO_MCP_AUTH_TOKEN`. The real
@@ -85,7 +98,8 @@ mcp-servers:
     entrypoint: "npx"
     entrypoint-args: ["-y", "@azure-devops/mcp", "myorg"]
     env:
-      AZURE_DEVOPS_EXT_PAT: ""
+      AZURE_DEVOPS_EXT_PAT:
+        pipeline-variable: AZURE_DEVOPS_EXT_PAT
     allowed:
       - core_list_projects
       - wit_get_work_item

--- a/src/compile/agentic_pipeline.rs
+++ b/src/compile/agentic_pipeline.rs
@@ -461,11 +461,10 @@ pub(crate) fn build_pipeline_context(
     };
     let resolved_execution_config_json =
         super::custom_tools::resolved_execution_config_json(front_matter, &custom_tool_schemas)?;
-    let mcpg_config_obj = common::generate_mcpg_config(front_matter, &extension_declarations)?;
-    let mcpg_config_json = serde_json::to_string_pretty(&mcpg_config_obj)
+    let mcpg_compilation =
+        common::compile_mcpg(front_matter, &extension_declarations, debug_pipeline)?;
+    let mcpg_config_json = serde_json::to_string_pretty(&mcpg_compilation.config)
         .map_err(|e| anyhow::anyhow!("Failed to serialize MCPG config: {e}"))?;
-    let mcpg_docker_env = common::generate_mcpg_docker_env(front_matter, &extension_declarations);
-    let mcpg_step_env = common::generate_mcpg_step_env(&extension_declarations);
 
     // Source / pipeline paths (for integrity check + metadata).
     // `source_path` embeds `{{ trigger_repo_directory }}` which the
@@ -560,8 +559,7 @@ pub(crate) fn build_pipeline_context(
         mcpg_config_json,
         custom_tools_json,
         resolved_execution_config_json,
-        mcpg_docker_env,
-        mcpg_step_env,
+        mcpg_launch_env: mcpg_compilation.launch_env,
         source_path,
         source_relative_path,
         pipeline_path: pipeline_path.clone(),
@@ -824,10 +822,9 @@ pub(crate) struct StandaloneCtx {
     pub(crate) custom_tools_json: Option<String>,
     /// Fully merged, compiler-owned Stage 3 configuration.
     pub(crate) resolved_execution_config_json: String,
-    /// `-e KEY=...` docker flags for MCPG.
-    pub(crate) mcpg_docker_env: String,
-    /// `env:` block for the MCPG step (`env:\n  KEY: ...`).
-    pub(crate) mcpg_step_env: String,
+    /// Typed environment bindings shared by the MCPG pipeline step and its
+    /// nested Docker invocation.
+    pub(crate) mcpg_launch_env: super::mcpg::McpgLaunchEnvironment,
     pub(crate) source_path: String,
     /// Validated path to the workflow source relative to the trigger repository.
     /// SafeOutputs variants combine this with their job-local checkout layout.
@@ -1266,9 +1263,7 @@ fn build_agent_job(
 
     // 15. MCP Gateway (MCPG), which launches SafeOutputs as a stdio child.
     steps.push(Step::Bash(start_mcpg_step(
-        &cfg.mcpg_docker_env,
-        &cfg.mcpg_step_env,
-        cfg.debug_pipeline,
+        &cfg.mcpg_launch_env,
         front_matter.supply_chain(),
     )?));
 
@@ -4055,9 +4050,8 @@ shell_script! {
     /// can later attach it to its isolated internal network. This is
     /// contractually a *single* Bash task — the API key never leaves the
     /// process — so the block-scalar body has to carry the full multi-line
-    /// `docker run …` invocation. The compiler-owned `docker_env_lines` and
-    /// `debug_flag` fragments splice any extra `-e VAR=…` and `-e DEBUG=…`
-    /// continuation lines directly into the middle of that invocation.
+    /// `docker run …` invocation. Dynamic env names arrive as a validated word
+    /// list; the static body converts them to a quoted Bash argument array.
     ///
     /// Uses:
     /// - the pipeline variables `MCP_GATEWAY_API_KEY` (secret) and
@@ -4066,13 +4060,15 @@ shell_script! {
     ///   emitted YAML prelude
     /// - `Binding::text` for the two static topology names (container +
     ///   image ref) and `Binding::number` for the fixed listen port
+    /// - typed step env for the validated environment-name list, so
+    ///   credential-like names never enter the committed shell prelude
     /// - Compile-time constant `MCP_GATEWAY_DOMAIN` bound as text so the
     ///   docker container receives the same domain constant used elsewhere
     START_MCPG {
         interpreter: Bash,
         bindings: [MCPG_CONTAINER, MCPG_IMAGE, MCPG_PORT, MCPG_DOMAIN],
-        externals: [MCP_GATEWAY_API_KEY, ADO_PROXY_IP],
-        fragments: [debug_flag, docker_env_lines],
+        externals: [MCP_GATEWAY_API_KEY, ADO_PROXY_IP, MCPG_ENV_NAMES],
+        fragments: [],
         body: r###"
 # Substitute runtime values into MCPG config
 MCP_RUNNER_UID=$(id -u)
@@ -4104,6 +4100,14 @@ GATEWAY_OUTPUT="/tmp/gh-aw/mcp-config/gateway-output.json"
 mkdir -p "$(dirname "$GATEWAY_OUTPUT")" /tmp/gh-aw/mcp-logs
 rm -f "$GATEWAY_OUTPUT"
 
+: "${MCPG_ENV_NAMES:=}"
+MCPG_DOCKER_ENV_ARGS=()
+# Names are compiler-validated shell words; splitting creates one Docker flag per name.
+# shellcheck disable=SC2086
+for MCPG_ENV_NAME in $MCPG_ENV_NAMES; do
+  MCPG_DOCKER_ENV_ARGS+=(-e "$MCPG_ENV_NAME")
+done
+
 # Start MCPG on Docker's bridge network. AWF attaches this named,
 # trusted container to its internal network after creating awf-net.
 # The Docker socket mount is required because MCPG spawns stdio-based MCP
@@ -4120,8 +4124,7 @@ echo "$MCPG_CONFIG" | docker run -i --rm \
   -e MCP_GATEWAY_PORT="$MCPG_PORT" \
   -e MCP_GATEWAY_DOMAIN="$MCPG_DOMAIN" \
   -e MCP_GATEWAY_API_KEY="$MCP_GATEWAY_API_KEY" \
-  # ado-aw:fragment debug_flag
-  # ado-aw:fragment docker_env_lines
+  "${MCPG_DOCKER_ENV_ARGS[@]}" \
   "$MCPG_IMAGE" \
   --routed --listen "0.0.0.0:$MCPG_PORT" --config-stdin --log-dir /tmp/gh-aw/mcp-logs \
   > "$GATEWAY_OUTPUT" 2> >(tee /tmp/gh-aw/mcp-logs/stderr.log >&2) &
@@ -4185,9 +4188,7 @@ cat /tmp/awf-tools/mcp-config.json
 }
 
 fn start_mcpg_step(
-    mcpg_docker_env: &str,
-    mcpg_step_env: &str,
-    debug_pipeline: bool,
+    mcpg_launch_env: &super::mcpg::McpgLaunchEnvironment,
     supply_chain: Option<&SupplyChainConfig>,
 ) -> Result<BashStep> {
     let registry_base = supply_chain
@@ -4195,49 +4196,24 @@ fn start_mcpg_step(
         .map(|r| r.name.as_str());
     let mcpg_image_v = image_ref(MCPG_IMAGE, &format!("v{MCPG_VERSION}"), registry_base);
 
-    // Match the legacy layout of two placeholder `\`-continuation lines when
-    // no extensions contribute docker env — bash treats a lone `\` as a
-    // no-op continuation and preserving the shape keeps the docker-run
-    // command's argument boundaries identical to the pre-migration YAML.
-    // `generate_mcpg_docker_env` returns a single `\` byte when no
-    // extensions contribute, so match that sentinel as well as an empty
-    // string.
-    let docker_env_lines: String =
-        if mcpg_docker_env.trim().is_empty() || mcpg_docker_env.trim() == "\\" {
-            // Two empty continuation lines mirror the legacy template's
-            // two-marker layout.
-            "\\\n  \\".to_string()
-        } else {
-            // `generate_mcpg_docker_env` already terminates every line with
-            // ` \` continuation, so re-indent the lines without appending
-            // another ` \` (issue #1034).
-            mcpg_docker_env.lines().collect::<Vec<_>>().join("\n  ")
-        };
-    // `--debug-pipeline` injects an extra `-e DEBUG="*" \` continuation line
-    // into the `docker run …` invocation so MCPG (and the stdio backends it
-    // spawns) emit verbose logs to the gateway stderr stream.
-    let debug_flag = if debug_pipeline {
-        "-e DEBUG=\"*\" \\".to_string()
-    } else {
-        "\\".to_string()
-    };
-
     use super::ir::env::EnvValue;
     let mut step = ShellScript::new(&START_MCPG)
         .bind_text("MCPG_CONTAINER", MCPG_CONTAINER_NAME)
         .bind_text("MCPG_IMAGE", &mcpg_image_v)
         .bind("MCPG_PORT", Binding::number(MCPG_PORT.into()))
         .bind_text("MCPG_DOMAIN", MCPG_DOMAIN)
-        .fragment("debug_flag", debug_flag)
-        .fragment("docker_env_lines", docker_env_lines)
         .into_step("Start MCP Gateway (MCPG)")
         .with_env(
             "MCP_GATEWAY_API_KEY",
             EnvValue::pipeline_var("MCP_GATEWAY_API_KEY"),
         )
-        .with_env("ADO_PROXY_IP", EnvValue::pipeline_var("ADO_PROXY_IP"));
-    for (k, v) in parse_env_block(mcpg_step_env)? {
-        step = step.with_env(k, v);
+        .with_env("ADO_PROXY_IP", EnvValue::pipeline_var("ADO_PROXY_IP"))
+        .with_env(
+            "MCPG_ENV_NAMES",
+            EnvValue::literal(mcpg_launch_env.names().collect::<Vec<_>>().join(" ")),
+        );
+    for (name, value) in mcpg_launch_env.iter() {
+        step = step.with_env(name, value.clone());
     }
     Ok(step)
 }
@@ -6491,6 +6467,7 @@ const _SUBMODULES_OPT_BIND: Option<SubmodulesOpt> = None;
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::compile::mcpg::McpgLaunchEnvironment;
 
     fn test_front_matter(yaml: &str) -> FrontMatter {
         serde_yaml::from_str(yaml).expect("front matter should parse")
@@ -6529,8 +6506,7 @@ mod tests {
             mcpg_config_json: "{}".to_string(),
             custom_tools_json: None,
             resolved_execution_config_json: "{}".to_string(),
-            mcpg_docker_env: String::new(),
-            mcpg_step_env: String::new(),
+            mcpg_launch_env: McpgLaunchEnvironment::default(),
             source_path: "$(Build.SourcesDirectory)/agents/test.md".to_string(),
             source_relative_path: "agents/test.md".to_string(),
             pipeline_path: "$(Build.SourcesDirectory)/agents/test.lock.yml".to_string(),
@@ -7521,7 +7497,7 @@ safe-outputs:
 
     #[test]
     fn start_mcpg_step_marks_copilot_mcp_servers_as_default() {
-        let step = start_mcpg_step("", "", false, None).unwrap();
+        let step = start_mcpg_step(&McpgLaunchEnvironment::default(), None).unwrap();
 
         assert!(
             step.script.contains(".value.tools = [\"*\"]"),
@@ -7533,6 +7509,32 @@ safe-outputs:
             "Copilot mcp-config conversion should mark generated MCP servers as default/trusted: {}",
             step.script
         );
+    }
+
+    #[test]
+    fn start_mcpg_step_uses_typed_env_and_static_docker_array() {
+        let source = crate::secure::AdoVariableName::parse("SOURCE_TOKEN").unwrap();
+        let mut env = McpgLaunchEnvironment::default();
+        env.bind_pipeline_variable("DEST_TOKEN", &source, "test")
+            .unwrap();
+        env.bind_literal("DEBUG", "*", "test").unwrap();
+
+        let step = start_mcpg_step(&env, None).unwrap();
+        assert!(matches!(
+            step.env.get("DEST_TOKEN"),
+            Some(EnvValue::PipelineVar(name)) if name == "SOURCE_TOKEN"
+        ));
+        assert!(matches!(
+            step.env.get("DEBUG"),
+            Some(EnvValue::Literal(value)) if value == "*"
+        ));
+        assert!(matches!(
+            step.env.get("MCPG_ENV_NAMES"),
+            Some(EnvValue::Literal(value)) if value == "DEBUG DEST_TOKEN"
+        ));
+        assert!(step.script.contains("MCPG_DOCKER_ENV_ARGS+=(-e"));
+        assert!(step.script.contains("\"${MCPG_DOCKER_ENV_ARGS[@]}\""));
+        assert!(!step.script.contains("DEST_TOKEN=\"$SOURCE_TOKEN\""));
     }
 
     // ── split_yaml_step_sequence ───────────────────────────────────────────
@@ -7657,8 +7659,7 @@ safe-outputs:
             mcpg_config_json: "{}".to_string(),
             custom_tools_json: None,
             resolved_execution_config_json: "{}".to_string(),
-            mcpg_docker_env: String::new(),
-            mcpg_step_env: String::new(),
+            mcpg_launch_env: McpgLaunchEnvironment::default(),
             source_path: "source.md".to_string(),
             source_relative_path: "source.md".to_string(),
             pipeline_path: "source.lock.yml".to_string(),

--- a/src/compile/codemods/0008_explicit_mcp_pipeline_env.rs
+++ b/src/compile/codemods/0008_explicit_mcp_pipeline_env.rs
@@ -1,0 +1,109 @@
+//! `mcp-servers.*.env.NAME: ""` -> explicit pipeline-variable source.
+
+use anyhow::Result;
+use serde_yaml::{Mapping, Value};
+
+use super::{Codemod, CodemodContext};
+
+const INTRODUCED_IN: &str = "0.51.0";
+
+pub static CODEMOD: Codemod = Codemod {
+    id: "explicit_mcp_pipeline_env",
+    summary: "empty MCP env passthrough values moved to explicit pipeline-variable objects",
+    introduced_in: INTRODUCED_IN,
+    apply: apply_codemod,
+};
+
+fn key(name: &str) -> Value {
+    Value::String(name.to_string())
+}
+
+fn pipeline_variable(name: &str) -> Value {
+    Value::Mapping(Mapping::from_iter([(
+        key("pipeline-variable"),
+        Value::String(name.to_string()),
+    )]))
+}
+
+fn apply_codemod(fm: &mut Mapping, _ctx: &CodemodContext) -> Result<bool> {
+    let Some(servers) = fm
+        .get_mut(key("mcp-servers"))
+        .and_then(Value::as_mapping_mut)
+    else {
+        return Ok(false);
+    };
+
+    let mut changed = false;
+    for server in servers.values_mut() {
+        let Some(server) = server.as_mapping_mut() else {
+            continue;
+        };
+        let Some(env) = server.get_mut(key("env")).and_then(Value::as_mapping_mut) else {
+            continue;
+        };
+        for (name, value) in env.iter_mut() {
+            if value.as_str() != Some("") {
+                continue;
+            }
+            let Some(name) = name.as_str() else {
+                continue;
+            };
+            *value = pipeline_variable(name);
+            changed = true;
+        }
+    }
+    Ok(changed)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn ctx() -> CodemodContext {
+        CodemodContext {
+            compiler_version: INTRODUCED_IN,
+            source_compiler_version: None,
+        }
+    }
+
+    fn map(yaml: &str) -> Mapping {
+        serde_yaml::from_str(yaml).unwrap()
+    }
+
+    #[test]
+    fn rewrites_every_empty_env_value_and_preserves_literals() {
+        let mut fm = map(
+            "mcp-servers:\n  one:\n    container: image\n    env:\n      TOKEN: \"\"\n      STATIC: value\n  two:\n    container: image\n    env:\n      OTHER: \"\"\n",
+        );
+        assert!(apply_codemod(&mut fm, &ctx()).unwrap());
+        assert_eq!(
+            fm["mcp-servers"]["one"]["env"]["TOKEN"]["pipeline-variable"],
+            "TOKEN"
+        );
+        assert_eq!(fm["mcp-servers"]["one"]["env"]["STATIC"], "value");
+        assert_eq!(
+            fm["mcp-servers"]["two"]["env"]["OTHER"]["pipeline-variable"],
+            "OTHER"
+        );
+    }
+
+    #[test]
+    fn explicit_and_non_mapping_shapes_are_noops() {
+        let mut fm = map(
+            "mcp-servers:\n  explicit:\n    container: image\n    env:\n      TOKEN:\n        pipeline-variable: SOURCE\n  scalar: true\n",
+        );
+        let snapshot = fm.clone();
+        assert!(!apply_codemod(&mut fm, &ctx()).unwrap());
+        assert_eq!(fm, snapshot);
+    }
+
+    #[test]
+    fn migration_is_idempotent() {
+        let mut fm =
+            map("mcp-servers:\n  one:\n    container: image\n    env:\n      TOKEN: \"\"\n");
+        assert!(apply_codemod(&mut fm, &ctx()).unwrap());
+        let snapshot = fm.clone();
+        assert!(!apply_codemod(&mut fm, &ctx()).unwrap());
+        assert_eq!(fm, snapshot);
+    }
+}

--- a/src/compile/codemods/mod.rs
+++ b/src/compile/codemods/mod.rs
@@ -47,6 +47,8 @@ mod m0005_drop_build_attachment_allowed_build_ids;
 mod m0006_explicit_push_trigger;
 #[path = "0007_promote_debug_create_github_issue.rs"]
 mod m0007_promote_debug_create_github_issue;
+#[path = "0008_explicit_mcp_pipeline_env.rs"]
+mod m0008_explicit_mcp_pipeline_env;
 
 #[allow(unused_imports)] // Re-exported for future codemods; only `take_key` is in-tree use.
 pub use helpers::{ConflictPolicy, insert_no_overwrite, rename_key, take_key};
@@ -152,6 +154,7 @@ pub static CODEMODS: &[&Codemod] = &[
     &m0005_drop_build_attachment_allowed_build_ids::CODEMOD,
     &m0006_explicit_push_trigger::CODEMOD,
     &m0007_promote_debug_create_github_issue::CODEMOD,
+    &m0008_explicit_mcp_pipeline_env::CODEMOD,
 ];
 
 /// Result of running the codemod registry on a single front-matter

--- a/src/compile/common.rs
+++ b/src/compile/common.rs
@@ -3020,7 +3020,11 @@ where
 }
 
 /// Validate a container-based MCP entry and emit any warnings.
-fn validate_stdio_mcp(name: &str, container: &str, opts: &crate::compile::types::McpOptions) {
+fn validate_stdio_mcp(
+    name: &str,
+    container: &str,
+    opts: &crate::compile::types::McpOptions,
+) -> Result<()> {
     for w in validate::validate_container_image(container, name) {
         eprintln!("{}", w);
     }
@@ -3032,9 +3036,26 @@ fn validate_stdio_mcp(name: &str, container: &str, opts: &crate::compile::types:
     for w in validate::validate_docker_args(&opts.args, name) {
         eprintln!("{}", w);
     }
-    for w in validate::warn_potential_secrets(name, &opts.env, &opts.headers) {
+    for env_name in opts.env.keys() {
+        if !validate::is_valid_env_var_name(env_name) {
+            anyhow::bail!(
+                "mcp-servers.{name}.env key '{env_name}' is invalid; expected [A-Za-z_][A-Za-z0-9_]*"
+            );
+        }
+    }
+    let literal_env: HashMap<String, String> = opts
+        .env
+        .iter()
+        .filter_map(|(name, value)| {
+            value
+                .literal()
+                .map(|value| (name.clone(), value.to_string()))
+        })
+        .collect();
+    for w in validate::warn_potential_secrets(name, &literal_env, &opts.headers) {
         eprintln!("{}", w);
     }
+    Ok(())
 }
 
 /// Build a stdio `McpgServerConfig` from a container-based MCP options block.
@@ -3057,7 +3078,16 @@ fn build_stdio_mcpg_server(
         runtime: runtime.build()?,
         url: None,
         headers: None,
-        env: nonempty_map(&opts.env),
+        env: if opts.env.is_empty() {
+            None
+        } else {
+            Some(
+                opts.env
+                    .iter()
+                    .map(|(name, value)| (name.clone(), value.mcpg_value()))
+                    .collect(),
+            )
+        },
         tools: nonempty_vec(&opts.allowed),
     })
 }
@@ -3085,6 +3115,7 @@ fn try_add_user_mcp(
     name: &str,
     config: &McpConfig,
     servers: &mut std::collections::BTreeMap<String, McpgServerConfig>,
+    launch_env: &mut super::mcpg::McpgLaunchEnvironment,
 ) -> Result<()> {
     // Prevent user-defined MCPs from overwriting the reserved safeoutputs backend
     if name.eq_ignore_ascii_case("safeoutputs") {
@@ -3137,12 +3168,19 @@ fn try_add_user_mcp(
     }
 
     if let Some(container) = &opts.container {
-        validate_stdio_mcp(name, container, opts);
-        servers.insert(
-            name.to_string(),
-            build_stdio_mcpg_server(container, opts)
-                .with_context(|| format!("invalid runtime configuration for MCP `{name}`"))?,
-        );
+        validate_stdio_mcp(name, container, opts)?;
+        let server = build_stdio_mcpg_server(container, opts)
+            .with_context(|| format!("invalid runtime configuration for MCP `{name}`"))?;
+        for (destination, value) in &opts.env {
+            if let Some(source) = value.pipeline_variable() {
+                launch_env.bind_pipeline_variable(
+                    destination,
+                    source,
+                    format!("mcp-servers.{name}.env.{destination}"),
+                )?;
+            }
+        }
+        servers.insert(name.to_string(), server);
     } else if let Some(url) = &opts.url {
         // HTTP-based MCP (remote server)
         for w in validate::validate_mcp_url(url, name) {
@@ -3152,6 +3190,15 @@ fn try_add_user_mcp(
             eprintln!("{}", w);
         }
         if !opts.env.is_empty() {
+            if opts
+                .env
+                .values()
+                .any(|value| value.pipeline_variable().is_some())
+            {
+                anyhow::bail!(
+                    "mcp-servers.{name}.env uses pipeline-variable, but HTTP MCP servers cannot receive process environment variables; use headers instead"
+                );
+            }
             eprintln!(
                 "Warning: MCP '{}': env vars are not supported for HTTP MCPs — they will be ignored. \
                 Use headers for authentication instead.",
@@ -3172,17 +3219,29 @@ fn try_add_user_mcp(
 /// SafeOutputs is always included as a hardened stdio container. Other
 /// extension-contributed MCPG entries (e.g., azure-devops) are included via the
 /// `extensions` parameter.
-pub fn generate_mcpg_config(
+pub fn compile_mcpg(
     front_matter: &FrontMatter,
     extension_declarations: &[Declarations],
-) -> Result<McpgConfig> {
+    debug_pipeline: bool,
+) -> Result<super::mcpg::McpgCompilation> {
     let mut mcp_servers = std::collections::BTreeMap::new();
+    let mut launch_env = super::mcpg::McpgLaunchEnvironment::default();
 
     // Add extension-contributed MCPG server entries (safeoutputs, azure-devops, etc.)
     for decl in extension_declarations {
         for (name, config) in &decl.mcpg_servers {
             mcp_servers.insert(name.clone(), config.clone());
         }
+        for mapping in &decl.pipeline_env {
+            launch_env.bind_pipeline_variable(
+                mapping.container_var(),
+                mapping.pipeline_var(),
+                format!("extension pipeline_env.{}", mapping.container_var()),
+            )?;
+        }
+    }
+    if debug_pipeline {
+        launch_env.bind_literal("DEBUG", "*", "debug-pipeline")?;
     }
 
     let effective_workspace = compute_effective_workspace(
@@ -3265,128 +3324,29 @@ pub fn generate_mcpg_config(
     );
 
     for (name, config) in &front_matter.mcp_servers {
-        try_add_user_mcp(name, config, &mut mcp_servers)?;
+        try_add_user_mcp(name, config, &mut mcp_servers, &mut launch_env)?;
     }
 
-    Ok(McpgConfig {
-        mcp_servers,
-        gateway: McpgGatewayConfig {
-            port: MCPG_PORT,
-            domain: MCPG_DOMAIN.to_string(),
-            api_key: "${MCP_GATEWAY_API_KEY}".to_string(),
-            payload_dir: "/tmp/gh-aw/mcp-payloads".to_string(),
+    Ok(super::mcpg::McpgCompilation {
+        config: McpgConfig {
+            mcp_servers,
+            gateway: McpgGatewayConfig {
+                port: MCPG_PORT,
+                domain: MCPG_DOMAIN.to_string(),
+                api_key: "${MCP_GATEWAY_API_KEY}".to_string(),
+                payload_dir: "/tmp/gh-aw/mcp-payloads".to_string(),
+            },
         },
+        launch_env,
     })
 }
 
-/// Generate additional `-e` flags for the MCPG Docker run command.
-///
-/// Two sources of env flags:
-/// 1. **Extension pipeline var mappings** — extensions declare `required_pipeline_vars()`
-///    which map container env vars to pipeline variables (typically secrets).
-///    These become `-e CONTAINER_VAR="$PIPELINE_VAR"` flags referencing bash vars
-///    (the companion `generate_mcpg_step_env` provides the ADO `env:` mapping).
-/// 2. **User-configured MCP passthrough** — front matter `mcp-servers:` entries with
-///    `env: { VAR: "" }` become bare `-e VAR` flags (MCPG passthrough from host env).
-///
-/// Returns flags formatted for inline insertion in the `docker run` command.
-pub fn generate_mcpg_docker_env(
+#[cfg(test)]
+fn generate_mcpg_config(
     front_matter: &FrontMatter,
     extension_declarations: &[Declarations],
-) -> String {
-    let mut env_flags: Vec<String> = Vec::new();
-    let mut seen: HashSet<String> = HashSet::new();
-
-    // 1. Extension pipeline var mappings (e.g., AZURE_DEVOPS_EXT_PAT -> SC_READ_TOKEN)
-    for decl in extension_declarations {
-        for mapping in &decl.pipeline_env {
-            if seen.contains(&mapping.container_var) {
-                continue;
-            }
-            env_flags.push(format!(
-                "-e {}=\"${}\"",
-                mapping.container_var, mapping.pipeline_var
-            ));
-            seen.insert(mapping.container_var.clone());
-        }
-    }
-
-    // 2. User-configured MCP passthrough env vars (empty value = passthrough from host)
-    for (mcp_name, config) in &front_matter.mcp_servers {
-        let opts = match config {
-            McpConfig::WithOptions(opts) if opts.enabled.unwrap_or(true) => opts,
-            _ => continue,
-        };
-
-        if opts.container.is_none() {
-            continue;
-        }
-
-        for (var_name, var_value) in &opts.env {
-            if !validate::is_valid_env_var_name(var_name) {
-                log::warn!(
-                    "MCP '{}': skipping invalid env var name '{}' — must match [A-Za-z_][A-Za-z0-9_]*",
-                    mcp_name,
-                    var_name
-                );
-                continue;
-            }
-            if seen.contains(var_name) {
-                continue;
-            }
-            if var_value.is_empty() {
-                env_flags.push(format!("-e {}", var_name));
-                seen.insert(var_name.clone());
-            }
-        }
-    }
-
-    env_flags.sort();
-    if env_flags.is_empty() {
-        "\\".to_string()
-    } else {
-        let flags = env_flags.join(" \\\n");
-        format!("{} \\", flags)
-    }
-}
-
-/// Generate the ADO step-level `env:` block for the MCPG start step.
-///
-/// ADO secret variables (set via `##vso[task.setvariable;issecret=true]`) must
-/// be explicitly mapped via the step's `env:` block to be available as bash
-/// environment variables. This function collects all pipeline variable mappings
-/// from extensions and generates the corresponding `env:` entries.
-///
-/// Returns YAML `env:` entries (e.g., `SC_READ_TOKEN: $(SC_READ_TOKEN)`),
-/// or an empty string if no mappings are needed.
-pub fn generate_mcpg_step_env(extension_declarations: &[Declarations]) -> String {
-    let mut entries: Vec<String> = Vec::new();
-    let mut seen: HashSet<String> = HashSet::new();
-
-    for decl in extension_declarations {
-        for mapping in &decl.pipeline_env {
-            if seen.contains(&mapping.pipeline_var) {
-                continue;
-            }
-            entries.push(format!(
-                "{}: $({})",
-                mapping.pipeline_var, mapping.pipeline_var
-            ));
-            seen.insert(mapping.pipeline_var.clone());
-        }
-    }
-
-    if entries.is_empty() {
-        return String::new();
-    }
-
-    // Return full `env:` block so the template marker can be cleanly omitted when empty
-    let indented = entries
-        .iter()
-        .map(|e| format!("  {}", e))
-        .collect::<Vec<_>>()
-        .join("\n");
-    format!("env:\n{}", indented)
+) -> Result<McpgConfig> {
+    Ok(compile_mcpg(front_matter, extension_declarations, false)?.config)
 }
 
 // ==================== Domain allowlist ====================
@@ -3786,7 +3746,7 @@ mod tests {
     use crate::compile::extensions::{
         CompileContext, CompilerExtension, Declarations, Extension, collect_extensions,
     };
-    use crate::compile::types::{McpConfig, McpOptions, OnConfig, Repository};
+    use crate::compile::types::{McpConfig, McpEnvValue, McpOptions, OnConfig, Repository};
     use std::collections::HashMap;
 
     /// Helper: create a minimal FrontMatter by parsing YAML
@@ -7474,7 +7434,10 @@ safe-outputs:
     fn test_generate_mcpg_config_container_with_env() {
         let mut fm = minimal_front_matter();
         let mut env = HashMap::new();
-        env.insert("TOKEN".to_string(), "secret".to_string());
+        env.insert(
+            "TOKEN".to_string(),
+            McpEnvValue::Literal("secret".to_string()),
+        );
         fm.mcp_servers.insert(
             "with-env".to_string(),
             McpConfig::WithOptions(Box::new(McpOptions {
@@ -7623,139 +7586,122 @@ safe-outputs:
     }
 
     #[test]
-    fn test_generate_mcpg_docker_env_with_permissions_read() {
-        // `permissions.read` selects the service connection the *engine* uses.
-        // It must not cause the token to be projected into MCPG's own
-        // environment, from where it would reach the MCP container.
+    fn test_compile_mcpg_builds_typed_pipeline_and_literal_env() {
         let (fm, _) = parse_markdown(
-            "---\nname: test\ndescription: test\ntools:\n  azure-devops: true\npermissions:\n  read: my-read-sc\n---\n",
-        ).unwrap();
-        let (_extensions, declarations) = collect_exts_and_decls_with_org(&fm, "myorg");
-        let env = generate_mcpg_docker_env(&fm, &declarations);
-        assert!(
-            !env.contains("-e ADO_MCP_AUTH_TOKEN=\"$SC_READ_TOKEN\""),
-            "the credential must not be mapped into MCPG: {env}"
-        );
-    }
-
-    #[test]
-    fn test_generate_mcpg_docker_env_no_extensions() {
-        // No tools enabled — no extension pipeline vars — only user MCP passthrough
-        let fm = minimal_front_matter();
-        let (_extensions, declarations) = collect_exts_and_decls_with_org(&fm, "myorg");
-        let env = generate_mcpg_docker_env(&fm, &declarations);
-        assert!(
-            !env.contains("ADO_MCP_AUTH_TOKEN"),
-            "Should not have ADO token when no extension needs it"
-        );
-    }
-
-    #[test]
-    fn test_generate_mcpg_docker_env_dedup_extension_and_user_passthrough() {
-        // Extension provides ADO_MCP_AUTH_TOKEN mapping, user MCP also has it as passthrough.
-        // Extension mapping should win (deduplicated).
-        let (mut fm, _) = parse_markdown(
-            "---\nname: test\ndescription: test\ntools:\n  azure-devops: true\npermissions:\n  read: my-read-sc\n---\n",
-        ).unwrap();
-        fm.mcp_servers.insert(
-            "ado-tool".to_string(),
-            McpConfig::WithOptions(Box::new(McpOptions {
-                container: Some("node:20-slim".to_string()),
-                env: {
-                    let mut e = HashMap::new();
-                    e.insert("ADO_MCP_AUTH_TOKEN".to_string(), "".to_string());
-                    e
-                },
-                ..Default::default()
-            })),
-        );
-        let (_extensions, declarations) = collect_exts_and_decls_with_org(&fm, "myorg");
-        let env = generate_mcpg_docker_env(&fm, &declarations);
-        let count = env.matches("ADO_MCP_AUTH_TOKEN").count();
-        assert_eq!(
-            count, 1,
-            "ADO_MCP_AUTH_TOKEN should appear exactly once, got {}",
-            count
-        );
-    }
-
-    #[test]
-    fn test_generate_mcpg_docker_env_passthrough_vars() {
-        let mut fm = minimal_front_matter();
-        fm.mcp_servers.insert(
-            "tool".to_string(),
-            McpConfig::WithOptions(Box::new(McpOptions {
-                container: Some("img:latest".to_string()),
-                env: {
-                    let mut e = HashMap::new();
-                    e.insert("PASS_THROUGH".to_string(), "".to_string());
-                    e.insert("STATIC".to_string(), "value".to_string());
-                    e
-                },
-                ..Default::default()
-            })),
-        );
-        let (_extensions, declarations) = collect_exts_and_decls_with_org(&fm, "myorg");
-        let env = generate_mcpg_docker_env(&fm, &declarations);
-        assert!(
-            env.contains("-e PASS_THROUGH"),
-            "Should include passthrough var"
-        );
-        assert!(!env.contains("-e STATIC"), "Should NOT include static var");
-    }
-
-    #[test]
-    fn test_generate_mcpg_docker_env_rejects_invalid_names() {
-        let mut fm = minimal_front_matter();
-        fm.mcp_servers.insert(
-            "evil".to_string(),
-            McpConfig::WithOptions(Box::new(McpOptions {
-                container: Some("img:latest".to_string()),
-                env: {
-                    let mut e = HashMap::new();
-                    e.insert("MY_VAR --privileged".to_string(), "".to_string());
-                    e.insert("GOOD_VAR".to_string(), "".to_string());
-                    e
-                },
-                ..Default::default()
-            })),
-        );
-        let (_extensions, declarations) = collect_exts_and_decls_with_org(&fm, "myorg");
-        let env = generate_mcpg_docker_env(&fm, &declarations);
-        assert!(
-            !env.contains("--privileged"),
-            "Should reject invalid env var name with Docker flag injection"
-        );
-        assert!(env.contains("-e GOOD_VAR"), "Should include valid env var");
-    }
-
-    // ─── generate_mcpg_step_env ──────────────────────────────────────────────
-
-    #[test]
-    fn test_generate_mcpg_step_env_with_ado_extension() {
-        // The ADO tool no longer contributes any pipeline variable: it used to
-        // map SC_READ_TOKEN into the MCPG step so the MCP could authenticate
-        // directly. Nothing should replace it.
-        let (fm, _) = parse_markdown(
-            "---\nname: test\ndescription: test\ntools:\n  azure-devops: true\n---\n",
+            "---\nname: test\ndescription: test\nmcp-servers:\n  tool:\n    container: img:latest\n    env:\n      PASS_THROUGH:\n        pipeline-variable: SOURCE_TOKEN\n      STATIC: value\n---\n",
         )
         .unwrap();
-        let (_extensions, declarations) = collect_exts_and_decls_with_org(&fm, "myorg");
-        let env = generate_mcpg_step_env(&declarations);
-        assert!(
-            !env.contains("SC_READ_TOKEN"),
-            "the ADO tool must not surface the read token to MCPG: {env}"
-        );
+        let compilation = compile_mcpg(&fm, &collect_exts_and_decls(&fm).1, false).unwrap();
+        assert!(matches!(
+            compilation.launch_env.get("PASS_THROUGH"),
+            Some(crate::compile::ir::env::EnvValue::PipelineVar(source))
+                if source == "SOURCE_TOKEN"
+        ));
+        assert!(compilation.launch_env.get("STATIC").is_none());
+        let env = compilation.config.mcp_servers["tool"].env.as_ref().unwrap();
+        assert_eq!(env["PASS_THROUGH"], "");
+        assert_eq!(env["STATIC"], "value");
     }
 
     #[test]
-    fn test_generate_mcpg_step_env_no_extensions() {
-        let fm = minimal_front_matter();
-        let (_extensions, declarations) = collect_exts_and_decls(&fm);
-        let env = generate_mcpg_step_env(&declarations);
-        assert!(
-            env.is_empty(),
-            "Should be empty when no extensions need pipeline vars"
+    fn test_compile_mcpg_rejects_invalid_destination_env_name() {
+        let (fm, _) = parse_markdown(
+            "---\nname: test\ndescription: test\nmcp-servers:\n  tool:\n    container: img:latest\n    env:\n      BAD-NAME:\n        pipeline-variable: SOURCE_TOKEN\n---\n",
+        )
+        .unwrap();
+        let error = compile_mcpg(&fm, &collect_exts_and_decls(&fm).1, false)
+            .unwrap_err()
+            .to_string();
+        assert!(error.contains("BAD-NAME"));
+        assert!(error.contains("[A-Za-z_][A-Za-z0-9_]*"));
+    }
+
+    #[test]
+    fn test_compile_mcpg_rejects_pipeline_env_for_http_server() {
+        let (fm, _) = parse_markdown(
+            "---\nname: test\ndescription: test\nmcp-servers:\n  remote:\n    url: https://mcp.example.com\n    env:\n      TOKEN:\n        pipeline-variable: SOURCE_TOKEN\n---\n",
+        )
+        .unwrap();
+        let error = compile_mcpg(&fm, &collect_exts_and_decls(&fm).1, false)
+            .unwrap_err()
+            .to_string();
+        assert!(error.contains("HTTP MCP servers"));
+    }
+
+    #[test]
+    fn test_compile_mcpg_skips_disabled_user_launch_env() {
+        let (fm, _) = parse_markdown(
+            "---\nname: test\ndescription: test\nmcp-servers:\n  disabled:\n    enabled: false\n    container: img:latest\n    env:\n      TOKEN:\n        pipeline-variable: SOURCE_TOKEN\n---\n",
+        )
+        .unwrap();
+        let compilation = compile_mcpg(&fm, &collect_exts_and_decls(&fm).1, false).unwrap();
+        assert!(compilation.launch_env.get("TOKEN").is_none());
+        assert!(!compilation.config.mcp_servers.contains_key("disabled"));
+    }
+
+    #[test]
+    fn test_compile_mcpg_rejects_conflicting_user_bindings() {
+        let (fm, _) = parse_markdown(
+            "---\nname: test\ndescription: test\nmcp-servers:\n  one:\n    container: one:latest\n    env:\n      TOKEN:\n        pipeline-variable: FIRST\n  two:\n    container: two:latest\n    env:\n      TOKEN:\n        pipeline-variable: SECOND\n---\n",
+        )
+        .unwrap();
+        let error = compile_mcpg(&fm, &collect_exts_and_decls(&fm).1, false)
+            .unwrap_err()
+            .to_string();
+        assert!(error.contains("mcp-servers.one.env.TOKEN"));
+        assert!(error.contains("mcp-servers.two.env.TOKEN"));
+    }
+
+    #[test]
+    fn test_compile_mcpg_extension_binding_wins_only_when_identical() {
+        let (fm, _) = parse_markdown(
+            "---\nname: test\ndescription: test\nmcp-servers:\n  tool:\n    container: tool:latest\n    env:\n      TOKEN:\n        pipeline-variable: OTHER\n---\n",
+        )
+        .unwrap();
+        let declarations = vec![Declarations {
+            pipeline_env: vec![
+                crate::compile::extensions::PipelineEnvMapping::new("TOKEN", "EXTENSION")
+                    .unwrap(),
+            ],
+            ..Default::default()
+        }];
+        let error = compile_mcpg(&fm, &declarations, false)
+            .unwrap_err()
+            .to_string();
+        assert!(error.contains("extension pipeline_env.TOKEN"));
+        assert!(error.contains("mcp-servers.tool.env.TOKEN"));
+    }
+
+    #[test]
+    fn test_compile_mcpg_skipped_duplicate_server_does_not_expose_env() {
+        let (fm, _) = parse_markdown(
+            "---\nname: test\ndescription: test\nmcp-servers:\n  extension-owned:\n    container: user:latest\n    env:\n      TOKEN:\n        pipeline-variable: SOURCE\n---\n",
+        )
+        .unwrap();
+        let declarations = vec![Declarations {
+            mcpg_servers: vec![(
+                "extension-owned".to_string(),
+                McpgServerConfig {
+                    server_type: "stdio".to_string(),
+                    container: Some("extension:latest".to_string()),
+                    entrypoint: None,
+                    entrypoint_args: None,
+                    runtime: Default::default(),
+                    url: None,
+                    headers: None,
+                    env: None,
+                    tools: None,
+                },
+            )],
+            ..Default::default()
+        }];
+        let compilation = compile_mcpg(&fm, &declarations, false).unwrap();
+        assert!(compilation.launch_env.get("TOKEN").is_none());
+        assert_eq!(
+            compilation.config.mcp_servers["extension-owned"]
+                .container
+                .as_deref(),
+            Some("extension:latest")
         );
     }
 
@@ -7979,10 +7925,17 @@ safe-outputs:
         )
         .unwrap();
         let (_extensions, declarations) = collect_exts_and_decls_with_org(&fm, "myorg");
-        let env = generate_mcpg_docker_env(&fm, &declarations);
+        let compilation = compile_mcpg(&fm, &declarations, false).unwrap();
         assert!(
-            !env.contains("SC_READ_TOKEN"),
-            "the real bearer must never reach the MCP container: {env}"
+            compilation
+                .launch_env
+                .iter()
+                .all(|(_, value)| !matches!(
+                    value,
+                    crate::compile::ir::env::EnvValue::PipelineVar(source)
+                        if source == "SC_READ_TOKEN"
+                )),
+            "the real bearer must never reach the MCP container"
         );
     }
 

--- a/src/compile/extensions/mod.rs
+++ b/src/compile/extensions/mod.rs
@@ -599,9 +599,33 @@ impl<'de> serde::Deserialize<'de> for AwfMount {
 #[derive(Debug, Clone)]
 pub struct PipelineEnvMapping {
     /// The env var name inside the MCP container (e.g., `AZURE_DEVOPS_EXT_PAT`).
-    pub container_var: String,
+    container_var: super::mcpg::McpgEnvName,
     /// The ADO pipeline variable name (e.g., `SC_READ_TOKEN`).
-    pub pipeline_var: String,
+    pipeline_var: crate::secure::AdoVariableName,
+}
+
+impl PipelineEnvMapping {
+    #[allow(dead_code)] // Reserved extension contract; no in-tree producer currently needs a credential mapping.
+    pub fn new(
+        container_var: impl Into<String>,
+        pipeline_var: impl Into<String>,
+    ) -> Result<Self> {
+        Ok(Self {
+            container_var: super::mcpg::McpgEnvName::parse(
+                container_var,
+                "extension pipeline_env",
+            )?,
+            pipeline_var: crate::secure::AdoVariableName::parse(pipeline_var)?,
+        })
+    }
+
+    pub fn container_var(&self) -> &str {
+        self.container_var.as_str()
+    }
+
+    pub fn pipeline_var(&self) -> &crate::secure::AdoVariableName {
+        &self.pipeline_var
+    }
 }
 
 // ──────────────────────────────────────────────────────────────────────

--- a/src/compile/mcpg.rs
+++ b/src/compile/mcpg.rs
@@ -1,0 +1,192 @@
+//! Typed MCPG configuration and host-launch environment.
+
+use anyhow::{Result, bail};
+use std::collections::BTreeMap;
+
+use super::extensions::McpgConfig;
+use super::ir::env::EnvValue;
+use crate::secure::AdoVariableName;
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+pub struct McpgEnvName(String);
+
+impl McpgEnvName {
+    pub fn parse(value: impl Into<String>, origin: &str) -> Result<Self> {
+        let value = value.into();
+        if !crate::validate::is_valid_env_var_name(&value) {
+            bail!(
+                "{origin} environment variable name '{value}' is invalid; expected [A-Za-z_][A-Za-z0-9_]*"
+            );
+        }
+        if value.starts_with("ADO_AW_MCPG_INTERNAL_")
+            || matches!(
+                value.as_str(),
+                "MCP_GATEWAY_API_KEY"
+                    | "MCP_GATEWAY_PORT"
+                    | "MCP_GATEWAY_DOMAIN"
+                    | "ADO_PROXY_IP"
+                    | "MCPG_CONTAINER"
+                    | "MCPG_IMAGE"
+                    | "MCPG_PORT"
+                    | "MCPG_DOMAIN"
+                    | "MCP_RUNNER_UID"
+                    | "MCP_RUNNER_GID"
+                    | "MCPG_CONFIG"
+                    | "GATEWAY_OUTPUT"
+                    | "MCPG_ENV_NAMES"
+                    | "MCPG_DOCKER_ENV_ARGS"
+                    | "MCPG_ENV_NAME"
+            )
+        {
+            bail!(
+                "{origin} environment variable name '{value}' is reserved by the MCPG launch step"
+            );
+        }
+        Ok(Self(value))
+    }
+
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+#[derive(Debug, Clone)]
+struct McpgLaunchBinding {
+    value: EnvValue,
+    origin: String,
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct McpgLaunchEnvironment {
+    bindings: BTreeMap<McpgEnvName, McpgLaunchBinding>,
+}
+
+impl McpgLaunchEnvironment {
+    pub fn bind_pipeline_variable(
+        &mut self,
+        destination: impl Into<String>,
+        source: &AdoVariableName,
+        origin: impl Into<String>,
+    ) -> Result<()> {
+        self.bind(destination, EnvValue::pipeline_var(source.as_str()), origin)
+    }
+
+    pub fn bind_literal(
+        &mut self,
+        destination: impl Into<String>,
+        value: impl Into<String>,
+        origin: impl Into<String>,
+    ) -> Result<()> {
+        self.bind(destination, EnvValue::literal(value), origin)
+    }
+
+    fn bind(
+        &mut self,
+        destination: impl Into<String>,
+        value: EnvValue,
+        origin: impl Into<String>,
+    ) -> Result<()> {
+        let origin = origin.into();
+        let destination = McpgEnvName::parse(destination, &origin)?;
+        if let Some(existing) = self.bindings.get(&destination) {
+            if existing.value == value {
+                return Ok(());
+            }
+            bail!(
+                "conflicting MCPG environment binding for '{}': {} requires {:?}, but {} requires {:?}",
+                destination.as_str(),
+                existing.origin,
+                existing.value,
+                origin,
+                value
+            );
+        }
+        self.bindings
+            .insert(destination, McpgLaunchBinding { value, origin });
+        Ok(())
+    }
+
+    pub fn iter(&self) -> impl Iterator<Item = (&str, &EnvValue)> {
+        self.bindings
+            .iter()
+            .map(|(name, binding)| (name.as_str(), &binding.value))
+    }
+
+    pub fn names(&self) -> impl Iterator<Item = &str> {
+        self.bindings.keys().map(McpgEnvName::as_str)
+    }
+
+    #[cfg(test)]
+    pub fn get(&self, name: &str) -> Option<&EnvValue> {
+        self.bindings
+            .iter()
+            .find_map(|(key, binding)| (key.as_str() == name).then_some(&binding.value))
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct McpgCompilation {
+    pub config: McpgConfig,
+    pub launch_env: McpgLaunchEnvironment,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn bindings_are_sorted_and_identical_values_deduplicate() {
+        let source = AdoVariableName::parse("PIPELINE_TOKEN").unwrap();
+        let mut env = McpgLaunchEnvironment::default();
+        env.bind_pipeline_variable("Z_TOKEN", &source, "z").unwrap();
+        env.bind_pipeline_variable("A_TOKEN", &source, "a").unwrap();
+        env.bind_pipeline_variable("A_TOKEN", &source, "same")
+            .unwrap();
+        assert_eq!(env.names().collect::<Vec<_>>(), vec!["A_TOKEN", "Z_TOKEN"]);
+    }
+
+    #[test]
+    fn conflicting_sources_fail_with_origins() {
+        let first = AdoVariableName::parse("FIRST").unwrap();
+        let second = AdoVariableName::parse("SECOND").unwrap();
+        let mut env = McpgLaunchEnvironment::default();
+        env.bind_pipeline_variable("TOKEN", &first, "mcp-servers.one")
+            .unwrap();
+        let error = env
+            .bind_pipeline_variable("TOKEN", &second, "mcp-servers.two")
+            .unwrap_err()
+            .to_string();
+        assert!(error.contains("mcp-servers.one"));
+        assert!(error.contains("mcp-servers.two"));
+    }
+
+    #[test]
+    fn invalid_destination_fails() {
+        let source = AdoVariableName::parse("TOKEN").unwrap();
+        let error = McpgLaunchEnvironment::default()
+            .bind_pipeline_variable("BAD-NAME", &source, "mcp-servers.one")
+            .unwrap_err()
+            .to_string();
+        assert!(error.contains("[A-Za-z_][A-Za-z0-9_]*"));
+    }
+
+    #[test]
+    fn internal_destination_names_are_reserved() {
+        let source = AdoVariableName::parse("TOKEN").unwrap();
+        for destination in [
+            "ADO_AW_MCPG_INTERNAL_IMAGE",
+            "MCP_GATEWAY_API_KEY",
+            "MCP_GATEWAY_PORT",
+            "MCP_GATEWAY_DOMAIN",
+            "ADO_PROXY_IP",
+            "MCPG_IMAGE",
+            "MCPG_ENV_NAMES",
+        ] {
+            let error = McpgLaunchEnvironment::default()
+                .bind_pipeline_variable(destination, &source, "mcp-servers.one")
+                .unwrap_err()
+                .to_string();
+            assert!(error.contains("reserved"));
+        }
+    }
+}

--- a/src/compile/mod.rs
+++ b/src/compile/mod.rs
@@ -22,6 +22,7 @@ pub mod imports;
 pub(crate) mod ir;
 mod job;
 mod job_ir;
+pub(crate) mod mcpg;
 mod onees;
 mod onees_ir;
 mod path_layout_check;

--- a/src/compile/types.rs
+++ b/src/compile/types.rs
@@ -3631,9 +3631,80 @@ impl SanitizeConfigTrait for McpConfig {
     fn sanitize_config_fields(&mut self) {
         match self {
             McpConfig::Enabled(_) => {}
-            McpConfig::WithOptions(opts) => opts.sanitize_config_fields(),
+            McpConfig::WithOptions(opts) => {
+                opts.sanitize_config_fields();
+                for value in opts.env.values_mut() {
+                    value.sanitize_config_fields();
+                }
+            }
         }
     }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum McpEnvValue {
+    Literal(String),
+    PipelineVariable(McpPipelineVariable),
+}
+
+impl<'de> serde::Deserialize<'de> for McpEnvValue {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        #[derive(Deserialize)]
+        #[serde(untagged)]
+        enum Raw {
+            Literal(String),
+            PipelineVariable(McpPipelineVariable),
+        }
+
+        match Raw::deserialize(deserializer)? {
+            Raw::Literal(value) if value.is_empty() => Err(serde::de::Error::custom(
+                "empty MCP env values are deprecated; use `{ pipeline-variable: NAME }`",
+            )),
+            Raw::Literal(value) => Ok(Self::Literal(value)),
+            Raw::PipelineVariable(reference) => Ok(Self::PipelineVariable(reference)),
+        }
+    }
+}
+
+impl McpEnvValue {
+    pub fn mcpg_value(&self) -> String {
+        match self {
+            Self::Literal(value) => value.clone(),
+            Self::PipelineVariable(_) => String::new(),
+        }
+    }
+
+    pub fn pipeline_variable(&self) -> Option<&crate::secure::AdoVariableName> {
+        match self {
+            Self::Literal(_) => None,
+            Self::PipelineVariable(reference) => Some(&reference.pipeline_variable),
+        }
+    }
+
+    pub fn literal(&self) -> Option<&str> {
+        match self {
+            Self::Literal(value) => Some(value),
+            Self::PipelineVariable(_) => None,
+        }
+    }
+}
+
+impl SanitizeConfigTrait for McpEnvValue {
+    fn sanitize_config_fields(&mut self) {
+        if let Self::Literal(value) = self {
+            *value = crate::sanitize::sanitize_config(value);
+        }
+    }
+}
+
+#[derive(Debug, Deserialize, Clone, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct McpPipelineVariable {
+    #[serde(rename = "pipeline-variable")]
+    pub pipeline_variable: crate::secure::AdoVariableName,
 }
 
 /// Detailed MCP options
@@ -3666,9 +3737,11 @@ pub struct McpOptions {
     /// Allowed tool names (for MCPG tool filtering)
     #[serde(default)]
     pub allowed: Vec<String>,
-    /// Environment variables for the MCP server process
+    /// Environment variables for the MCP server process. Static strings are
+    /// embedded in MCPG config; `pipeline-variable` objects are wired through
+    /// the typed MCPG launch-step environment.
     #[serde(default)]
-    pub env: HashMap<String, String>,
+    pub env: HashMap<String, McpEnvValue>,
 }
 
 /// Unified trigger configuration — `on:` front matter key.
@@ -4503,6 +4576,39 @@ mod tests {
     use super::*;
 
     const IMPORT_SHA: &str = "0123456789abcdef0123456789abcdef01234567";
+
+    #[test]
+    fn mcp_env_value_accepts_literal_and_pipeline_variable() {
+        let literal: McpEnvValue = serde_yaml::from_str("value").unwrap();
+        assert_eq!(literal, McpEnvValue::Literal("value".to_string()));
+
+        let pipeline: McpEnvValue =
+            serde_yaml::from_str("pipeline-variable: Library.Secret-Name_01").unwrap();
+        assert_eq!(
+            pipeline.pipeline_variable().map(|name| name.as_str()),
+            Some("Library.Secret-Name_01")
+        );
+    }
+
+    #[test]
+    fn mcp_env_value_rejects_legacy_empty_and_expression_sources() {
+        let empty = serde_yaml::from_str::<McpEnvValue>("''")
+            .unwrap_err()
+            .to_string();
+        assert!(empty.contains("pipeline-variable"));
+
+        for source in [
+            "$(TOKEN)",
+            "$[ dependencies.Setup.outputs['mint.TOKEN'] ]",
+            "${{ variables.TOKEN }}",
+        ] {
+            let yaml = format!("pipeline-variable: {source:?}");
+            assert!(
+                serde_yaml::from_str::<McpEnvValue>(&yaml).is_err(),
+                "source should be rejected: {source}"
+            );
+        }
+    }
 
     fn bare_import(uses: impl Into<String>) -> ImportEntry {
         ImportEntry {

--- a/src/secure.rs
+++ b/src/secure.rs
@@ -31,6 +31,7 @@
 //! - [`AzureDevOpsOrgUrl`] — an HTTPS Azure DevOps organization collection URL.
 //! - [`ArtifactName`] — an ADO artifact / attachment name.
 //! - [`Identifier`] — an engine agent/model identifier.
+//! - [`AdoVariableName`] — an Azure DevOps pipeline or variable-group variable name.
 //! - [`HostName`] — a DNS-style hostname.
 //! - [`RegistryRef`] — a container-registry host or base path.
 //! - [`AdoOrganization`] — an Azure DevOps Services organization name.
@@ -321,6 +322,23 @@ impl WorkItemTemporaryId {
             self.as_str().to_string()
         } else {
             format!("#{}", self.as_str())
+        }
+    }
+}
+
+validated_string! {
+    /// An Azure DevOps pipeline or variable-group variable name.
+    ///
+    /// Allows the alphanumeric, dot, underscore, and hyphen form accepted by
+    /// Azure DevOps macro references while rejecting expression syntax,
+    /// whitespace, control characters, and logging-command injection.
+    AdoVariableName, "Azure DevOps variable name", |value: &str, label: &str| {
+        if validate::is_valid_ado_variable_name(value) {
+            Ok(())
+        } else {
+            anyhow::bail!(
+                "{label} '{value}' must start with an ASCII alphanumeric or '_' and contain only [A-Za-z0-9._-]"
+            )
         }
     }
 }

--- a/src/validate.rs
+++ b/src/validate.rs
@@ -556,7 +556,7 @@ pub fn validate_mcp_url(url: &str, mcp_name: &str) -> Vec<String> {
 }
 
 /// Warn when env values or headers look like they contain inline secrets.
-/// Secrets should use pipeline variables and passthrough ("") instead.
+/// MCP secrets should use explicit `pipeline-variable` references instead.
 pub fn warn_potential_secrets(
     mcp_name: &str,
     env: &HashMap<String, String>,

--- a/tests/codemod_tests.rs
+++ b/tests/codemod_tests.rs
@@ -5,11 +5,10 @@
 //! assert on the user-visible behavior of `compile` and `check` for
 //! sources with various front-matter shapes.
 //!
-//! The codemod registry shipped with this binary is intentionally
-//! empty; the rewrite path is exercised by the white-box tests in
+//! White-box rewrite mechanics are exercised in
 //! `src/compile/codemod_integration_test.rs`, which can inject a
-//! stub registry. These tests cover the user-facing CLI behaviors
-//! that don't require codemod registration:
+//! stub registry. These tests cover shipped codemods and user-facing
+//! CLI behavior:
 //!
 //! - Healthy current sources compile and `check` cleanly without
 //!   rewriting the source.
@@ -152,6 +151,30 @@ fn compile_migrates_debug_create_issue_to_public_safe_output() {
     assert!(
         String::from_utf8_lossy(&output.stderr).contains("promote_debug_create_github_issue")
     );
+}
+
+#[test]
+fn compile_migrates_empty_mcp_env_to_explicit_pipeline_variable() {
+    let dir = fresh_temp_dir();
+    let original = "---\nname: mcp-env-migration\ndescription: d\nmcp-servers:\n  custom:\n    container: node:20-slim\n    env:\n      TOKEN: \"\"\n      STATIC: value\n---\nbody\n";
+    let source = write_source(dir.path(), original);
+    let output = run_compile(&source);
+    assert!(
+        output.status.success(),
+        "compile should succeed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let after = fs::read_to_string(&source).expect("re-read source");
+    assert!(after.contains("TOKEN:"));
+    assert!(after.contains("pipeline-variable: TOKEN"));
+    assert!(after.contains("STATIC: value"));
+    assert!(
+        String::from_utf8_lossy(&output.stderr).contains("explicit_mcp_pipeline_env")
+    );
+
+    let lock = source.with_extension("lock.yml");
+    let compiled = fs::read_to_string(lock).expect("read lock");
+    assert!(compiled.contains("TOKEN: $(TOKEN)"));
 }
 
 // ─── Healthy compile (no codemods needed) ──────────────────────────────────

--- a/tests/compiler_tests.rs
+++ b/tests/compiler_tests.rs
@@ -2357,14 +2357,38 @@ fn test_mcpg_config_http_based_mcp() {
     let _ = fs::remove_dir_all(&temp_dir);
 }
 
-/// Test that env passthrough generates -e flags in MCPG Docker run
+/// Test that explicit MCP pipeline variables are plumbed through typed step env.
 #[test]
-fn test_mcpg_docker_env_passthrough() {
+fn test_mcpg_pipeline_variable_env() {
     let temp_dir =
         std::env::temp_dir().join(format!("agentic-pipeline-mcpg-env-{}", std::process::id()));
     fs::create_dir_all(&temp_dir).expect("Failed to create temp directory");
 
-    let input = "---\nname: \"Env Test\"\ndescription: \"Tests env passthrough\"\npermissions:\n  read: my-read-sc\n  write: my-write-sc\nmcp-servers:\n  my-tool:\n    container: \"node:20-slim\"\n    env:\n      AZURE_DEVOPS_EXT_PAT: \"\"\n      MY_TOKEN: \"\"\n      STATIC_VAR: \"static-value\"\nsafe-outputs:\n  create-work-item:\n    work-item-type: Task\n---\n\n## Test\n";
+    let input = r###"---
+name: "Env Test"
+description: "Tests explicit pipeline variable env"
+permissions:
+  read: my-read-sc
+  write: my-write-sc
+steps:
+  - bash: |
+      echo "##vso[task.setvariable variable=MY_TOKEN;issecret=true]test-only"
+mcp-servers:
+  my-tool:
+    container: "node:20-slim"
+    env:
+      AZURE_DEVOPS_EXT_PAT:
+        pipeline-variable: AZURE_DEVOPS_EXT_PAT
+      CONTAINER_TOKEN:
+        pipeline-variable: MY_TOKEN
+      STATIC_VAR: "static-value"
+safe-outputs:
+  create-work-item:
+    work-item-type: Task
+---
+
+## Test
+"###;
 
     let input_path = temp_dir.join("env-passthrough.md");
     let output_path = temp_dir.join("env-passthrough.yml");
@@ -2389,23 +2413,36 @@ fn test_mcpg_docker_env_passthrough() {
 
     let compiled = fs::read_to_string(&output_path).unwrap();
 
-    // AZURE_DEVOPS_EXT_PAT with "" is bare passthrough for user-configured MCPs
-    // (only tools.azure-devops extension provides SC_READ_TOKEN mapping)
     assert!(
-        compiled.contains("-e AZURE_DEVOPS_EXT_PAT"),
-        "Should forward AZURE_DEVOPS_EXT_PAT as passthrough"
+        compiled.contains("AZURE_DEVOPS_EXT_PAT: $(AZURE_DEVOPS_EXT_PAT)"),
+        "Should map the same-name pipeline variable through typed step env"
+    );
+    assert!(
+        compiled.contains("CONTAINER_TOKEN: $(MY_TOKEN)"),
+        "Should remap the source pipeline variable to the container env name"
+    );
+    assert!(
+        compiled
+            .find("task.setvariable variable=MY_TOKEN")
+            .is_some_and(|producer| {
+                compiled
+                    .find("displayName: Start MCP Gateway (MCPG)")
+                    .is_some_and(|consumer| producer < consumer)
+            }),
+        "A same-job task.setvariable producer must precede the typed MCPG consumer"
+    );
+    assert!(
+        compiled.contains("MCPG_ENV_NAMES: AZURE_DEVOPS_EXT_PAT CONTAINER_TOKEN"),
+        "Docker forwarding names should come from the same sorted typed bindings"
     );
 
-    // Should forward passthrough env var MY_TOKEN
-    assert!(
-        compiled.contains("-e MY_TOKEN"),
-        "Should forward passthrough env var"
-    );
-
-    // Static var should be in config
     assert!(
         compiled.contains("\"STATIC_VAR\": \"static-value\""),
         "Static env var should be in config"
+    );
+    assert!(
+        compiled.contains("\"CONTAINER_TOKEN\": \"\""),
+        "MCPG JSON should receive its internal passthrough marker"
     );
 
     // Regression for issue #1034: the docker-env continuation lines must never
@@ -2419,6 +2456,43 @@ fn test_mcpg_docker_env_passthrough() {
     );
 
     let _ = fs::remove_dir_all(&temp_dir);
+}
+
+#[test]
+fn test_mcpg_pipeline_variable_env_compiles_for_all_targets() {
+    for target in ["standalone", "1es", "job", "stage"] {
+        let temp_dir = std::env::temp_dir().join(format!(
+            "agentic-pipeline-mcpg-env-{target}-{}",
+            std::process::id()
+        ));
+        fs::create_dir_all(&temp_dir).expect("Failed to create temp directory");
+        let input = format!(
+            "---\nname: \"Env {target}\"\ndescription: \"Tests MCP env for {target}\"\ntarget: {target}\nmcp-servers:\n  my-tool:\n    container: node:20-slim\n    env:\n      CONTAINER_TOKEN:\n        pipeline-variable: SOURCE_TOKEN\n---\n\nTest.\n"
+        );
+        let input_path = temp_dir.join("env.md");
+        let output_path = temp_dir.join("env.yml");
+        fs::write(&input_path, input).unwrap();
+        let output = std::process::Command::new(PathBuf::from(env!("CARGO_BIN_EXE_ado-aw")))
+            .args([
+                "compile",
+                input_path.to_str().unwrap(),
+                "-o",
+                output_path.to_str().unwrap(),
+            ])
+            .output()
+            .expect("Failed to run compiler");
+        assert!(
+            output.status.success(),
+            "target {target} should compile: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+        let compiled = fs::read_to_string(&output_path).unwrap();
+        assert!(
+            compiled.contains("CONTAINER_TOKEN: $(SOURCE_TOKEN)"),
+            "target {target} should retain typed pipeline variable mapping"
+        );
+        let _ = fs::remove_dir_all(&temp_dir);
+    }
 }
 
 /// Test that user-defined parameters are emitted in the compiled pipeline YAML
@@ -5042,7 +5116,7 @@ fn test_debug_pipeline_includes_debug_env() {
     assert_valid_yaml(&compiled, "minimal-agent.md (debug-pipeline)");
 
     assert!(
-        compiled.contains(r#"DEBUG="*""#),
+        compiled.contains("DEBUG: '*'"),
         "Pipeline compiled with --debug-pipeline should contain DEBUG=* env var"
     );
 }
@@ -5076,7 +5150,7 @@ fn test_default_excludes_debug_diagnostics() {
     let compiled = compile_fixture("minimal-agent.md");
 
     assert!(
-        !compiled.contains(r#"DEBUG="*""#),
+        !compiled.contains("DEBUG: '*'"),
         "Pipeline compiled without --debug-pipeline should NOT contain DEBUG=* env var"
     );
     assert!(
@@ -5094,7 +5168,7 @@ fn test_debug_pipeline_valid_yaml_standalone() {
     let compiled = compile_fixture_with_flags("complete-agent.md", &["--debug-pipeline"]);
     assert_valid_yaml(&compiled, "complete-agent.md (debug-pipeline)");
     assert!(
-        compiled.contains(r#"DEBUG="*""#),
+        compiled.contains("DEBUG: '*'"),
         "complete-agent.md compiled with --debug-pipeline should contain DEBUG=* env var"
     );
     assert!(
@@ -5108,7 +5182,7 @@ fn test_debug_pipeline_valid_yaml_1es() {
     let compiled = compile_fixture_with_flags("1es-test-agent.md", &["--debug-pipeline"]);
     assert_valid_yaml(&compiled, "1es-test-agent.md (debug-pipeline)");
     assert!(
-        compiled.contains(r#"DEBUG="*""#),
+        compiled.contains("DEBUG: '*'"),
         "1es-test-agent.md compiled with --debug-pipeline should contain DEBUG=* env var"
     );
     assert!(
@@ -5131,7 +5205,7 @@ fn test_skip_integrity_and_debug_pipeline_combined() {
 
     // Debug content present
     assert!(
-        compiled.contains(r#"DEBUG="*""#),
+        compiled.contains("DEBUG: '*'"),
         "Combined flags: should contain DEBUG=*"
     );
     assert!(


### PR DESCRIPTION
## Summary

- replace ambiguous empty-string MCP env passthrough with an explicit `pipeline-variable` source, including an in-place codemod for existing workflows
- compile effective MCPG configuration and launch bindings together, then feed ADO step env and Docker passthrough from one typed IR representation
- validate remapping, conflicts, HTTP/disabled/reserved entries, same-job variables, debug propagation, and all four compile targets

Fixes #945

## Test plan

- `cargo test`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --bin ado-aw compile::shell`
- `cargo test --test bash_lint_tests`
- `cargo test --test generated_shell_guard`
- `cargo test --test compiler_tests`
